### PR TITLE
feat(frontend): add connection status indicator with auto-reconnect

### DIFF
--- a/frontend/taskguild/src/components/ChatBubble.tsx
+++ b/frontend/taskguild/src/components/ChatBubble.tsx
@@ -11,6 +11,8 @@ import {
   Timer,
 } from 'lucide-react'
 import { MarkdownDescription } from './MarkdownDescription'
+import { ConnectionIndicator } from './ConnectionIndicator'
+import type { ConnectionStatus } from '@/hooks/useEventSubscription'
 
 /* ─── Helpers ─── */
 
@@ -147,12 +149,16 @@ export function InputBar({
   onSendMessage,
   isRespondPending,
   isSendPending,
+  connectionStatus,
+  onReconnect,
 }: {
   pendingInteraction?: Interaction
   onRespond: (id: string, response: string) => void
   onSendMessage: (message: string) => void
   isRespondPending: boolean
   isSendPending: boolean
+  connectionStatus?: ConnectionStatus
+  onReconnect?: () => void
 }) {
   const [text, setText] = useState('')
 
@@ -181,7 +187,10 @@ export function InputBar({
           {pendingInteraction.title}
         </p>
       )}
-      <div className="flex gap-3 items-end">
+      <div className="flex gap-2 items-end">
+        {connectionStatus && onReconnect && (
+          <ConnectionIndicator status={connectionStatus} onReconnect={onReconnect} />
+        )}
         <input
           value={text}
           onChange={(e) => setText(e.target.value)}

--- a/frontend/taskguild/src/components/ConnectionIndicator.tsx
+++ b/frontend/taskguild/src/components/ConnectionIndicator.tsx
@@ -1,0 +1,43 @@
+import { Wifi, WifiOff, Loader } from 'lucide-react'
+import type { ConnectionStatus } from '@/hooks/useEventSubscription'
+
+export function ConnectionIndicator({
+  status,
+  onReconnect,
+}: {
+  status: ConnectionStatus
+  onReconnect: () => void
+}) {
+  if (status === 'connected') {
+    return (
+      <div
+        className="flex items-center justify-center shrink-0 w-8 h-8 rounded-lg"
+        title="Connected to server"
+      >
+        <Wifi className="w-4 h-4 text-green-400" />
+      </div>
+    )
+  }
+
+  if (status === 'connecting') {
+    return (
+      <div
+        className="flex items-center justify-center shrink-0 w-8 h-8 rounded-lg"
+        title="Connecting..."
+      >
+        <Loader className="w-4 h-4 text-yellow-400 animate-spin" />
+      </div>
+    )
+  }
+
+  // disconnected
+  return (
+    <button
+      onClick={onReconnect}
+      className="flex items-center justify-center shrink-0 w-8 h-8 rounded-lg hover:bg-slate-800 transition-colors"
+      title="Disconnected. Click to reconnect."
+    >
+      <WifiOff className="w-4 h-4 text-red-400" />
+    </button>
+  )
+}

--- a/frontend/taskguild/src/hooks/useEventSubscription.ts
+++ b/frontend/taskguild/src/hooks/useEventSubscription.ts
@@ -1,19 +1,34 @@
-import { useEffect } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { createClient } from '@connectrpc/connect'
 import { EventService, type EventType, SubscribeEventsRequestSchema } from '@taskguild/proto/taskguild/v1/event_pb.ts'
 import { create } from '@bufbuild/protobuf'
 import { transport } from '@/lib/transport'
 
+export type ConnectionStatus = 'connecting' | 'connected' | 'disconnected'
+
 export function useEventSubscription(
   eventTypes: EventType[],
   projectId: string,
   onEvent: () => void,
-) {
+): { connectionStatus: ConnectionStatus; reconnect: () => void } {
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('connecting')
+  const [reconnectTrigger, setReconnectTrigger] = useState(0)
+  const autoReconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const autoReconnectCountRef = useRef(0)
+
   useEffect(() => {
     if (!projectId) return
 
     const client = createClient(EventService, transport)
     const controller = new AbortController()
+
+    // Clear any pending auto-reconnect timer
+    if (autoReconnectTimerRef.current) {
+      clearTimeout(autoReconnectTimerRef.current)
+      autoReconnectTimerRef.current = null
+    }
+
+    setConnectionStatus('connecting')
 
     async function subscribe() {
       try {
@@ -24,18 +39,48 @@ export function useEventSubscription(
         for await (const _event of client.subscribeEvents(req, {
           signal: controller.signal,
         })) {
+          setConnectionStatus('connected')
+          autoReconnectCountRef.current = 0 // Reset backoff on successful event
           onEvent()
+        }
+        // Stream ended normally (server closed the stream)
+        if (!controller.signal.aborted) {
+          setConnectionStatus('disconnected')
+          scheduleAutoReconnect()
         }
       } catch (e) {
         if (controller.signal.aborted) return
         console.error('Event subscription error:', e)
+        setConnectionStatus('disconnected')
+        scheduleAutoReconnect()
       }
+    }
+
+    function scheduleAutoReconnect() {
+      const count = autoReconnectCountRef.current
+      // Exponential backoff: 2s, 4s, 8s, 16s, max 30s
+      const delay = Math.min(2000 * Math.pow(2, count), 30000)
+      autoReconnectCountRef.current = count + 1
+      autoReconnectTimerRef.current = setTimeout(() => {
+        setReconnectTrigger((prev) => prev + 1)
+      }, delay)
     }
 
     subscribe()
 
     return () => {
       controller.abort()
+      if (autoReconnectTimerRef.current) {
+        clearTimeout(autoReconnectTimerRef.current)
+        autoReconnectTimerRef.current = null
+      }
     }
-  }, [projectId, eventTypes, onEvent])
+  }, [projectId, eventTypes, onEvent, reconnectTrigger])
+
+  const reconnect = useCallback(() => {
+    autoReconnectCountRef.current = 0 // Reset backoff on manual reconnect
+    setReconnectTrigger((prev) => prev + 1)
+  }, [])
+
+  return { connectionStatus, reconnect }
 }

--- a/frontend/taskguild/src/routes/projects/$projectId/chat.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/chat.tsx
@@ -9,6 +9,7 @@ import { useEventSubscription } from '@/hooks/useEventSubscription'
 import { ChatBubble } from '@/components/ChatBubble'
 import { shortId } from '@/lib/id'
 import { ArrowLeft } from 'lucide-react'
+import { ConnectionIndicator } from '@/components/ConnectionIndicator'
 
 export const Route = createFileRoute('/projects/$projectId/chat')({
   component: ProjectChatPage,
@@ -46,7 +47,7 @@ function ProjectChatPage() {
     EventType.TASK_CREATED, EventType.TASK_UPDATED, EventType.INTERACTION_CREATED, EventType.INTERACTION_RESPONDED,
   ], [])
 
-  useEventSubscription(eventTypes, projectId, onEvent)
+  const { connectionStatus, reconnect } = useEventSubscription(eventTypes, projectId, onEvent)
 
   // Auto-scroll to bottom when new interactions arrive
   useEffect(() => {
@@ -116,6 +117,16 @@ function ProjectChatPage() {
               </div>
             )
           })}
+        </div>
+      </div>
+
+      {/* Connection status bar */}
+      <div className="shrink-0 border-t border-slate-800 px-6 py-2">
+        <div className="max-w-3xl mx-auto flex items-center gap-2">
+          <ConnectionIndicator status={connectionStatus} onReconnect={reconnect} />
+          <span className="text-[11px] text-gray-500">
+            {connectionStatus === 'connected' ? 'Connected' : connectionStatus === 'connecting' ? 'Connecting...' : 'Disconnected'}
+          </span>
         </div>
       </div>
     </div>

--- a/frontend/taskguild/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -63,7 +63,7 @@ function TaskDetailPage() {
     EventType.AGENT_STATUS_CHANGED, EventType.INTERACTION_CREATED, EventType.INTERACTION_RESPONDED,
   ], [])
 
-  useEventSubscription(eventTypes, projectId, onEvent)
+  const { connectionStatus, reconnect } = useEventSubscription(eventTypes, projectId, onEvent)
 
   // Auto-scroll to bottom when new interactions arrive
   useEffect(() => {
@@ -247,6 +247,8 @@ function TaskDetailPage() {
             onSendMessage={handleSendMessage}
             isRespondPending={respondMut.isPending}
             isSendPending={sendMut.isPending}
+            connectionStatus={connectionStatus}
+            onReconnect={reconnect}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add `ConnectionIndicator` component showing real-time SSE connection state (connected/connecting/disconnected) with Wifi/WifiOff/Loader icons
- Enhance `useEventSubscription` hook to track connection status and return `{ connectionStatus, reconnect }` instead of void
- Implement automatic reconnection with exponential backoff (2s → 4s → 8s → 16s → max 30s) on stream disconnection
- Display connection indicator in project chat page status bar and task detail InputBar
- Allow manual reconnect via clicking the disconnected icon, which resets backoff

## Test plan
- [ ] Verify connected state shows green Wifi icon when SSE stream is active
- [ ] Verify connecting state shows spinning yellow loader on initial connection
- [ ] Verify disconnected state shows red WifiOff icon when server is unreachable
- [ ] Verify clicking WifiOff icon triggers manual reconnect
- [ ] Verify auto-reconnect fires with exponential backoff after disconnection
- [ ] Verify backoff resets after successful reconnection
- [ ] Verify connection indicator renders in both chat page and task detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)