### PR TITLE
Sort tasks by newest first within each status column

### DIFF
--- a/frontend/taskguild/src/components/TaskBoard.tsx
+++ b/frontend/taskguild/src/components/TaskBoard.tsx
@@ -114,6 +114,15 @@ export function TaskBoard({ projectId, workflow }: TaskBoardProps) {
       const arr = map.get(effectiveStatusId)
       if (arr) arr.push(t)
     }
+    // Sort tasks within each status: newest first (reverse chronological by created_at)
+    for (const arr of map.values()) {
+      arr.sort((a, b) => {
+        const aSeconds = Number(a.createdAt?.seconds ?? 0n)
+        const bSeconds = Number(b.createdAt?.seconds ?? 0n)
+        if (bSeconds !== aSeconds) return bSeconds - aSeconds
+        return (b.createdAt?.nanos ?? 0) - (a.createdAt?.nanos ?? 0)
+      })
+    }
     return map
   }, [tasks, sortedStatuses, pendingMoves])
 


### PR DESCRIPTION
## Summary
- Sort tasks within each status column in reverse chronological order (newest first) based on `created_at` timestamp
- Compares both seconds and nanoseconds for precise ordering

## Test plan
- [ ] Verify tasks in each status column are displayed with the newest tasks at the top
- [ ] Verify task ordering is preserved correctly after drag-and-drop moves

🤖 Generated with [Claude Code](https://claude.com/claude-code)