### PR TITLE
fix: always serialize permission_mode and use_worktree defaults in workflow YAML

### DIFF
--- a/backend/internal/workflow/entity.go
+++ b/backend/internal/workflow/entity.go
@@ -13,8 +13,8 @@ type Workflow struct {
 	UpdatedAt    time.Time     `yaml:"updated_at"`
 
 	// Task defaults
-	DefaultPermissionMode string `yaml:"default_permission_mode,omitempty"`
-	DefaultUseWorktree    bool   `yaml:"default_use_worktree,omitempty"`
+	DefaultPermissionMode string `yaml:"default_permission_mode"`
+	DefaultUseWorktree    bool   `yaml:"default_use_worktree"`
 }
 
 type HookTrigger string


### PR DESCRIPTION
## Summary
- Remove `omitempty` YAML tags from `DefaultPermissionMode` and `DefaultUseWorktree` fields in `Workflow` struct
- Ensures these fields are always present in serialized YAML output, even when set to zero values (empty string / false)
- Prevents unintended omission of explicit default configuration values

## Test plan
- [ ] Verify workflow YAML serialization includes `default_permission_mode` and `default_use_worktree` even with zero values
- [ ] Verify existing workflows with non-zero values still serialize correctly
- [ ] Verify YAML deserialization still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)