### PR TITLE
Add keyboard shortcuts for approving/denying requests

### DIFF
--- a/frontend/taskguild/src/components/ChatBubble.tsx
+++ b/frontend/taskguild/src/components/ChatBubble.tsx
@@ -27,10 +27,12 @@ export function ChatBubble({
   interaction,
   onRespond,
   isRespondPending,
+  hideActions = false,
 }: {
   interaction: Interaction
   onRespond: (id: string, response: string) => void
   isRespondPending: boolean
+  hideActions?: boolean
 }) {
   // User message — right-aligned bubble
   if (interaction.type === InteractionType.USER_MESSAGE) {
@@ -92,7 +94,7 @@ export function ChatBubble({
           )}
 
           {/* Inline action buttons for pending interactions */}
-          {isPending && interaction.options.length > 0 && (
+          {isPending && !hideActions && interaction.options.length > 0 && (
             interaction.type === InteractionType.QUESTION ? (
               /* Question: vertical card layout with label + description */
               <div className="flex flex-col gap-2 mt-3">

--- a/frontend/taskguild/src/components/PendingRequestsPanel.tsx
+++ b/frontend/taskguild/src/components/PendingRequestsPanel.tsx
@@ -1,0 +1,54 @@
+import { RequestItem } from './RequestItem'
+import { useRequestKeyboard } from '@/hooks/useRequestKeyboard'
+import type { Interaction } from '@taskguild/proto/taskguild/v1/interaction_pb.ts'
+
+export function PendingRequestsPanel({
+  pendingRequests,
+  onRespond,
+  isRespondPending,
+  enabled = true,
+  className,
+}: {
+  pendingRequests: Interaction[]
+  onRespond: (interactionId: string, response: string) => void
+  isRespondPending: boolean
+  enabled?: boolean
+  className?: string
+}) {
+  const { selectedId, setSelectedId } = useRequestKeyboard({
+    pendingRequests,
+    onRespond,
+    isRespondPending,
+    enabled,
+  })
+
+  if (pendingRequests.length === 0) return null
+
+  return (
+    <div className={className}>
+      <div className="flex items-center gap-2 mb-2">
+        <p className="text-xs text-gray-500 uppercase tracking-wide">
+          Pending Requests
+        </p>
+        <span className="inline-flex items-center justify-center px-1.5 py-0.5 text-[10px] font-bold bg-amber-500/20 text-amber-400 rounded">
+          {pendingRequests.length}
+        </span>
+        <span className="ml-auto text-[10px] text-gray-600 font-mono hidden sm:inline">
+          j/k navigate · y allow · Y always · n deny
+        </span>
+      </div>
+      <div className="space-y-3">
+        {pendingRequests.map((interaction) => (
+          <RequestItem
+            key={interaction.id}
+            interaction={interaction}
+            onRespond={onRespond}
+            isRespondPending={isRespondPending}
+            isSelected={interaction.id === selectedId}
+            onSelect={() => setSelectedId(interaction.id)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/taskguild/src/hooks/useRequestKeyboard.ts
+++ b/frontend/taskguild/src/hooks/useRequestKeyboard.ts
@@ -1,0 +1,154 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import type { Interaction } from '@taskguild/proto/taskguild/v1/interaction_pb.ts'
+import { InteractionType } from '@taskguild/proto/taskguild/v1/interaction_pb.ts'
+
+interface UseRequestKeyboardOptions {
+  pendingRequests: Interaction[]
+  onRespond: (interactionId: string, response: string) => void
+  isRespondPending?: boolean
+  enabled?: boolean
+}
+
+interface UseRequestKeyboardResult {
+  selectedId: string | null
+  setSelectedId: (id: string | null) => void
+}
+
+function isInputFocused(): boolean {
+  const el = document.activeElement
+  if (!el) return false
+  const tag = el.tagName.toLowerCase()
+  return (
+    tag === 'input' ||
+    tag === 'textarea' ||
+    tag === 'select' ||
+    (el as HTMLElement).isContentEditable
+  )
+}
+
+function getPermissionShortcutValue(key: string): string | null {
+  switch (key) {
+    case 'y':
+      return 'allow'
+    case 'Y':
+      return 'always_allow'
+    case 'n':
+      return 'deny'
+    default:
+      return null
+  }
+}
+
+export function useRequestKeyboard({
+  pendingRequests,
+  onRespond,
+  isRespondPending = false,
+  enabled = true,
+}: UseRequestKeyboardOptions): UseRequestKeyboardResult {
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const prevRequestsRef = useRef<Interaction[]>([])
+
+  // Auto-select when exactly 1 pending request, or re-select when selected request disappears
+  useEffect(() => {
+    if (pendingRequests.length === 0) {
+      setSelectedId(null)
+      prevRequestsRef.current = pendingRequests
+      return
+    }
+
+    if (pendingRequests.length === 1) {
+      setSelectedId(pendingRequests[0].id)
+      prevRequestsRef.current = pendingRequests
+      return
+    }
+
+    // If the currently selected ID is still in the list, keep it
+    if (selectedId && pendingRequests.some((r) => r.id === selectedId)) {
+      prevRequestsRef.current = pendingRequests
+      return
+    }
+
+    // Selected request disappeared — re-select at the same index position
+    if (selectedId) {
+      const prevIndex = prevRequestsRef.current.findIndex((r) => r.id === selectedId)
+      const clampedIndex = Math.min(Math.max(prevIndex, 0), pendingRequests.length - 1)
+      setSelectedId(pendingRequests[clampedIndex]?.id ?? null)
+    }
+
+    prevRequestsRef.current = pendingRequests
+  }, [pendingRequests, selectedId])
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (!enabled) return
+      if (isInputFocused()) return
+      if (isRespondPending) return
+      if (pendingRequests.length === 0) return
+
+      const currentIndex = pendingRequests.findIndex((r) => r.id === selectedId)
+
+      switch (e.key) {
+        case 'j': {
+          e.preventDefault()
+          if (currentIndex < 0) {
+            // Nothing selected — select first
+            setSelectedId(pendingRequests[0].id)
+          } else {
+            // Wrap around
+            const next = (currentIndex + 1) % pendingRequests.length
+            setSelectedId(pendingRequests[next].id)
+          }
+          break
+        }
+        case 'k': {
+          e.preventDefault()
+          if (currentIndex < 0) {
+            // Nothing selected — select last
+            setSelectedId(pendingRequests[pendingRequests.length - 1].id)
+          } else {
+            // Wrap around
+            const prev = (currentIndex - 1 + pendingRequests.length) % pendingRequests.length
+            setSelectedId(pendingRequests[prev].id)
+          }
+          break
+        }
+        case 'y':
+        case 'Y':
+        case 'n': {
+          if (!selectedId) return
+          const selected = pendingRequests.find((r) => r.id === selectedId)
+          if (!selected || selected.type !== InteractionType.PERMISSION_REQUEST) return
+          const value = getPermissionShortcutValue(e.key)
+          if (!value) return
+          // Verify the option actually exists in the interaction
+          if (!selected.options.some((opt) => opt.value === value)) return
+          e.preventDefault()
+          onRespond(selectedId, value)
+          break
+        }
+        default: {
+          // Number keys 1-9 for QUESTION type options
+          const num = parseInt(e.key, 10)
+          if (num >= 1 && num <= 9) {
+            if (!selectedId) return
+            const selected = pendingRequests.find((r) => r.id === selectedId)
+            if (!selected) return
+            if (num > selected.options.length) return
+            e.preventDefault()
+            const option = selected.options[num - 1]
+            onRespond(selectedId, option.value)
+          }
+          break
+        }
+      }
+    },
+    [enabled, pendingRequests, selectedId, isRespondPending, onRespond],
+  )
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [handleKeyDown])
+
+  return { selectedId, setSelectedId }
+}

--- a/frontend/taskguild/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -16,6 +16,7 @@ import { InputBar } from '@/components/ChatBubble'
 import { MarkdownDescription } from '@/components/MarkdownDescription'
 import { TimelineEntry, type TimelineItem } from '@/components/TimelineEntry'
 import { RequestItem } from '@/components/RequestItem'
+import { PendingRequestsPanel } from '@/components/PendingRequestsPanel'
 import {
   ArrowLeft,
   ArrowRight,
@@ -369,27 +370,13 @@ function TaskDetailPage() {
         >
           <div className="flex-1 min-h-0 overflow-y-auto">
             <div className="max-w-3xl mx-auto px-4 py-4 md:px-6 space-y-3">
-              {/* Section header */}
-              <div className="flex items-center gap-2">
-                <p className="text-xs text-gray-500 uppercase tracking-wide">
-                  Agent Requests
-                </p>
-                {pendingRequests.length > 0 && (
-                  <span className="inline-flex items-center justify-center px-1.5 py-0.5 text-[10px] font-bold bg-amber-500/20 text-amber-400 rounded">
-                    {pendingRequests.length} pending
-                  </span>
-                )}
-              </div>
-
-              {/* Pending requests */}
-              {pendingRequests.map((interaction) => (
-                <RequestItem
-                  key={interaction.id}
-                  interaction={interaction}
-                  onRespond={handleRespond}
-                  isRespondPending={respondMut.isPending}
-                />
-              ))}
+              {/* Pending requests with keyboard shortcuts */}
+              <PendingRequestsPanel
+                pendingRequests={pendingRequests}
+                onRespond={handleRespond}
+                isRespondPending={respondMut.isPending}
+                enabled={mobileTab === 'requests'}
+              />
 
               {/* Resolved requests (collapsible) */}
               {resolvedRequests.length > 0 && (


### PR DESCRIPTION
## Summary
- Add keyboard navigation (`j`/`k`) to cycle through pending requests in both Chat and Task detail pages
- Add shortcut keys for permission requests: `y` (allow), `Y` (always allow), `n` (deny)
- Add number key shortcuts (`1`-`9`) for answering question-type interactions
- Extract new `PendingRequestsPanel` component with keyboard hint display
- Pin pending requests panel between header and chat area on the Chat page for better visibility
- Add visual selection state (cyan border/ring) and auto-scroll for the selected request item
- Hide inline action buttons in chat bubbles for pending requests when the pinned panel is shown

## Test plan
- [ ] Verify `j`/`k` keys navigate between pending requests with visual highlight
- [ ] Verify `y`, `Y`, `n` keys correctly respond to permission requests
- [ ] Verify number keys (`1`, `2`, etc.) select question options
- [ ] Verify keyboard shortcuts are disabled when an input field is focused
- [ ] Verify shortcuts work on both Chat page and Task detail page
- [ ] Verify auto-selection when only one pending request exists
- [ ] Verify selection recovery when a selected request is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)