### PR TITLE
feat: add SyncPermissionsFromDir RPC to sync repo settings

### DIFF
--- a/backend/gen/proto/taskguild/v1/permission.pb.go
+++ b/backend/gen/proto/taskguild/v1/permission.pb.go
@@ -299,6 +299,102 @@ func (x *UpdatePermissionsResponse) GetPermissions() *PermissionSet {
 	return nil
 }
 
+type SyncPermissionsFromDirRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ProjectId     string                 `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
+	Directory     string                 `protobuf:"bytes,2,opt,name=directory,proto3" json:"directory,omitempty"` // path to the repository root directory
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SyncPermissionsFromDirRequest) Reset() {
+	*x = SyncPermissionsFromDirRequest{}
+	mi := &file_taskguild_v1_permission_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SyncPermissionsFromDirRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SyncPermissionsFromDirRequest) ProtoMessage() {}
+
+func (x *SyncPermissionsFromDirRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_taskguild_v1_permission_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SyncPermissionsFromDirRequest.ProtoReflect.Descriptor instead.
+func (*SyncPermissionsFromDirRequest) Descriptor() ([]byte, []int) {
+	return file_taskguild_v1_permission_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *SyncPermissionsFromDirRequest) GetProjectId() string {
+	if x != nil {
+		return x.ProjectId
+	}
+	return ""
+}
+
+func (x *SyncPermissionsFromDirRequest) GetDirectory() string {
+	if x != nil {
+		return x.Directory
+	}
+	return ""
+}
+
+type SyncPermissionsFromDirResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Permissions   *PermissionSet         `protobuf:"bytes,1,opt,name=permissions,proto3" json:"permissions,omitempty"` // merged permission set
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SyncPermissionsFromDirResponse) Reset() {
+	*x = SyncPermissionsFromDirResponse{}
+	mi := &file_taskguild_v1_permission_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SyncPermissionsFromDirResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SyncPermissionsFromDirResponse) ProtoMessage() {}
+
+func (x *SyncPermissionsFromDirResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_taskguild_v1_permission_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SyncPermissionsFromDirResponse.ProtoReflect.Descriptor instead.
+func (*SyncPermissionsFromDirResponse) Descriptor() ([]byte, []int) {
+	return file_taskguild_v1_permission_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *SyncPermissionsFromDirResponse) GetPermissions() *PermissionSet {
+	if x != nil {
+		return x.Permissions
+	}
+	return nil
+}
+
 var File_taskguild_v1_permission_proto protoreflect.FileDescriptor
 
 const file_taskguild_v1_permission_proto_rawDesc = "" +
@@ -324,10 +420,17 @@ const file_taskguild_v1_permission_proto_rawDesc = "" +
 	"\x03ask\x18\x03 \x03(\tR\x03ask\x12\x12\n" +
 	"\x04deny\x18\x04 \x03(\tR\x04deny\"Z\n" +
 	"\x19UpdatePermissionsResponse\x12=\n" +
-	"\vpermissions\x18\x01 \x01(\v2\x1b.taskguild.v1.PermissionSetR\vpermissions2\xd6\x01\n" +
+	"\vpermissions\x18\x01 \x01(\v2\x1b.taskguild.v1.PermissionSetR\vpermissions\"\\\n" +
+	"\x1dSyncPermissionsFromDirRequest\x12\x1d\n" +
+	"\n" +
+	"project_id\x18\x01 \x01(\tR\tprojectId\x12\x1c\n" +
+	"\tdirectory\x18\x02 \x01(\tR\tdirectory\"_\n" +
+	"\x1eSyncPermissionsFromDirResponse\x12=\n" +
+	"\vpermissions\x18\x01 \x01(\v2\x1b.taskguild.v1.PermissionSetR\vpermissions2\xcb\x02\n" +
 	"\x11PermissionService\x12[\n" +
 	"\x0eGetPermissions\x12#.taskguild.v1.GetPermissionsRequest\x1a$.taskguild.v1.GetPermissionsResponse\x12d\n" +
-	"\x11UpdatePermissions\x12&.taskguild.v1.UpdatePermissionsRequest\x1a'.taskguild.v1.UpdatePermissionsResponseB\xbd\x01\n" +
+	"\x11UpdatePermissions\x12&.taskguild.v1.UpdatePermissionsRequest\x1a'.taskguild.v1.UpdatePermissionsResponse\x12s\n" +
+	"\x16SyncPermissionsFromDir\x12+.taskguild.v1.SyncPermissionsFromDirRequest\x1a,.taskguild.v1.SyncPermissionsFromDirResponseB\xbd\x01\n" +
 	"\x10com.taskguild.v1B\x0fPermissionProtoP\x01ZGgithub.com/kazz187/taskguild/backend/gen/proto/taskguild/v1;taskguildv1\xa2\x02\x03TXX\xaa\x02\fTaskguild.V1\xca\x02\fTaskguild\\V1\xe2\x02\x18Taskguild\\V1\\GPBMetadata\xea\x02\rTaskguild::V1b\x06proto3"
 
 var (
@@ -342,28 +445,33 @@ func file_taskguild_v1_permission_proto_rawDescGZIP() []byte {
 	return file_taskguild_v1_permission_proto_rawDescData
 }
 
-var file_taskguild_v1_permission_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_taskguild_v1_permission_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_taskguild_v1_permission_proto_goTypes = []any{
-	(*PermissionSet)(nil),             // 0: taskguild.v1.PermissionSet
-	(*GetPermissionsRequest)(nil),     // 1: taskguild.v1.GetPermissionsRequest
-	(*GetPermissionsResponse)(nil),    // 2: taskguild.v1.GetPermissionsResponse
-	(*UpdatePermissionsRequest)(nil),  // 3: taskguild.v1.UpdatePermissionsRequest
-	(*UpdatePermissionsResponse)(nil), // 4: taskguild.v1.UpdatePermissionsResponse
-	(*timestamppb.Timestamp)(nil),     // 5: google.protobuf.Timestamp
+	(*PermissionSet)(nil),                  // 0: taskguild.v1.PermissionSet
+	(*GetPermissionsRequest)(nil),          // 1: taskguild.v1.GetPermissionsRequest
+	(*GetPermissionsResponse)(nil),         // 2: taskguild.v1.GetPermissionsResponse
+	(*UpdatePermissionsRequest)(nil),       // 3: taskguild.v1.UpdatePermissionsRequest
+	(*UpdatePermissionsResponse)(nil),      // 4: taskguild.v1.UpdatePermissionsResponse
+	(*SyncPermissionsFromDirRequest)(nil),  // 5: taskguild.v1.SyncPermissionsFromDirRequest
+	(*SyncPermissionsFromDirResponse)(nil), // 6: taskguild.v1.SyncPermissionsFromDirResponse
+	(*timestamppb.Timestamp)(nil),          // 7: google.protobuf.Timestamp
 }
 var file_taskguild_v1_permission_proto_depIdxs = []int32{
-	5, // 0: taskguild.v1.PermissionSet.updated_at:type_name -> google.protobuf.Timestamp
+	7, // 0: taskguild.v1.PermissionSet.updated_at:type_name -> google.protobuf.Timestamp
 	0, // 1: taskguild.v1.GetPermissionsResponse.permissions:type_name -> taskguild.v1.PermissionSet
 	0, // 2: taskguild.v1.UpdatePermissionsResponse.permissions:type_name -> taskguild.v1.PermissionSet
-	1, // 3: taskguild.v1.PermissionService.GetPermissions:input_type -> taskguild.v1.GetPermissionsRequest
-	3, // 4: taskguild.v1.PermissionService.UpdatePermissions:input_type -> taskguild.v1.UpdatePermissionsRequest
-	2, // 5: taskguild.v1.PermissionService.GetPermissions:output_type -> taskguild.v1.GetPermissionsResponse
-	4, // 6: taskguild.v1.PermissionService.UpdatePermissions:output_type -> taskguild.v1.UpdatePermissionsResponse
-	5, // [5:7] is the sub-list for method output_type
-	3, // [3:5] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	0, // 3: taskguild.v1.SyncPermissionsFromDirResponse.permissions:type_name -> taskguild.v1.PermissionSet
+	1, // 4: taskguild.v1.PermissionService.GetPermissions:input_type -> taskguild.v1.GetPermissionsRequest
+	3, // 5: taskguild.v1.PermissionService.UpdatePermissions:input_type -> taskguild.v1.UpdatePermissionsRequest
+	5, // 6: taskguild.v1.PermissionService.SyncPermissionsFromDir:input_type -> taskguild.v1.SyncPermissionsFromDirRequest
+	2, // 7: taskguild.v1.PermissionService.GetPermissions:output_type -> taskguild.v1.GetPermissionsResponse
+	4, // 8: taskguild.v1.PermissionService.UpdatePermissions:output_type -> taskguild.v1.UpdatePermissionsResponse
+	6, // 9: taskguild.v1.PermissionService.SyncPermissionsFromDir:output_type -> taskguild.v1.SyncPermissionsFromDirResponse
+	7, // [7:10] is the sub-list for method output_type
+	4, // [4:7] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_taskguild_v1_permission_proto_init() }
@@ -377,7 +485,7 @@ func file_taskguild_v1_permission_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_taskguild_v1_permission_proto_rawDesc), len(file_taskguild_v1_permission_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/frontend/taskguild/pnpm-lock.yaml
+++ b/frontend/taskguild/pnpm-lock.yaml
@@ -532,89 +532,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -704,66 +720,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -870,24 +899,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.0':
     resolution: {integrity: sha512-XKcSStleEVnbH6W/9DHzZv1YhjE4eSS6zOu2eRtYAIh7aV4o3vIBs+t/B15xlqoxt6ef/0uiqJVB6hkHjWD/0A==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.0':
     resolution: {integrity: sha512-/hlXCBqn9K6fi7eAM0RsobHwJYa5V/xzWspVTzxnX+Ft9v6n+30Pz8+RxCn7sQL/vRHHLS30iQPrHQunu6/vJA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.0':
     resolution: {integrity: sha512-lKUaygq4G7sWkhQbfdRRBkaq4LY39IriqBQ+Gk6l5nKq6Ay2M2ZZb1tlIyRNgZKS8cbErTwuYSor0IIULC0SHw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.0':
     resolution: {integrity: sha512-xuDjhAsFdUuFP5W9Ze4k/o4AskUtI8bcAGU4puTYprr89QaYFmhYOPfP+d1pH+k9ets6RoE23BXZM1X1jJqoyw==}
@@ -1478,24 +1511,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}

--- a/proto/gen/ts/taskguild/v1/permission-PermissionService_connectquery.ts
+++ b/proto/gen/ts/taskguild/v1/permission-PermissionService_connectquery.ts
@@ -18,3 +18,11 @@ export const getPermissions = PermissionService.method.getPermissions;
  * @generated from rpc taskguild.v1.PermissionService.UpdatePermissions
  */
 export const updatePermissions = PermissionService.method.updatePermissions;
+
+/**
+ * SyncPermissionsFromDir reads .claude/settings.json from the given directory
+ * and merges its permission rules (allow/ask/deny) into the stored set.
+ *
+ * @generated from rpc taskguild.v1.PermissionService.SyncPermissionsFromDir
+ */
+export const syncPermissionsFromDir = PermissionService.method.syncPermissionsFromDir;

--- a/proto/gen/ts/taskguild/v1/permission_pb.ts
+++ b/proto/gen/ts/taskguild/v1/permission_pb.ts
@@ -12,7 +12,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file taskguild/v1/permission.proto.
  */
 export const file_taskguild_v1_permission: GenFile = /*@__PURE__*/
-  fileDesc("Ch10YXNrZ3VpbGQvdjEvcGVybWlzc2lvbi5wcm90bxIMdGFza2d1aWxkLnYxIn0KDVBlcm1pc3Npb25TZXQSEgoKcHJvamVjdF9pZBgBIAEoCRINCgVhbGxvdxgCIAMoCRILCgNhc2sYAyADKAkSDAoEZGVueRgEIAMoCRIuCgp1cGRhdGVkX2F0GAUgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCIrChVHZXRQZXJtaXNzaW9uc1JlcXVlc3QSEgoKcHJvamVjdF9pZBgBIAEoCSJKChZHZXRQZXJtaXNzaW9uc1Jlc3BvbnNlEjAKC3Blcm1pc3Npb25zGAEgASgLMhsudGFza2d1aWxkLnYxLlBlcm1pc3Npb25TZXQiWAoYVXBkYXRlUGVybWlzc2lvbnNSZXF1ZXN0EhIKCnByb2plY3RfaWQYASABKAkSDQoFYWxsb3cYAiADKAkSCwoDYXNrGAMgAygJEgwKBGRlbnkYBCADKAkiTQoZVXBkYXRlUGVybWlzc2lvbnNSZXNwb25zZRIwCgtwZXJtaXNzaW9ucxgBIAEoCzIbLnRhc2tndWlsZC52MS5QZXJtaXNzaW9uU2V0MtYBChFQZXJtaXNzaW9uU2VydmljZRJbCg5HZXRQZXJtaXNzaW9ucxIjLnRhc2tndWlsZC52MS5HZXRQZXJtaXNzaW9uc1JlcXVlc3QaJC50YXNrZ3VpbGQudjEuR2V0UGVybWlzc2lvbnNSZXNwb25zZRJkChFVcGRhdGVQZXJtaXNzaW9ucxImLnRhc2tndWlsZC52MS5VcGRhdGVQZXJtaXNzaW9uc1JlcXVlc3QaJy50YXNrZ3VpbGQudjEuVXBkYXRlUGVybWlzc2lvbnNSZXNwb25zZUK9AQoQY29tLnRhc2tndWlsZC52MUIPUGVybWlzc2lvblByb3RvUAFaR2dpdGh1Yi5jb20va2F6ejE4Ny90YXNrZ3VpbGQvYmFja2VuZC9nZW4vcHJvdG8vdGFza2d1aWxkL3YxO3Rhc2tndWlsZHYxogIDVFhYqgIMVGFza2d1aWxkLlYxygIMVGFza2d1aWxkXFYx4gIYVGFza2d1aWxkXFYxXEdQQk1ldGFkYXRh6gINVGFza2d1aWxkOjpWMWIGcHJvdG8z", [file_google_protobuf_timestamp]);
+  fileDesc("Ch10YXNrZ3VpbGQvdjEvcGVybWlzc2lvbi5wcm90bxIMdGFza2d1aWxkLnYxIn0KDVBlcm1pc3Npb25TZXQSEgoKcHJvamVjdF9pZBgBIAEoCRINCgVhbGxvdxgCIAMoCRILCgNhc2sYAyADKAkSDAoEZGVueRgEIAMoCRIuCgp1cGRhdGVkX2F0GAUgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCIrChVHZXRQZXJtaXNzaW9uc1JlcXVlc3QSEgoKcHJvamVjdF9pZBgBIAEoCSJKChZHZXRQZXJtaXNzaW9uc1Jlc3BvbnNlEjAKC3Blcm1pc3Npb25zGAEgASgLMhsudGFza2d1aWxkLnYxLlBlcm1pc3Npb25TZXQiWAoYVXBkYXRlUGVybWlzc2lvbnNSZXF1ZXN0EhIKCnByb2plY3RfaWQYASABKAkSDQoFYWxsb3cYAiADKAkSCwoDYXNrGAMgAygJEgwKBGRlbnkYBCADKAkiTQoZVXBkYXRlUGVybWlzc2lvbnNSZXNwb25zZRIwCgtwZXJtaXNzaW9ucxgBIAEoCzIbLnRhc2tndWlsZC52MS5QZXJtaXNzaW9uU2V0IkYKHVN5bmNQZXJtaXNzaW9uc0Zyb21EaXJSZXF1ZXN0EhIKCnByb2plY3RfaWQYASABKAkSEQoJZGlyZWN0b3J5GAIgASgJIlIKHlN5bmNQZXJtaXNzaW9uc0Zyb21EaXJSZXNwb25zZRIwCgtwZXJtaXNzaW9ucxgBIAEoCzIbLnRhc2tndWlsZC52MS5QZXJtaXNzaW9uU2V0MssCChFQZXJtaXNzaW9uU2VydmljZRJbCg5HZXRQZXJtaXNzaW9ucxIjLnRhc2tndWlsZC52MS5HZXRQZXJtaXNzaW9uc1JlcXVlc3QaJC50YXNrZ3VpbGQudjEuR2V0UGVybWlzc2lvbnNSZXNwb25zZRJkChFVcGRhdGVQZXJtaXNzaW9ucxImLnRhc2tndWlsZC52MS5VcGRhdGVQZXJtaXNzaW9uc1JlcXVlc3QaJy50YXNrZ3VpbGQudjEuVXBkYXRlUGVybWlzc2lvbnNSZXNwb25zZRJzChZTeW5jUGVybWlzc2lvbnNGcm9tRGlyEisudGFza2d1aWxkLnYxLlN5bmNQZXJtaXNzaW9uc0Zyb21EaXJSZXF1ZXN0GiwudGFza2d1aWxkLnYxLlN5bmNQZXJtaXNzaW9uc0Zyb21EaXJSZXNwb25zZUK9AQoQY29tLnRhc2tndWlsZC52MUIPUGVybWlzc2lvblByb3RvUAFaR2dpdGh1Yi5jb20va2F6ejE4Ny90YXNrZ3VpbGQvYmFja2VuZC9nZW4vcHJvdG8vdGFza2d1aWxkL3YxO3Rhc2tndWlsZHYxogIDVFhYqgIMVGFza2d1aWxkLlYxygIMVGFza2d1aWxkXFYx4gIYVGFza2d1aWxkXFYxXEdQQk1ldGFkYXRh6gINVGFza2d1aWxkOjpWMWIGcHJvdG8z", [file_google_protobuf_timestamp]);
 
 /**
  * PermissionSet represents a project-scoped set of permission rules.
@@ -137,6 +137,49 @@ export const UpdatePermissionsResponseSchema: GenMessage<UpdatePermissionsRespon
   messageDesc(file_taskguild_v1_permission, 4);
 
 /**
+ * @generated from message taskguild.v1.SyncPermissionsFromDirRequest
+ */
+export type SyncPermissionsFromDirRequest = Message<"taskguild.v1.SyncPermissionsFromDirRequest"> & {
+  /**
+   * @generated from field: string project_id = 1;
+   */
+  projectId: string;
+
+  /**
+   * path to the repository root directory
+   *
+   * @generated from field: string directory = 2;
+   */
+  directory: string;
+};
+
+/**
+ * Describes the message taskguild.v1.SyncPermissionsFromDirRequest.
+ * Use `create(SyncPermissionsFromDirRequestSchema)` to create a new message.
+ */
+export const SyncPermissionsFromDirRequestSchema: GenMessage<SyncPermissionsFromDirRequest> = /*@__PURE__*/
+  messageDesc(file_taskguild_v1_permission, 5);
+
+/**
+ * @generated from message taskguild.v1.SyncPermissionsFromDirResponse
+ */
+export type SyncPermissionsFromDirResponse = Message<"taskguild.v1.SyncPermissionsFromDirResponse"> & {
+  /**
+   * merged permission set
+   *
+   * @generated from field: taskguild.v1.PermissionSet permissions = 1;
+   */
+  permissions?: PermissionSet;
+};
+
+/**
+ * Describes the message taskguild.v1.SyncPermissionsFromDirResponse.
+ * Use `create(SyncPermissionsFromDirResponseSchema)` to create a new message.
+ */
+export const SyncPermissionsFromDirResponseSchema: GenMessage<SyncPermissionsFromDirResponse> = /*@__PURE__*/
+  messageDesc(file_taskguild_v1_permission, 6);
+
+/**
  * PermissionService manages project-scoped permission rules (allow/ask/deny)
  * for Claude Code tools and Bash command patterns.
  *
@@ -163,6 +206,17 @@ export const PermissionService: GenService<{
     methodKind: "unary";
     input: typeof UpdatePermissionsRequestSchema;
     output: typeof UpdatePermissionsResponseSchema;
+  },
+  /**
+   * SyncPermissionsFromDir reads .claude/settings.json from the given directory
+   * and merges its permission rules (allow/ask/deny) into the stored set.
+   *
+   * @generated from rpc taskguild.v1.PermissionService.SyncPermissionsFromDir
+   */
+  syncPermissionsFromDir: {
+    methodKind: "unary";
+    input: typeof SyncPermissionsFromDirRequestSchema;
+    output: typeof SyncPermissionsFromDirResponseSchema;
   },
 }> = /*@__PURE__*/
   serviceDesc(file_taskguild_v1_permission, 0);

--- a/proto/taskguild/v1/permission.proto
+++ b/proto/taskguild/v1/permission.proto
@@ -13,6 +13,10 @@ service PermissionService {
 
   // UpdatePermissions replaces the full permission set for a project.
   rpc UpdatePermissions(UpdatePermissionsRequest) returns (UpdatePermissionsResponse);
+
+  // SyncPermissionsFromDir reads .claude/settings.json from the given directory
+  // and merges its permission rules (allow/ask/deny) into the stored set.
+  rpc SyncPermissionsFromDir(SyncPermissionsFromDirRequest) returns (SyncPermissionsFromDirResponse);
 }
 
 // PermissionSet represents a project-scoped set of permission rules.
@@ -39,4 +43,12 @@ message UpdatePermissionsRequest {
 }
 message UpdatePermissionsResponse {
   PermissionSet permissions = 1;
+}
+
+message SyncPermissionsFromDirRequest {
+  string project_id = 1;
+  string directory = 2;  // path to the repository root directory
+}
+message SyncPermissionsFromDirResponse {
+  PermissionSet permissions = 1;  // merged permission set
 }


### PR DESCRIPTION
## Summary
- Add `SyncPermissionsFromDir` RPC to the PermissionService that reads `.claude/settings.json` from a given directory and merges its allow/ask/deny rules into the stored permission set using union strategy
- Implement backend server logic with file parsing (`readSettingsPermissions`) and helper utilities (`toStringSlice`)
- Add proto definitions for `SyncPermissionsFromDirRequest` / `SyncPermissionsFromDirResponse` and regenerate Go/TypeScript code
- Add "Sync from Repo" button in the frontend `PermissionList` component with loading spinner, error display, and success feedback

## Test plan
- [ ] Verify `SyncPermissionsFromDir` RPC correctly reads and parses `.claude/settings.json`
- [ ] Verify union merge strategy deduplicates rules across allow/ask/deny categories
- [ ] Verify graceful handling when `.claude/settings.json` does not exist (returns existing permissions)
- [ ] Verify frontend "Sync from Repo" button triggers the RPC and refreshes the permission list
- [ ] Verify error states are displayed properly in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)