### PR TITLE
feat: add shell command formatting and bash syntax highlighting

### DIFF
--- a/backend/cmd/taskguild-agent/runner.go
+++ b/backend/cmd/taskguild-agent/runner.go
@@ -18,6 +18,7 @@ import (
 	claudeagent "github.com/kazz187/claude-agent-sdk-go"
 	v1 "github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1"
 	"github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1/taskguildv1connect"
+	"github.com/kazz187/taskguild/backend/pkg/shellformat"
 )
 
 func init() {
@@ -1572,9 +1573,16 @@ func formatToolDescription(toolName string, input map[string]any) string {
 			sb.WriteString(fmt.Sprintf("**Description:** %s\n", desc))
 		}
 		if cmd := str("command"); cmd != "" {
-			fence := codeBlockFence(cmd)
+			// Format the command for readability (breaks one-liners into
+			// multi-line with proper indentation). Falls back to the
+			// original command on parse error.
+			formatted, _ := shellformat.Format(cmd)
+			if formatted == "" {
+				formatted = cmd
+			}
+			fence := codeBlockFence(formatted)
 			sb.WriteString(fmt.Sprintf("\n%sbash\n", fence))
-			sb.WriteString(cmd)
+			sb.WriteString(formatted)
 			sb.WriteString(fmt.Sprintf("\n%s\n", fence))
 		}
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -48,4 +48,5 @@ require (
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	mvdan.cc/sh/v3 v3.12.0 // indirect
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -159,3 +159,5 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+mvdan.cc/sh/v3 v3.12.0 h1:ejKUR7ONP5bb+UGHGEG/k9V5+pRVIyD+LsZz7o8KHrI=
+mvdan.cc/sh/v3 v3.12.0/go.mod h1:Se6Cj17eYSn+sNooLZiEUnNNmNxg0imoYlTu4CyaGyg=

--- a/backend/pkg/shellformat/format.go
+++ b/backend/pkg/shellformat/format.go
@@ -1,0 +1,582 @@
+// Package shellformat provides shell one-liner formatting for improved readability.
+//
+// It parses shell commands using mvdan.cc/sh/v3/syntax (the shfmt parser) and
+// reformats them with proper indentation and line breaks. The formatted output
+// uses backslash continuations, making it valid shell that can be copy-pasted
+// and executed directly.
+package shellformat
+
+import (
+	"bytes"
+	"strings"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// Option configures the formatter.
+type Option func(*config)
+
+// Variant represents a shell language variant.
+type Variant int
+
+const (
+	// Bash is the default shell variant (GNU Bash).
+	Bash Variant = iota
+	// POSIX is the POSIX-compliant shell variant.
+	POSIX
+	// MkSH is the MirBSD Korn Shell variant.
+	MkSH
+)
+
+type config struct {
+	indent   int
+	maxWidth int
+	variant  Variant
+}
+
+func defaultConfig() *config {
+	return &config{
+		indent:   2,
+		maxWidth: 80,
+		variant:  Bash,
+	}
+}
+
+// WithIndent sets the indentation width in spaces (default: 2).
+func WithIndent(n int) Option {
+	return func(c *config) { c.indent = n }
+}
+
+// WithMaxWidth sets the maximum line width threshold (default: 80).
+// Statements shorter than this threshold are kept on a single line.
+func WithMaxWidth(n int) Option {
+	return func(c *config) { c.maxWidth = n }
+}
+
+// WithVariant sets the shell language variant (default: Bash).
+func WithVariant(v Variant) Option {
+	return func(c *config) { c.variant = v }
+}
+
+func (c *config) syntaxVariant() syntax.LangVariant {
+	switch c.variant {
+	case POSIX:
+		return syntax.LangPOSIX
+	case MkSH:
+		return syntax.LangMirBSDKorn
+	default:
+		return syntax.LangBash
+	}
+}
+
+// Format parses a shell one-liner and formats it with proper indentation
+// and line breaks for readability. The formatted output uses backslash
+// continuations and is valid shell that can be copy-pasted and executed.
+//
+// Short statements that fit within the configured max width are kept
+// on a single line. Longer statements have their binary operators
+// (&&, ||, |) placed at the beginning of continuation lines.
+//
+// On parse error, the original input is returned unchanged with a nil error.
+func Format(input string, opts ...Option) (string, error) {
+	cfg := defaultConfig()
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", nil
+	}
+
+	parser := syntax.NewParser(
+		syntax.Variant(cfg.syntaxVariant()),
+		syntax.KeepComments(true),
+	)
+
+	prog, err := parser.Parse(strings.NewReader(input), "")
+	if err != nil {
+		return input, nil
+	}
+
+	f := &formatter{
+		width:   cfg.indent,
+		maxW:    cfg.maxWidth,
+		printer: syntax.NewPrinter(syntax.Indent(uint(cfg.indent)), syntax.SpaceRedirects(true)),
+	}
+
+	f.file(prog)
+	return strings.TrimRight(f.buf.String(), "\n"), nil
+}
+
+// formatter walks the AST and produces formatted output.
+type formatter struct {
+	buf     bytes.Buffer
+	indent  int             // current indent level
+	width   int             // spaces per indent level
+	maxW    int             // max line width
+	printer *syntax.Printer // for rendering leaf nodes
+}
+
+// nodeStr renders a syntax node to a compact string using the standard printer.
+func (f *formatter) nodeStr(node syntax.Node) string {
+	var buf bytes.Buffer
+	f.printer.Print(&buf, node)
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+// indentStr returns the current indentation as a string.
+func (f *formatter) indentStr() string {
+	return strings.Repeat(" ", f.indent*f.width)
+}
+
+// writeIndent writes the current indentation to the buffer.
+func (f *formatter) writeIndent() {
+	f.buf.WriteString(f.indentStr())
+}
+
+// availWidth returns the available width at the current indentation.
+func (f *formatter) availWidth() int {
+	w := f.maxW - f.indent*f.width
+	if w < 20 {
+		w = 20
+	}
+	return w
+}
+
+// file formats a File node (list of statements).
+func (f *formatter) file(prog *syntax.File) {
+	for i, stmt := range prog.Stmts {
+		if i > 0 {
+			f.buf.WriteByte('\n')
+		}
+		f.stmt(stmt)
+	}
+}
+
+// stmt formats a Stmt node. It tries the inline form first.
+// If the inline form doesn't fit within the max width, or the statement
+// contains a compound command (BinaryCmd, if, for, while, case, etc.)
+// that benefits from expansion, it formats with proper line breaks.
+func (f *formatter) stmt(s *syntax.Stmt) {
+	// For compound commands that always benefit from expansion,
+	// skip the inline check and go straight to expansion.
+	needsExpansion := false
+	switch s.Cmd.(type) {
+	case *syntax.BinaryCmd:
+		needsExpansion = true
+	case *syntax.IfClause, *syntax.ForClause, *syntax.WhileClause, *syntax.CaseClause:
+		needsExpansion = true
+	case *syntax.FuncDecl:
+		needsExpansion = true
+	}
+
+	if !needsExpansion {
+		// Try inline form for simple commands.
+		flat := f.nodeStr(s)
+		if !strings.Contains(flat, "\n") && len(flat) <= f.availWidth() {
+			f.buf.WriteString(flat)
+			return
+		}
+	}
+
+	// Expand based on command type.
+	if s.Negated {
+		f.buf.WriteString("! ")
+	}
+
+	if s.Cmd != nil {
+		switch cmd := s.Cmd.(type) {
+		case *syntax.BinaryCmd:
+			f.binaryCmd(cmd)
+		case *syntax.IfClause:
+			f.ifClause(cmd)
+		case *syntax.ForClause:
+			f.forClause(cmd)
+		case *syntax.WhileClause:
+			f.whileClause(cmd)
+		case *syntax.CaseClause:
+			f.caseClause(cmd)
+		case *syntax.Block:
+			f.block(cmd)
+		case *syntax.Subshell:
+			f.subshell(cmd)
+		case *syntax.FuncDecl:
+			f.funcDecl(cmd)
+		default:
+			f.buf.WriteString(f.nodeStr(s.Cmd))
+		}
+	}
+
+	// For non-BinaryCmd, handle outer redirects.
+	if _, ok := s.Cmd.(*syntax.BinaryCmd); !ok {
+		for _, r := range s.Redirs {
+			f.buf.WriteByte(' ')
+			f.writeRedirect(r)
+		}
+	}
+
+	if s.Background {
+		f.buf.WriteString(" &")
+	}
+}
+
+// chainElem represents one element in a flattened binary command chain.
+type chainElem struct {
+	op   string       // operator before this element ("" for first)
+	stmt *syntax.Stmt // the statement
+}
+
+// flattenBinaryCmd flattens a left-associative binary command tree
+// into a linear chain of (operator, statement) pairs.
+func flattenBinaryCmd(cmd *syntax.BinaryCmd) []chainElem {
+	var chain []chainElem
+	collectBinary(cmd, &chain)
+	return chain
+}
+
+func collectBinary(cmd *syntax.BinaryCmd, chain *[]chainElem) {
+	// Flatten the left side if it's also a bare BinaryCmd.
+	if leftBin, ok := cmd.X.Cmd.(*syntax.BinaryCmd); ok && isBareBinaryStmt(cmd.X) {
+		collectBinary(leftBin, chain)
+	} else {
+		*chain = append(*chain, chainElem{stmt: cmd.X})
+	}
+
+	op := cmd.Op.String()
+
+	// Flatten the right side if it's also a bare BinaryCmd.
+	if rightBin, ok := cmd.Y.Cmd.(*syntax.BinaryCmd); ok && isBareBinaryStmt(cmd.Y) {
+		var rightChain []chainElem
+		collectBinary(rightBin, &rightChain)
+		if len(rightChain) > 0 {
+			rightChain[0].op = op
+			*chain = append(*chain, rightChain...)
+		}
+	} else {
+		*chain = append(*chain, chainElem{op: op, stmt: cmd.Y})
+	}
+}
+
+// isBareBinaryStmt returns true if the Stmt is a "bare" wrapper around
+// a BinaryCmd with no extra attributes (negation, redirects, background).
+func isBareBinaryStmt(s *syntax.Stmt) bool {
+	return !s.Negated && !s.Background && len(s.Redirs) == 0
+}
+
+// binaryCmd formats a BinaryCmd node by flattening the chain and
+// rendering each element on its own line with the operator as prefix.
+func (f *formatter) binaryCmd(cmd *syntax.BinaryCmd) {
+	chain := flattenBinaryCmd(cmd)
+
+	// Estimate inline length.
+	totalLen := 0
+	for i, elem := range chain {
+		if i > 0 {
+			totalLen += 1 + len(elem.op) + 1 // " OP "
+		}
+		totalLen += len(f.nodeStr(elem.stmt))
+	}
+
+	// Keep inline if: chain has only 2 elements AND fits within width.
+	// Chains with 3+ elements are always expanded for readability.
+	if len(chain) <= 2 && totalLen <= f.availWidth() {
+		// Render inline.
+		for i, elem := range chain {
+			if i > 0 {
+				f.buf.WriteByte(' ')
+				f.buf.WriteString(elem.op)
+				f.buf.WriteByte(' ')
+			}
+			f.buf.WriteString(f.nodeStr(elem.stmt))
+		}
+		return
+	}
+
+	// Multi-line rendering with operators at the start of continuation lines.
+	for i, elem := range chain {
+		if i > 0 {
+			f.buf.WriteString(" \\\n")
+			f.writeIndent()
+			f.buf.WriteString(strings.Repeat(" ", f.width)) // sub-indent for the operator
+			f.buf.WriteString(elem.op)
+			f.buf.WriteByte(' ')
+		}
+		// Render the element's statement.
+		// Use nodeStr for simple stmts; for compound stmts that need expansion
+		// we render them recursively.
+		f.stmtInChain(elem.stmt)
+	}
+}
+
+// stmtInChain renders a statement that is part of a binary command chain.
+// Simple statements are rendered inline; compound statements that would
+// benefit from expansion are rendered with proper indentation.
+func (f *formatter) stmtInChain(s *syntax.Stmt) {
+	flat := f.nodeStr(s)
+	if !strings.Contains(flat, "\n") {
+		f.buf.WriteString(flat)
+		return
+	}
+
+	// Compound statement needs expansion. Increase indent for the body.
+	if s.Negated {
+		f.buf.WriteString("! ")
+	}
+	if s.Cmd != nil {
+		switch cmd := s.Cmd.(type) {
+		case *syntax.Subshell:
+			f.subshell(cmd)
+		case *syntax.Block:
+			f.block(cmd)
+		case *syntax.IfClause:
+			f.ifClause(cmd)
+		case *syntax.ForClause:
+			f.forClause(cmd)
+		case *syntax.WhileClause:
+			f.whileClause(cmd)
+		case *syntax.CaseClause:
+			f.caseClause(cmd)
+		default:
+			f.buf.WriteString(f.nodeStr(s.Cmd))
+		}
+	}
+	for _, r := range s.Redirs {
+		f.buf.WriteByte(' ')
+		f.writeRedirect(r)
+	}
+	if s.Background {
+		f.buf.WriteString(" &")
+	}
+}
+
+// writeRedirect writes a redirect to the buffer.
+func (f *formatter) writeRedirect(r *syntax.Redirect) {
+	if r.N != nil {
+		f.buf.WriteString(r.N.Value)
+	}
+	f.buf.WriteString(r.Op.String())
+	f.buf.WriteByte(' ')
+	if r.Word != nil {
+		f.buf.WriteString(f.nodeStr(r.Word))
+	}
+	if r.Hdoc != nil {
+		f.buf.WriteString(f.nodeStr(r.Hdoc))
+	}
+}
+
+// stmtList formats a list of statements, each on its own line.
+func (f *formatter) stmtList(stmts []*syntax.Stmt) {
+	for i, s := range stmts {
+		if i > 0 {
+			f.buf.WriteByte('\n')
+		}
+		f.writeIndent()
+		f.stmt(s)
+	}
+}
+
+// ifClause formats an if/elif/else clause with proper indentation.
+func (f *formatter) ifClause(cmd *syntax.IfClause) {
+	f.ifClauseInner(cmd, "if")
+}
+
+func (f *formatter) ifClauseInner(cmd *syntax.IfClause, keyword string) {
+	if keyword == "else" {
+		// "else" block (no condition)
+		f.buf.WriteString("else")
+	} else {
+		// "if" or "elif" block
+		f.buf.WriteString(keyword)
+		f.buf.WriteByte(' ')
+		// Render condition statements inline.
+		for i, s := range cmd.Cond {
+			if i > 0 {
+				f.buf.WriteString("; ")
+			}
+			f.buf.WriteString(f.nodeStr(s))
+		}
+		f.buf.WriteString("; then")
+	}
+	f.buf.WriteByte('\n')
+
+	// Body
+	f.indent++
+	f.stmtList(cmd.Then)
+	f.indent--
+
+	// Else/elif
+	if cmd.Else != nil {
+		f.buf.WriteByte('\n')
+		f.writeIndent()
+		if len(cmd.Else.Cond) > 0 {
+			f.ifClauseInner(cmd.Else, "elif")
+		} else {
+			f.ifClauseInner(cmd.Else, "else")
+		}
+	}
+
+	// Only write "fi" at the outermost level (non-elif/else).
+	if keyword == "if" {
+		f.buf.WriteByte('\n')
+		f.writeIndent()
+		f.buf.WriteString("fi")
+	}
+}
+
+// forClause formats a for/select loop.
+func (f *formatter) forClause(cmd *syntax.ForClause) {
+	if cmd.Select {
+		f.buf.WriteString("select ")
+	} else {
+		f.buf.WriteString("for ")
+	}
+
+	switch loop := cmd.Loop.(type) {
+	case *syntax.WordIter:
+		f.buf.WriteString(loop.Name.Value)
+		if loop.InPos.IsValid() {
+			f.buf.WriteString(" in")
+			for _, w := range loop.Items {
+				f.buf.WriteByte(' ')
+				f.buf.WriteString(f.nodeStr(w))
+			}
+		}
+	case *syntax.CStyleLoop:
+		f.buf.WriteString(f.nodeStr(loop))
+	}
+
+	f.buf.WriteString("; do")
+	f.buf.WriteByte('\n')
+
+	f.indent++
+	f.stmtList(cmd.Do)
+	f.indent--
+
+	f.buf.WriteByte('\n')
+	f.writeIndent()
+	f.buf.WriteString("done")
+}
+
+// whileClause formats a while/until loop.
+func (f *formatter) whileClause(cmd *syntax.WhileClause) {
+	if cmd.Until {
+		f.buf.WriteString("until ")
+	} else {
+		f.buf.WriteString("while ")
+	}
+
+	// Render condition.
+	for i, s := range cmd.Cond {
+		if i > 0 {
+			f.buf.WriteString("; ")
+		}
+		f.buf.WriteString(f.nodeStr(s))
+	}
+	f.buf.WriteString("; do")
+	f.buf.WriteByte('\n')
+
+	f.indent++
+	f.stmtList(cmd.Do)
+	f.indent--
+
+	f.buf.WriteByte('\n')
+	f.writeIndent()
+	f.buf.WriteString("done")
+}
+
+// caseClause formats a case statement.
+func (f *formatter) caseClause(cmd *syntax.CaseClause) {
+	f.buf.WriteString("case ")
+	f.buf.WriteString(f.nodeStr(cmd.Word))
+	f.buf.WriteString(" in")
+
+	for _, item := range cmd.Items {
+		f.buf.WriteByte('\n')
+		f.writeIndent()
+		// Pattern
+		for i, pat := range item.Patterns {
+			if i > 0 {
+				f.buf.WriteString(" | ")
+			}
+			f.buf.WriteString(f.nodeStr(pat))
+		}
+		f.buf.WriteByte(')')
+
+		if len(item.Stmts) > 0 {
+			f.buf.WriteByte('\n')
+			f.indent++
+			f.stmtList(item.Stmts)
+			f.buf.WriteByte('\n')
+			f.writeIndent()
+			f.buf.WriteString(item.Op.String())
+			f.indent--
+		}
+	}
+
+	f.buf.WriteByte('\n')
+	f.writeIndent()
+	f.buf.WriteString("esac")
+}
+
+// block formats a { ... } block.
+func (f *formatter) block(cmd *syntax.Block) {
+	f.buf.WriteString("{")
+
+	if len(cmd.Stmts) > 0 {
+		f.buf.WriteByte('\n')
+		f.indent++
+		f.stmtList(cmd.Stmts)
+		f.indent--
+		f.buf.WriteByte('\n')
+		f.writeIndent()
+	}
+	f.buf.WriteString("}")
+}
+
+// subshell formats a ( ... ) subshell.
+func (f *formatter) subshell(cmd *syntax.Subshell) {
+	// Try inline first.
+	flat := f.nodeStr(cmd)
+	if !strings.Contains(flat, "\n") && len(flat) <= f.availWidth() {
+		f.buf.WriteString(flat)
+		return
+	}
+
+	f.buf.WriteString("(")
+
+	if len(cmd.Stmts) > 0 {
+		f.buf.WriteByte('\n')
+		f.indent++
+		f.stmtList(cmd.Stmts)
+		f.indent--
+		f.buf.WriteByte('\n')
+		f.writeIndent()
+	}
+	f.buf.WriteString(")")
+}
+
+// funcDecl formats a function declaration.
+func (f *formatter) funcDecl(cmd *syntax.FuncDecl) {
+	if cmd.RsrvWord {
+		f.buf.WriteString("function ")
+	}
+	f.buf.WriteString(cmd.Name.Value)
+	if cmd.Parens {
+		f.buf.WriteString("()")
+	}
+	f.buf.WriteByte(' ')
+
+	// The body is a *Stmt which usually contains a Block.
+	if cmd.Body != nil && cmd.Body.Cmd != nil {
+		if blk, ok := cmd.Body.Cmd.(*syntax.Block); ok {
+			f.block(blk)
+		} else {
+			f.buf.WriteString(f.nodeStr(cmd.Body))
+		}
+		for _, r := range cmd.Body.Redirs {
+			f.buf.WriteByte(' ')
+			f.writeRedirect(r)
+		}
+	}
+}

--- a/backend/pkg/shellformat/format_test.go
+++ b/backend/pkg/shellformat/format_test.go
@@ -1,0 +1,298 @@
+package shellformat
+
+import (
+	"strings"
+	"testing"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+func TestFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		opts     []Option
+	}{
+		{
+			name:     "empty input",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "whitespace only",
+			input:    "   \n\t  ",
+			expected: "",
+		},
+		{
+			name:     "simple command stays on one line",
+			input:    "echo hello",
+			expected: "echo hello",
+		},
+		{
+			name:     "short 2-element && chain stays on one line",
+			input:    "echo a && echo b",
+			expected: "echo a && echo b",
+		},
+		{
+			name:     "short 2-element pipe stays on one line",
+			input:    "cat file | grep foo",
+			expected: "cat file | grep foo",
+		},
+		{
+			name:  "long 2-element && chain breaks into lines",
+			input: "docker compose build --no-cache --pull --progress=plain 2>&1 && docker compose up -d --remove-orphans --force-recreate",
+			expected: `docker compose build --no-cache --pull --progress=plain 2>&1 \
+  && docker compose up -d --remove-orphans --force-recreate`,
+		},
+		{
+			name:  "3+ element && chain always breaks",
+			input: "echo a && echo b && echo c",
+			expected: `echo a \
+  && echo b \
+  && echo c`,
+		},
+		{
+			name:  "4-element mixed && and || chain",
+			input: `echo hello && cd /tmp && ls -la || echo "failed"`,
+			expected: `echo hello \
+  && cd /tmp \
+  && ls -la \
+  || echo "failed"`,
+		},
+		{
+			name:  "5-element pipe chain",
+			input: "cat file | grep foo | sort | uniq -c | sort -rn",
+			expected: `cat file \
+  | grep foo \
+  | sort \
+  | uniq -c \
+  | sort -rn`,
+		},
+		{
+			name:  "semicolon separated statements",
+			input: "cd /tmp; ls -la; echo done",
+			expected: `cd /tmp
+ls -la
+echo done`,
+		},
+		{
+			name:  "if statement",
+			input: `if [ -f /tmp/foo ]; then echo exists; else echo missing; fi`,
+			expected: `if [ -f /tmp/foo ]; then
+  echo exists
+else
+  echo missing
+fi`,
+		},
+		{
+			name:  "for loop",
+			input: "for i in 1 2 3; do echo $i; done",
+			expected: `for i in 1 2 3; do
+  echo $i
+done`,
+		},
+		{
+			name:  "while loop",
+			input: `while read line; do echo "$line"; done < input.txt`,
+			expected: `while read line; do
+  echo "$line"
+done < input.txt`,
+		},
+		{
+			name:  "case statement",
+			input: `case "$1" in start) echo starting;; stop) echo stopping;; *) echo "usage: $0 {start|stop}";; esac`,
+			expected: `case "$1" in
+start)
+  echo starting
+  ;;
+stop)
+  echo stopping
+  ;;
+*)
+  echo "usage: $0 {start|stop}"
+  ;;
+esac`,
+		},
+		{
+			name:     "short command substitution stays inline",
+			input:    `echo "Hello $(whoami)"`,
+			expected: `echo "Hello $(whoami)"`,
+		},
+		{
+			// CmdSubst inside Word is rendered by the standard printer (inline).
+			// Expanding CmdSubst with pipes is a future enhancement.
+			name:     "command substitution with pipe stays inline for now",
+			input:    `echo "$(curl -s https://example.com | jq .name)"`,
+			expected: `echo "$(curl -s https://example.com | jq .name)"`,
+		},
+		{
+			name:     "redirect",
+			input:    "echo hello > /tmp/out 2>&1",
+			expected: "echo hello > /tmp/out 2>&1",
+		},
+		{
+			name:     "here string",
+			input:    `cat <<< "hello world"`,
+			expected: `cat <<< "hello world"`,
+		},
+		{
+			name:     "process substitution",
+			input:    "diff <(sort file1) <(sort file2)",
+			expected: "diff <(sort file1) <(sort file2)",
+		},
+		{
+			name:  "function definition",
+			input: "foo() { echo hello; echo world; }; foo",
+			expected: `foo() {
+  echo hello
+  echo world
+}
+foo`,
+		},
+		{
+			name:     "variable assignment with command",
+			input:    "ENV=production APP=myapp docker compose up -d",
+			expected: "ENV=production APP=myapp docker compose up -d",
+		},
+		{
+			name:  "complex compound command with subshell",
+			input: `cd /app && docker compose build --no-cache && docker compose up -d && echo "Deploy done" || (echo "Deploy failed" && exit 1)`,
+			expected: `cd /app \
+  && docker compose build --no-cache \
+  && docker compose up -d \
+  && echo "Deploy done" \
+  || (echo "Deploy failed" && exit 1)`,
+		},
+		{
+			name:  "complex nested if with command substitution",
+			input: `if curl -sf "https://api.example.com/health" > /dev/null 2>&1; then echo "$(date): API is up" >> /var/log/health.log; else echo "$(date): API is DOWN" | mail -s "Alert" admin@example.com && echo "Alert sent"; fi`,
+			expected: `if curl -sf "https://api.example.com/health" > /dev/null 2>&1; then
+  echo "$(date): API is up" >> /var/log/health.log
+else
+  echo "$(date): API is DOWN" \
+    | mail -s "Alert" admin@example.com \
+    && echo "Alert sent"
+fi`,
+		},
+		{
+			// The standard printer converts backticks to $() form.
+			name:     "backtick command substitution normalized to dollar-paren",
+			input:    "echo `date +%Y-%m-%d`",
+			expected: "echo $(date +%Y-%m-%d)",
+		},
+		{
+			name:  "array and for loop",
+			input: `arr=(1 2 3); for i in "${arr[@]}"; do echo $i; done`,
+			expected: `arr=(1 2 3)
+for i in "${arr[@]}"; do
+  echo $i
+done`,
+		},
+		{
+			name:     "parse error returns original",
+			input:    `echo "unclosed string`,
+			expected: `echo "unclosed string`,
+		},
+		{
+			name:  "with custom indent width 4",
+			input: "echo a && echo b && echo c",
+			opts:  []Option{WithIndent(4)},
+			expected: `echo a \
+    && echo b \
+    && echo c`,
+		},
+		{
+			name:     "negated command",
+			input:    "! test -f /tmp/foo && echo missing",
+			expected: "! test -f /tmp/foo && echo missing",
+		},
+		{
+			name:     "background command",
+			input:    "sleep 10 & echo started",
+			expected: "sleep 10 &\necho started",
+		},
+		{
+			name:  "deeply nested binary chain",
+			input: "a && b && c && d && e && f",
+			expected: `a \
+  && b \
+  && c \
+  && d \
+  && e \
+  && f`,
+		},
+		{
+			name:  "mixed pipe and && chain",
+			input: "cat file | grep pattern | awk '{print $1}' && echo done || echo failed",
+			expected: `cat file \
+  | grep pattern \
+  | awk '{print $1}' \
+  && echo done \
+  || echo failed`,
+		},
+		{
+			name:  "if with elif",
+			input: `if [ "$1" = "a" ]; then echo A; elif [ "$1" = "b" ]; then echo B; else echo other; fi`,
+			expected: `if [ "$1" = "a" ]; then
+  echo A
+elif [ "$1" = "b" ]; then
+  echo B
+else
+  echo other
+fi`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Format(tt.input, tt.opts...)
+			if err != nil {
+				t.Fatalf("Format() returned error: %v", err)
+			}
+			if got != tt.expected {
+				t.Errorf("Format(%q)\n  got:\n%s\n\n  expected:\n%s", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestFormatOutputIsValidBash verifies that the formatted output
+// can be re-parsed by the shell parser (roundtrip check).
+func TestFormatOutputIsValidBash(t *testing.T) {
+	inputs := []string{
+		"echo hello && cd /tmp && ls -la || echo failed",
+		"cat file | grep foo | sort | uniq -c | sort -rn",
+		"cd /tmp; ls -la; echo done",
+		`if [ -f /tmp/foo ]; then echo exists; else echo missing; fi`,
+		"for i in 1 2 3; do echo $i; done",
+		`while read line; do echo "$line"; done < input.txt`,
+		`case "$1" in start) echo starting;; stop) echo stopping;; esac`,
+		`cd /app && docker compose build --no-cache && docker compose up -d && echo "Deploy done" || (echo "Deploy failed" && exit 1)`,
+		`foo() { echo hello; echo world; }; foo`,
+		`ENV=production APP=myapp docker compose up -d`,
+		`echo "$(curl -s https://example.com | jq .name)" > output.txt`,
+		`diff <(sort file1) <(sort file2)`,
+		`if curl -sf "https://api.example.com/health" > /dev/null 2>&1; then echo "$(date): API is up" >> /var/log/health.log; else echo "$(date): API is DOWN" | mail -s "Alert" admin@example.com && echo "Alert sent"; fi`,
+		`a && b && c && d && e && f`,
+		`cat file | grep pattern | awk '{print $1}' && echo done || echo failed`,
+		`arr=(1 2 3); for i in "${arr[@]}"; do echo $i; done`,
+	}
+
+	parser := syntax.NewParser(syntax.KeepComments(true))
+
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			formatted, err := Format(input)
+			if err != nil {
+				t.Fatalf("Format() returned error: %v", err)
+			}
+
+			// Verify the output can be re-parsed.
+			_, err = parser.Parse(strings.NewReader(formatted), "")
+			if err != nil {
+				t.Errorf("Formatted output is not valid bash:\n%s\n\nParse error: %v", formatted, err)
+			}
+		})
+	}
+}

--- a/frontend/taskguild/src/components/MarkdownDescription.test.ts
+++ b/frontend/taskguild/src/components/MarkdownDescription.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest'
+import { tokenizeBashLine } from './MarkdownDescription'
+
+describe('tokenizeBashLine', () => {
+  /** Helper to extract [type, value] pairs from tokens. */
+  function tokenTypes(line: string) {
+    return tokenizeBashLine(line).map((t) => [t.type, t.value] as const)
+  }
+
+  /** Helper to get the types of non-whitespace tokens. */
+  function nonWsTypes(line: string) {
+    return tokenizeBashLine(line)
+      .filter((t) => t.value.trim() !== '')
+      .map((t) => [t.type, t.value] as const)
+  }
+
+  it('tokenizes a simple command', () => {
+    const tokens = nonWsTypes('echo hello')
+    expect(tokens).toEqual([
+      ['command', 'echo'],
+      ['text', 'hello'],
+    ])
+  })
+
+  it('tokenizes command with flags', () => {
+    const tokens = nonWsTypes('ls -la --color=auto /tmp')
+    expect(tokens).toEqual([
+      ['command', 'ls'],
+      ['flag', '-la'],
+      ['flag', '--color=auto'],
+      ['text', '/tmp'],
+    ])
+  })
+
+  it('tokenizes && operator', () => {
+    const tokens = nonWsTypes('echo a && echo b')
+    expect(tokens).toEqual([
+      ['command', 'echo'],
+      ['text', 'a'],
+      ['operator', '&&'],
+      ['command', 'echo'],
+      ['text', 'b'],
+    ])
+  })
+
+  it('tokenizes || operator', () => {
+    const tokens = nonWsTypes('cmd1 || cmd2')
+    expect(tokens).toEqual([
+      ['command', 'cmd1'],
+      ['operator', '||'],
+      ['command', 'cmd2'],
+    ])
+  })
+
+  it('tokenizes pipe operator', () => {
+    const tokens = nonWsTypes('cat file | grep pattern')
+    expect(tokens).toEqual([
+      ['command', 'cat'],
+      ['text', 'file'],
+      ['operator', '|'],
+      ['command', 'grep'],
+      ['text', 'pattern'],
+    ])
+  })
+
+  it('tokenizes semicolon operator', () => {
+    const tokens = nonWsTypes('cd /tmp; ls')
+    expect(tokens).toEqual([
+      ['command', 'cd'],
+      ['text', '/tmp'],
+      ['operator', ';'],
+      ['command', 'ls'],
+    ])
+  })
+
+  it('tokenizes double-quoted strings', () => {
+    const tokens = nonWsTypes('echo "hello world"')
+    expect(tokens).toEqual([
+      ['command', 'echo'],
+      ['string', '"hello world"'],
+    ])
+  })
+
+  it('tokenizes single-quoted strings', () => {
+    const tokens = nonWsTypes("echo 'hello world'")
+    expect(tokens).toEqual([
+      ['command', 'echo'],
+      ['string', "'hello world'"],
+    ])
+  })
+
+  it('tokenizes double-quoted strings with escapes', () => {
+    const tokens = nonWsTypes('echo "hello \\"world\\""')
+    expect(tokens).toEqual([
+      ['command', 'echo'],
+      ['string', '"hello \\"world\\""'],
+    ])
+  })
+
+  it('tokenizes variables', () => {
+    const tokens = nonWsTypes('echo $HOME ${PATH} $(whoami)')
+    expect(tokens).toEqual([
+      ['command', 'echo'],
+      ['variable', '$HOME'],
+      ['variable', '${PATH}'],
+      ['variable', '$(whoami)'],
+    ])
+  })
+
+  it('tokenizes special variables', () => {
+    const tokens = nonWsTypes('echo $? $! $# $$ $@')
+    expect(tokens).toEqual([
+      ['command', 'echo'],
+      ['variable', '$?'],
+      ['variable', '$!'],
+      ['variable', '$#'],
+      ['variable', '$$'],
+      ['variable', '$@'],
+    ])
+  })
+
+  it('tokenizes redirections', () => {
+    const tokens = nonWsTypes('echo hello > /tmp/out 2>&1')
+    expect(tokens).toEqual([
+      ['command', 'echo'],
+      ['text', 'hello'],
+      ['redirect', '>'],
+      ['text', '/tmp/out'],
+      ['redirect', '2>&'],
+      ['text', '1'],
+    ])
+  })
+
+  it('tokenizes append redirection', () => {
+    const tokens = nonWsTypes('echo hello >> /tmp/out')
+    expect(tokens).toEqual([
+      ['command', 'echo'],
+      ['text', 'hello'],
+      ['redirect', '>>'],
+      ['text', '/tmp/out'],
+    ])
+  })
+
+  it('tokenizes here-string redirect', () => {
+    const tokens = nonWsTypes('cat <<<')
+    expect(tokens).toEqual([
+      ['command', 'cat'],
+      ['redirect', '<<<'],
+    ])
+  })
+
+  it('tokenizes keywords', () => {
+    const tokens = nonWsTypes('if then else fi')
+    expect(tokens).toEqual([
+      ['keyword', 'if'],
+      ['keyword', 'then'],
+      ['keyword', 'else'],
+      ['keyword', 'fi'],
+    ])
+  })
+
+  it('tokenizes for loop keywords', () => {
+    const tokens = nonWsTypes('for do done')
+    expect(tokens).toEqual([
+      ['keyword', 'for'],
+      ['keyword', 'do'],
+      ['keyword', 'done'],
+    ])
+  })
+
+  it('tokenizes backslash continuation', () => {
+    const tokens = tokenTypes('echo hello \\')
+    expect(tokens).toEqual([
+      ['command', 'echo'],
+      ['text', ' '],
+      ['text', 'hello'],
+      ['text', ' '],
+      ['continuation', '\\'],
+    ])
+  })
+
+  it('tokenizes comments', () => {
+    const tokens = nonWsTypes('# this is a comment')
+    expect(tokens).toEqual([['comment', '# this is a comment']])
+  })
+
+  it('tokenizes inline comment', () => {
+    const tokens = nonWsTypes('echo hello # comment')
+    expect(tokens).toEqual([
+      ['command', 'echo'],
+      ['text', 'hello'],
+      ['comment', '# comment'],
+    ])
+  })
+
+  it('tokenizes variable assignments', () => {
+    const tokens = nonWsTypes('VAR=value cmd')
+    expect(tokens).toEqual([
+      ['variable', 'VAR=value'],
+      ['command', 'cmd'],
+    ])
+  })
+
+  it('tokenizes ANSI-C quoted strings', () => {
+    const tokens = nonWsTypes("echo $'hello\\nworld'")
+    expect(tokens).toEqual([
+      ['command', 'echo'],
+      ['string', "$'hello\\nworld'"],
+    ])
+  })
+
+  it('tokenizes empty line', () => {
+    const tokens = tokenizeBashLine('')
+    expect(tokens).toEqual([])
+  })
+
+  it('tokenizes complex formatted line', () => {
+    const tokens = nonWsTypes('  && docker compose build --no-cache')
+    expect(tokens).toEqual([
+      ['operator', '&&'],
+      ['command', 'docker'],
+      ['text', 'compose'],
+      ['text', 'build'],
+      ['flag', '--no-cache'],
+    ])
+  })
+
+  it('tokenizes pipe at start of continuation line', () => {
+    const tokens = nonWsTypes('  | grep pattern')
+    expect(tokens).toEqual([
+      ['operator', '|'],
+      ['command', 'grep'],
+      ['text', 'pattern'],
+    ])
+  })
+
+  it('tokenizes case pattern terminators', () => {
+    const tokens = nonWsTypes(';;')
+    expect(tokens).toEqual([['operator', ';;']])
+  })
+})


### PR DESCRIPTION
## Summary
- Add `shellformat` backend package (using `mvdan.cc/sh/v3`) to reformat one-liner shell commands into readable multi-line form with proper indentation in tool descriptions
- Add lightweight bash tokenizer to the frontend `MarkdownDescription` component for syntax-highlighted code blocks — highlighting commands, keywords, strings, variables, flags, operators, redirections, and comments
- Include comprehensive unit tests for both the Go formatter (`format_test.go`) and the TypeScript tokenizer (`MarkdownDescription.test.ts`)

## Test plan
- [ ] Verify backend `shellformat` tests pass (`go test ./backend/pkg/shellformat/...`)
- [ ] Verify frontend tokenizer tests pass (`vitest run MarkdownDescription.test.ts`)
- [ ] Confirm bash code blocks in the UI render with correct syntax highlighting
- [ ] Confirm long one-liner shell commands in tool descriptions are formatted into readable multi-line output

🤖 Generated with [Claude Code](https://claude.com/claude-code)