### PR TITLE
Fix @bufbuild/protobuf/codegenv2 import error in Vite build

### DIFF
--- a/frontend/taskguild/vite.config.ts
+++ b/frontend/taskguild/vite.config.ts
@@ -15,6 +15,9 @@ const config = defineConfig({
     tanstackRouter({ target: 'react', autoCodeSplitting: true }),
     viteReact(),
   ],
+  resolve: {
+    dedupe: ['@bufbuild/protobuf'],
+  },
 })
 
 export default config


### PR DESCRIPTION
## Summary
- Add `resolve.dedupe` configuration for `@bufbuild/protobuf` in `vite.config.ts` to resolve duplicate module import errors during Vite build
- Fixes `@bufbuild/protobuf/codegenv2` import error caused by multiple instances of the protobuf package being resolved

## Test plan
- [ ] Verify `npm run build` completes without `@bufbuild/protobuf/codegenv2` import errors
- [ ] Verify the application runs correctly in development mode
- [ ] Verify protobuf-related functionality works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)