### PR TITLE
Add background color to pending requests panel

### DIFF
--- a/frontend/taskguild/src/routes/projects/$projectId/chat.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/chat.tsx
@@ -115,7 +115,7 @@ function ProjectChatPage() {
 
       {/* Pending requests section — pinned between header and chat */}
       {pendingRequests.length > 0 && (
-        <div className="shrink-0 border-b border-slate-800 px-4 md:px-6 py-3">
+        <div className="shrink-0 border-b border-slate-800 bg-slate-800/50 px-4 md:px-6 py-3">
           <div className="max-w-3xl mx-auto">
             <PendingRequestsPanel
               pendingRequests={pendingRequests}

--- a/frontend/taskguild/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -238,7 +238,7 @@ function TaskDetailPage() {
 
       {/* Pending requests section — pinned between header and timeline */}
       {pendingRequests.length > 0 && (
-        <div className="shrink-0 border-b border-slate-800 px-4 md:px-6 py-3">
+        <div className="shrink-0 border-b border-slate-800 bg-slate-800/50 px-4 md:px-6 py-3">
           <div className="max-w-3xl mx-auto">
             <PendingRequestsPanel
               pendingRequests={pendingRequests}


### PR DESCRIPTION
## Summary
- Add `bg-slate-800/50` background color to the pending requests panel in both chat and task detail pages
- Improves visual distinction of the pending requests section from surrounding content

## Test plan
- [ ] Verify pending requests panel has visible background color on the chat page
- [ ] Verify pending requests panel has visible background color on the task detail page
- [ ] Confirm the background color provides good contrast and readability

🤖 Generated with [Claude Code](https://claude.com/claude-code)