### PR TITLE
Extract sentinel to shared pkg and add subcommands to server

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-server build-agent run test tidy clean
+.PHONY: build build-server build-agent run run-direct test tidy clean
 
 build: build-server build-agent
 
@@ -9,7 +9,10 @@ build-agent:
 	go build -o bin/taskguild-agent ./cmd/taskguild-agent/
 
 run:
-	TASKGUILD_API_KEY=dev go run ./cmd/taskguild-server/
+	TASKGUILD_API_KEY=dev go run ./cmd/taskguild-server/ sentinel
+
+run-direct:
+	TASKGUILD_API_KEY=dev go run ./cmd/taskguild-server/ run
 
 test:
 	go test ./...

--- a/backend/cmd/taskguild-server/main.go
+++ b/backend/cmd/taskguild-server/main.go
@@ -1,201 +1,25 @@
 package main
 
 import (
-	"context"
-	"log/slog"
-	"net/http"
 	"os"
-	"os/signal"
-	"syscall"
-	"time"
 
-	"github.com/kazz187/taskguild/backend/internal/agent"
-	agentrepo "github.com/kazz187/taskguild/backend/internal/agent/repositoryimpl"
-	"github.com/kazz187/taskguild/backend/internal/agentmanager"
-	"github.com/kazz187/taskguild/backend/internal/config"
-	"github.com/kazz187/taskguild/backend/internal/event"
-	"github.com/kazz187/taskguild/backend/internal/eventbus"
-	"github.com/kazz187/taskguild/backend/internal/interaction"
-	interactionrepo "github.com/kazz187/taskguild/backend/internal/interaction/repositoryimpl"
-	"github.com/kazz187/taskguild/backend/internal/orchestrator"
-	"github.com/kazz187/taskguild/backend/internal/permission"
-	permissionrepo "github.com/kazz187/taskguild/backend/internal/permission/repositoryimpl"
-	"github.com/kazz187/taskguild/backend/internal/project"
-	projectrepo "github.com/kazz187/taskguild/backend/internal/project/repositoryimpl"
-	"github.com/kazz187/taskguild/backend/internal/pushnotification"
-	pushsubrepo "github.com/kazz187/taskguild/backend/internal/pushsubscription/repositoryimpl"
-	"github.com/kazz187/taskguild/backend/internal/skill"
-	skillrepo "github.com/kazz187/taskguild/backend/internal/skill/repositoryimpl"
-	"github.com/kazz187/taskguild/backend/internal/task"
-	taskrepo "github.com/kazz187/taskguild/backend/internal/task/repositoryimpl"
-	"github.com/kazz187/taskguild/backend/internal/tasklog"
-	tasklogrepo "github.com/kazz187/taskguild/backend/internal/tasklog/repositoryimpl"
-	"github.com/kazz187/taskguild/backend/internal/workflow"
-	workflowrepo "github.com/kazz187/taskguild/backend/internal/workflow/repositoryimpl"
-	"github.com/kazz187/taskguild/backend/pkg/clog"
-	"github.com/kazz187/taskguild/backend/pkg/storage"
-
-	taskguildv1 "github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1"
-
-	server "github.com/kazz187/taskguild/backend/internal"
+	"github.com/alecthomas/kingpin/v2"
 )
 
-// agentChangeNotifier implements agent.ChangeNotifier by broadcasting
-// a SyncAgentsCommand to connected agents in the same project.
-type agentChangeNotifier struct {
-	registry    *agentmanager.Registry
-	projectRepo project.Repository
-}
+var (
+	app = kingpin.New("taskguild-server", "TaskGuild server").
+		UsageWriter(os.Stderr)
 
-func (n *agentChangeNotifier) NotifyAgentChange(projectID string) {
-	p, err := n.projectRepo.Get(context.Background(), projectID)
-	if err != nil {
-		slog.Error("failed to look up project for agent change notification", "project_id", projectID, "error", err)
-		return
-	}
-	n.registry.BroadcastCommandToProject(p.Name, &taskguildv1.AgentCommand{
-		Command: &taskguildv1.AgentCommand_SyncAgents{
-			SyncAgents: &taskguildv1.SyncAgentsCommand{},
-		},
-	})
-}
-
-// permissionChangeNotifier implements permission.ChangeNotifier by broadcasting
-// a SyncPermissionsCommand to connected agents in the same project.
-type permissionChangeNotifier struct {
-	registry    *agentmanager.Registry
-	projectRepo project.Repository
-}
-
-func (n *permissionChangeNotifier) NotifyPermissionChange(projectID string) {
-	p, err := n.projectRepo.Get(context.Background(), projectID)
-	if err != nil {
-		slog.Error("failed to look up project for permission change notification", "project_id", projectID, "error", err)
-		return
-	}
-	n.registry.BroadcastCommandToProject(p.Name, &taskguildv1.AgentCommand{
-		Command: &taskguildv1.AgentCommand_SyncPermissions{
-			SyncPermissions: &taskguildv1.SyncPermissionsCommand{},
-		},
-	})
-}
+	runCmd      = app.Command("run", "Run the server")
+	sentinelCmd = app.Command("sentinel", "Supervisor that manages 'run' with auto-restart and binary watching")
+)
 
 func main() {
-	env, err := config.LoadEnv()
-	if err != nil {
-		slog.Error("failed to load env", "error", err)
-		os.Exit(1)
-	}
-
-	// Setup logger
-	level := env.SlogLevel()
-	var handler slog.Handler
-	if env.Env == "local" {
-		handler = clog.NewConnectTextHandler(os.Stderr, clog.WithLevel(level))
-	} else {
-		handler = slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: level})
-	}
-	slog.SetDefault(slog.New(clog.NewAttributesHandler(handler)))
-
-	// Setup storage
-	var store storage.Storage
-	switch env.StorageEnv.Type {
-	case "s3":
-		store, err = storage.NewS3Storage(context.Background(), env.StorageEnv.S3Bucket, env.StorageEnv.S3Prefix, env.StorageEnv.S3Region)
-		if err != nil {
-			slog.Error("failed to create S3 storage", "error", err)
-			os.Exit(1)
-		}
-	default:
-		store, err = storage.NewLocalStorage(env.StorageEnv.BaseDir)
-		if err != nil {
-			slog.Error("failed to create local storage", "error", err)
-			os.Exit(1)
-		}
-	}
-
-	// Setup event bus
-	bus := eventbus.New()
-
-	// Setup repositories
-	projectRepo := projectrepo.NewYAMLRepository(store)
-	workflowRepo := workflowrepo.NewYAMLRepository(store)
-	taskRepo := taskrepo.NewYAMLRepository(store)
-	interactionRepo := interactionrepo.NewYAMLRepository(store)
-	agentRepo := agentrepo.NewYAMLRepository(store)
-	skillRepo := skillrepo.NewYAMLRepository(store)
-	taskLogRepo := tasklogrepo.NewYAMLRepository(store)
-	pushSubRepo := pushsubrepo.NewYAMLRepository(store)
-	permissionRepo := permissionrepo.NewYAMLRepository(store)
-
-	// Setup agent-manager registry
-	agentManagerRegistry := agentmanager.NewRegistry()
-
-	// Setup servers
-	projectServer := project.NewServer(projectRepo)
-	workflowServer := workflow.NewServer(workflowRepo)
-	taskServer := task.NewServer(taskRepo, workflowRepo, bus)
-	interactionServer := interaction.NewServer(interactionRepo, taskRepo, bus)
-	agentManagerServer := agentmanager.NewServer(agentManagerRegistry, taskRepo, workflowRepo, agentRepo, interactionRepo, projectRepo, skillRepo, taskLogRepo, permissionRepo, bus)
-	agentChangeNotifier := &agentChangeNotifier{
-		registry:    agentManagerRegistry,
-		projectRepo: projectRepo,
-	}
-	agentServer := agent.NewServer(agentRepo, agentChangeNotifier)
-	skillServer := skill.NewServer(skillRepo)
-	taskLogServer := tasklog.NewServer(taskLogRepo)
-	eventServer := event.NewServer(bus)
-	permissionChangeNotifier := &permissionChangeNotifier{
-		registry:    agentManagerRegistry,
-		projectRepo: projectRepo,
-	}
-	permissionServer := permission.NewServer(permissionRepo, permissionChangeNotifier)
-
-	// Setup push notification
-	vapidEnv := config.VAPIDEnvFromEnv(env)
-	pushSender := pushnotification.NewSender(vapidEnv, pushSubRepo)
-	pushNotificationServer := pushnotification.NewServer(vapidEnv, pushSubRepo, pushSender)
-	pushDispatcher := pushnotification.NewDispatcher(bus, interactionRepo, taskRepo, pushSender)
-
-	srv := server.NewServer(
-		env,
-		projectServer,
-		workflowServer,
-		taskServer,
-		interactionServer,
-		agentManagerServer,
-		agentServer,
-		skillServer,
-		eventServer,
-		taskLogServer,
-		pushNotificationServer,
-		permissionServer,
-	)
-
-	// Setup orchestrator
-	orch := orchestrator.New(bus, taskRepo, workflowRepo, projectRepo, agentManagerRegistry)
-
-	// Graceful shutdown
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-	defer cancel()
-
-	go orch.Start(ctx)
-	go pushDispatcher.Start(ctx)
-
-	go func() {
-		if err := srv.ListenAndServe(ctx); err != nil && err != http.ErrServerClosed {
-			slog.Error("server error", "error", err)
-			cancel()
-		}
-	}()
-
-	<-ctx.Done()
-	slog.Info("shutting down server")
-
-	// Give active connections time to finish after stream contexts are cancelled.
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer shutdownCancel()
-	if err := srv.Shutdown(shutdownCtx); err != nil {
-		slog.Error("shutdown error", "error", err)
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+	switch cmd {
+	case runCmd.FullCommand():
+		runServer()
+	case sentinelCmd.FullCommand():
+		runSentinel()
 	}
 }

--- a/backend/cmd/taskguild-server/run.go
+++ b/backend/cmd/taskguild-server/run.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/kazz187/taskguild/backend/internal/agent"
+	agentrepo "github.com/kazz187/taskguild/backend/internal/agent/repositoryimpl"
+	"github.com/kazz187/taskguild/backend/internal/agentmanager"
+	"github.com/kazz187/taskguild/backend/internal/config"
+	"github.com/kazz187/taskguild/backend/internal/event"
+	"github.com/kazz187/taskguild/backend/internal/eventbus"
+	"github.com/kazz187/taskguild/backend/internal/interaction"
+	interactionrepo "github.com/kazz187/taskguild/backend/internal/interaction/repositoryimpl"
+	"github.com/kazz187/taskguild/backend/internal/orchestrator"
+	"github.com/kazz187/taskguild/backend/internal/permission"
+	permissionrepo "github.com/kazz187/taskguild/backend/internal/permission/repositoryimpl"
+	"github.com/kazz187/taskguild/backend/internal/project"
+	projectrepo "github.com/kazz187/taskguild/backend/internal/project/repositoryimpl"
+	"github.com/kazz187/taskguild/backend/internal/pushnotification"
+	pushsubrepo "github.com/kazz187/taskguild/backend/internal/pushsubscription/repositoryimpl"
+	"github.com/kazz187/taskguild/backend/internal/skill"
+	skillrepo "github.com/kazz187/taskguild/backend/internal/skill/repositoryimpl"
+	"github.com/kazz187/taskguild/backend/internal/task"
+	taskrepo "github.com/kazz187/taskguild/backend/internal/task/repositoryimpl"
+	"github.com/kazz187/taskguild/backend/internal/tasklog"
+	tasklogrepo "github.com/kazz187/taskguild/backend/internal/tasklog/repositoryimpl"
+	"github.com/kazz187/taskguild/backend/internal/workflow"
+	workflowrepo "github.com/kazz187/taskguild/backend/internal/workflow/repositoryimpl"
+	"github.com/kazz187/taskguild/backend/pkg/clog"
+	"github.com/kazz187/taskguild/backend/pkg/storage"
+
+	taskguildv1 "github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1"
+
+	server "github.com/kazz187/taskguild/backend/internal"
+)
+
+// agentChangeNotifier implements agent.ChangeNotifier by broadcasting
+// a SyncAgentsCommand to connected agents in the same project.
+type agentChangeNotifier struct {
+	registry    *agentmanager.Registry
+	projectRepo project.Repository
+}
+
+func (n *agentChangeNotifier) NotifyAgentChange(projectID string) {
+	p, err := n.projectRepo.Get(context.Background(), projectID)
+	if err != nil {
+		slog.Error("failed to look up project for agent change notification", "project_id", projectID, "error", err)
+		return
+	}
+	n.registry.BroadcastCommandToProject(p.Name, &taskguildv1.AgentCommand{
+		Command: &taskguildv1.AgentCommand_SyncAgents{
+			SyncAgents: &taskguildv1.SyncAgentsCommand{},
+		},
+	})
+}
+
+// permissionChangeNotifier implements permission.ChangeNotifier by broadcasting
+// a SyncPermissionsCommand to connected agents in the same project.
+type permissionChangeNotifier struct {
+	registry    *agentmanager.Registry
+	projectRepo project.Repository
+}
+
+func (n *permissionChangeNotifier) NotifyPermissionChange(projectID string) {
+	p, err := n.projectRepo.Get(context.Background(), projectID)
+	if err != nil {
+		slog.Error("failed to look up project for permission change notification", "project_id", projectID, "error", err)
+		return
+	}
+	n.registry.BroadcastCommandToProject(p.Name, &taskguildv1.AgentCommand{
+		Command: &taskguildv1.AgentCommand_SyncPermissions{
+			SyncPermissions: &taskguildv1.SyncPermissionsCommand{},
+		},
+	})
+}
+
+func runServer() {
+	env, err := config.LoadEnv()
+	if err != nil {
+		slog.Error("failed to load env", "error", err)
+		os.Exit(1)
+	}
+
+	// Setup logger
+	level := env.SlogLevel()
+	var handler slog.Handler
+	if env.Env == "local" {
+		handler = clog.NewConnectTextHandler(os.Stderr, clog.WithLevel(level))
+	} else {
+		handler = slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: level})
+	}
+	slog.SetDefault(slog.New(clog.NewAttributesHandler(handler)))
+
+	// Setup storage
+	var store storage.Storage
+	switch env.StorageEnv.Type {
+	case "s3":
+		store, err = storage.NewS3Storage(context.Background(), env.StorageEnv.S3Bucket, env.StorageEnv.S3Prefix, env.StorageEnv.S3Region)
+		if err != nil {
+			slog.Error("failed to create S3 storage", "error", err)
+			os.Exit(1)
+		}
+	default:
+		store, err = storage.NewLocalStorage(env.StorageEnv.BaseDir)
+		if err != nil {
+			slog.Error("failed to create local storage", "error", err)
+			os.Exit(1)
+		}
+	}
+
+	// Setup event bus
+	bus := eventbus.New()
+
+	// Setup repositories
+	projectRepo := projectrepo.NewYAMLRepository(store)
+	workflowRepo := workflowrepo.NewYAMLRepository(store)
+	taskRepo := taskrepo.NewYAMLRepository(store)
+	interactionRepo := interactionrepo.NewYAMLRepository(store)
+	agentRepo := agentrepo.NewYAMLRepository(store)
+	skillRepo := skillrepo.NewYAMLRepository(store)
+	taskLogRepo := tasklogrepo.NewYAMLRepository(store)
+	pushSubRepo := pushsubrepo.NewYAMLRepository(store)
+	permissionRepo := permissionrepo.NewYAMLRepository(store)
+
+	// Setup agent-manager registry
+	agentManagerRegistry := agentmanager.NewRegistry()
+
+	// Setup servers
+	projectServer := project.NewServer(projectRepo)
+	workflowServer := workflow.NewServer(workflowRepo)
+	taskServer := task.NewServer(taskRepo, workflowRepo, bus)
+	interactionServer := interaction.NewServer(interactionRepo, taskRepo, bus)
+	agentManagerServer := agentmanager.NewServer(agentManagerRegistry, taskRepo, workflowRepo, agentRepo, interactionRepo, projectRepo, skillRepo, taskLogRepo, permissionRepo, bus)
+	agentChangeNotifier := &agentChangeNotifier{
+		registry:    agentManagerRegistry,
+		projectRepo: projectRepo,
+	}
+	agentServer := agent.NewServer(agentRepo, agentChangeNotifier)
+	skillServer := skill.NewServer(skillRepo)
+	taskLogServer := tasklog.NewServer(taskLogRepo)
+	eventServer := event.NewServer(bus)
+	permissionChangeNotifier := &permissionChangeNotifier{
+		registry:    agentManagerRegistry,
+		projectRepo: projectRepo,
+	}
+	permissionServer := permission.NewServer(permissionRepo, permissionChangeNotifier)
+
+	// Setup push notification
+	vapidEnv := config.VAPIDEnvFromEnv(env)
+	pushSender := pushnotification.NewSender(vapidEnv, pushSubRepo)
+	pushNotificationServer := pushnotification.NewServer(vapidEnv, pushSubRepo, pushSender)
+	pushDispatcher := pushnotification.NewDispatcher(bus, interactionRepo, taskRepo, pushSender)
+
+	srv := server.NewServer(
+		env,
+		projectServer,
+		workflowServer,
+		taskServer,
+		interactionServer,
+		agentManagerServer,
+		agentServer,
+		skillServer,
+		eventServer,
+		taskLogServer,
+		pushNotificationServer,
+		permissionServer,
+	)
+
+	// Setup orchestrator
+	orch := orchestrator.New(bus, taskRepo, workflowRepo, projectRepo, agentManagerRegistry)
+
+	// Graceful shutdown
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+
+	go orch.Start(ctx)
+	go pushDispatcher.Start(ctx)
+
+	go func() {
+		if err := srv.ListenAndServe(ctx); err != nil && err != http.ErrServerClosed {
+			slog.Error("server error", "error", err)
+			cancel()
+		}
+	}()
+
+	<-ctx.Done()
+	slog.Info("shutting down server")
+
+	// Give active connections time to finish after stream contexts are cancelled.
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutdownCancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		slog.Error("shutdown error", "error", err)
+	}
+}

--- a/backend/cmd/taskguild-server/sentinel.go
+++ b/backend/cmd/taskguild-server/sentinel.go
@@ -2,7 +2,7 @@ package main
 
 import "github.com/kazz187/taskguild/backend/pkg/sentinel"
 
-// runSentinel starts the sentinel supervisor for the agent.
+// runSentinel starts the sentinel supervisor for the server.
 func runSentinel() {
 	sentinel.Run()
 }

--- a/backend/pkg/sentinel/sentinel.go
+++ b/backend/pkg/sentinel/sentinel.go
@@ -1,0 +1,323 @@
+package sentinel
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+const (
+	// GracePeriod is the time to wait after SIGTERM before sending SIGKILL.
+	GracePeriod = 10 * time.Second
+
+	// InitialBackoff is the initial delay before restarting after an abnormal exit.
+	InitialBackoff = 5 * time.Second
+
+	// MaxBackoff is the maximum delay between restarts.
+	MaxBackoff = 10 * time.Minute
+
+	// BackoffFactor is the multiplier for each successive backoff.
+	BackoffFactor = 2.0
+
+	// SuccessRunTime is how long the child must run before backoff resets.
+	SuccessRunTime = 30 * time.Second
+
+	// DebounceInterval is the delay after an fsnotify event before checking the checksum.
+	DebounceInterval = 100 * time.Millisecond
+)
+
+// Sentinel manages the lifecycle of a child process with the "run" subcommand.
+type Sentinel struct {
+	binaryPath string
+	lastHash   [sha256.Size]byte
+	backoff    time.Duration
+	stopCh     chan struct{} // closed when sentinel should exit
+}
+
+// Run starts the sentinel supervisor loop. It resolves the current executable
+// path, starts a child process with the "run" subcommand, watches the binary
+// for changes, and restarts the child on crash with exponential backoff.
+// This function blocks until SIGINT/SIGTERM is received.
+func Run() {
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
+	log.SetPrefix("[sentinel] ")
+
+	// Resolve own binary path.
+	binaryPath, err := os.Executable()
+	if err != nil {
+		log.Fatalf("failed to resolve executable path: %v", err)
+	}
+	// Resolve symlinks so we watch the real file location.
+	binaryPath, err = filepath.EvalSymlinks(binaryPath)
+	if err != nil {
+		log.Fatalf("failed to resolve symlinks for binary: %v", err)
+	}
+
+	log.Printf("starting sentinel (binary: %s)", binaryPath)
+
+	s := &Sentinel{
+		binaryPath: binaryPath,
+		backoff:    InitialBackoff,
+		stopCh:     make(chan struct{}),
+	}
+
+	// Compute initial SHA256 hash of the binary.
+	s.lastHash, err = HashFile(binaryPath)
+	if err != nil {
+		log.Fatalf("failed to hash binary: %v", err)
+	}
+	log.Printf("initial binary hash: %x", s.lastHash[:8])
+
+	// Set up OS signal handler.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	// Start fsnotify watcher in a goroutine.
+	updateCh := make(chan struct{}, 1)
+	go s.watchBinary(updateCh)
+
+	// Run the main supervision loop.
+	s.mainLoop(sigCh, updateCh)
+}
+
+// mainLoop is the core supervision loop that manages the child process lifecycle.
+func (s *Sentinel) mainLoop(sigCh <-chan os.Signal, updateCh <-chan struct{}) {
+	for {
+		// Check if we should stop before starting a new child.
+		select {
+		case <-s.stopCh:
+			log.Println("sentinel stopping (stopCh closed)")
+			return
+		default:
+		}
+
+		// Start child process.
+		child, err := s.startChild()
+		if err != nil {
+			log.Printf("failed to start child: %v", err)
+			s.sleepBackoff()
+			s.increaseBackoff()
+			continue
+		}
+
+		startTime := time.Now()
+
+		// Wait for child exit in a goroutine.
+		childDone := make(chan error, 1)
+		go func() {
+			childDone <- child.Wait()
+		}()
+
+		// Wait for one of: child exit, binary update, or OS signal.
+		select {
+		case err := <-childDone:
+			// Child exited on its own.
+			elapsed := time.Since(startTime)
+			if err != nil {
+				log.Printf("child exited with error after %v: %v", elapsed, err)
+				if elapsed >= SuccessRunTime {
+					// Ran long enough — reset backoff.
+					s.backoff = InitialBackoff
+				}
+				s.sleepBackoff()
+				s.increaseBackoff()
+			} else {
+				// Clean exit. The "run" subcommand normally runs forever,
+				// so a clean exit is unexpected and warrants a restart.
+				log.Printf("child exited cleanly after %v", elapsed)
+				s.backoff = InitialBackoff
+				time.Sleep(1 * time.Second)
+			}
+
+		case <-updateCh:
+			// Binary was updated on disk.
+			log.Println("binary update detected, restarting child...")
+			s.stopChild(child)
+			// Drain childDone so we don't leak the goroutine.
+			<-childDone
+			// Refresh the hash for the new binary.
+			if h, err := HashFile(s.binaryPath); err == nil {
+				s.lastHash = h
+				log.Printf("new binary hash: %x", s.lastHash[:8])
+			}
+			s.backoff = InitialBackoff
+
+		case sig := <-sigCh:
+			// Sentinel received SIGINT/SIGTERM — forward to child and shut down.
+			log.Printf("received %v, forwarding to child and shutting down...", sig)
+			s.stopChild(child)
+			// Wait for child to actually exit.
+			<-childDone
+			log.Println("sentinel exiting")
+			return
+		}
+	}
+}
+
+// startChild launches a new child process with the "run" subcommand.
+func (s *Sentinel) startChild() (*exec.Cmd, error) {
+	cmd := exec.Command(s.binaryPath, "run")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	// Child inherits environment (env vars like TASKGUILD_*).
+	cmd.Env = os.Environ()
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("exec %s run: %w", s.binaryPath, err)
+	}
+
+	log.Printf("started child process (pid: %d)", cmd.Process.Pid)
+	return cmd, nil
+}
+
+// stopChild sends SIGTERM to the child process and schedules a SIGKILL
+// after the grace period if the process doesn't exit.
+// It does NOT call cmd.Wait() — the caller is responsible for draining childDone.
+func (s *Sentinel) stopChild(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+
+	pid := cmd.Process.Pid
+	log.Printf("sending SIGTERM to child (pid: %d)", pid)
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		log.Printf("failed to send SIGTERM (process may have already exited): %v", err)
+		return
+	}
+
+	// Schedule a SIGKILL after the grace period.
+	go func() {
+		time.Sleep(GracePeriod)
+		// Check if process is still alive by trying to signal it.
+		if err := cmd.Process.Signal(syscall.Signal(0)); err == nil {
+			log.Printf("grace period expired, sending SIGKILL to child (pid: %d)", pid)
+			if err := cmd.Process.Kill(); err != nil {
+				log.Printf("failed to send SIGKILL: %v", err)
+			}
+		}
+	}()
+}
+
+// watchBinary watches the parent directory of the binary for filesystem events
+// using fsnotify. When a relevant event is detected and the SHA256 hash has
+// changed, it sends a notification on updateCh.
+func (s *Sentinel) watchBinary(updateCh chan<- struct{}) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Printf("failed to create fsnotify watcher: %v", err)
+		return
+	}
+	defer watcher.Close()
+
+	// Watch the parent directory, not the file itself.
+	// Many deployment tools do atomic replace (write temp file, rename),
+	// which changes the inode. Watching the directory catches these renames.
+	watchDir := filepath.Dir(s.binaryPath)
+	binaryName := filepath.Base(s.binaryPath)
+
+	if err := watcher.Add(watchDir); err != nil {
+		log.Printf("failed to watch directory %s: %v", watchDir, err)
+		return
+	}
+	log.Printf("watching directory %s for changes to %s", watchDir, binaryName)
+
+	// Debounce timer: after a relevant event, wait before computing the checksum
+	// to let multiple rapid events settle (e.g., atomic deploy: write + rename).
+	var debounceTimer *time.Timer
+
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+			// Only care about events for our binary filename.
+			if filepath.Base(event.Name) != binaryName {
+				continue
+			}
+			// Interesting operations: Create (atomic rename lands here), Write, Rename.
+			if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Rename) == 0 {
+				continue
+			}
+
+			log.Printf("detected filesystem event: %s %s", event.Op, event.Name)
+
+			// Reset debounce timer.
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			debounceTimer = time.AfterFunc(DebounceInterval, func() {
+				newHash, err := HashFile(s.binaryPath)
+				if err != nil {
+					log.Printf("failed to hash binary after event: %v", err)
+					return
+				}
+				if newHash != s.lastHash {
+					log.Printf("binary checksum changed (old: %x, new: %x)",
+						s.lastHash[:8], newHash[:8])
+					// Non-blocking send.
+					select {
+					case updateCh <- struct{}{}:
+					default:
+					}
+				} else {
+					log.Printf("filesystem event but checksum unchanged, ignoring")
+				}
+			})
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			log.Printf("fsnotify error: %v", err)
+
+		case <-s.stopCh:
+			return
+		}
+	}
+}
+
+// HashFile computes the SHA256 hash of the file at the given path.
+func HashFile(path string) ([sha256.Size]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return [sha256.Size]byte{}, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return [sha256.Size]byte{}, fmt.Errorf("hash %s: %w", path, err)
+	}
+
+	var result [sha256.Size]byte
+	copy(result[:], h.Sum(nil))
+	return result, nil
+}
+
+// sleepBackoff waits for the current backoff duration.
+// It can be interrupted by closing stopCh.
+func (s *Sentinel) sleepBackoff() {
+	log.Printf("waiting %v before restart...", s.backoff)
+	select {
+	case <-time.After(s.backoff):
+	case <-s.stopCh:
+	}
+}
+
+// increaseBackoff multiplies the backoff by the factor, capping at the maximum.
+func (s *Sentinel) increaseBackoff() {
+	s.backoff = time.Duration(float64(s.backoff) * BackoffFactor)
+	if s.backoff > MaxBackoff {
+		s.backoff = MaxBackoff
+	}
+}


### PR DESCRIPTION
## Summary
- Extract the sentinel supervisor logic from `cmd/taskguild-agent` into a reusable `pkg/sentinel` package, enabling both agent and server binaries to share the same binary-watching auto-restart supervisor
- Refactor `taskguild-server` to use `kingpin` CLI subcommands (`run` for direct server startup, `sentinel` for supervised mode)
- Move server bootstrap logic from `main.go` into `run.go` for clearer separation of concerns
- Update Makefile with `run` (sentinel mode) and `run-direct` targets

## Test plan
- [ ] `go build ./...` compiles successfully
- [ ] `go test ./pkg/sentinel/...` passes (sentinel unit tests)
- [ ] `go test ./...` passes (all tests)
- [ ] `taskguild-server run` starts the server directly
- [ ] `taskguild-server sentinel` starts the server under the sentinel supervisor
- [ ] `taskguild-agent sentinel` still works as before
- [ ] `make run` launches server in sentinel mode
- [ ] `make run-direct` launches server directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)