### PR TITLE
Fix task status transition error visibility and strip NEXT_STATUS from result_summary

### DIFF
--- a/backend/cmd/taskguild-agent/runner_test.go
+++ b/backend/cmd/taskguild-agent/runner_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseNextStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple case",
+			input:    "Some output\nNEXT_STATUS: Review",
+			expected: "Review",
+		},
+		{
+			name:     "with trailing newline",
+			input:    "Some output\nNEXT_STATUS: Review\n",
+			expected: "Review",
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "no NEXT_STATUS",
+			input:    "Some output\nDone.",
+			expected: "",
+		},
+		{
+			name:     "multiple NEXT_STATUS returns last",
+			input:    "NEXT_STATUS: Draft\nSome text\nNEXT_STATUS: Review",
+			expected: "Review",
+		},
+		{
+			name:     "NEXT_STATUS in middle of text",
+			input:    "Line 1\nNEXT_STATUS: Develop\nLine 3",
+			expected: "Develop",
+		},
+		{
+			name:     "NEXT_STATUS with extra spaces",
+			input:    "Output\n  NEXT_STATUS:   Closed  ",
+			expected: "Closed",
+		},
+		{
+			name:     "NEXT_STATUS with no value",
+			input:    "Output\nNEXT_STATUS:",
+			expected: "",
+		},
+		{
+			name:     "only NEXT_STATUS line",
+			input:    "NEXT_STATUS: Review",
+			expected: "Review",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseNextStatus(tt.input)
+			if got != tt.expected {
+				t.Errorf("parseNextStatus(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStripNextStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "strip single NEXT_STATUS at end",
+			input:    "Summary text\nMore details\nNEXT_STATUS: Review",
+			expected: "Summary text\nMore details",
+		},
+		{
+			name:     "strip NEXT_STATUS with trailing newline",
+			input:    "Summary text\nNEXT_STATUS: Review\n",
+			expected: "Summary text",
+		},
+		{
+			name:     "strip multiple NEXT_STATUS lines",
+			input:    "NEXT_STATUS: Draft\nSome text\nNEXT_STATUS: Review",
+			expected: "Some text",
+		},
+		{
+			name:     "no NEXT_STATUS",
+			input:    "Summary text\nMore details",
+			expected: "Summary text\nMore details",
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "only NEXT_STATUS line",
+			input:    "NEXT_STATUS: Review",
+			expected: "",
+		},
+		{
+			name:     "NEXT_STATUS with leading whitespace",
+			input:    "Summary\n  NEXT_STATUS: Closed  \nTrailing",
+			expected: "Summary\nTrailing",
+		},
+		{
+			name:     "preserves surrounding text",
+			input:    "Line 1\nLine 2\nNEXT_STATUS: Review\nLine 4\nLine 5",
+			expected: "Line 1\nLine 2\nLine 4\nLine 5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripNextStatus(tt.input)
+			if got != tt.expected {
+				t.Errorf("stripNextStatus(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Improve `handleStatusTransition` to return errors instead of silently logging and returning, making transition failures visible to users via task logs
- Add `stripNextStatus` helper to remove `NEXT_STATUS: ...` control directives from `result_summary` so they don't appear in the UI
- Add task logger (`tl`) parameter to `handleStatusTransition` for logging transition outcomes (success, auto-transition, and failures) as user-visible task log entries
- Add unit tests for `parseNextStatus` and `stripNextStatus` functions

## Test plan
- [ ] Verify task status transitions still work correctly when NEXT_STATUS is valid
- [ ] Verify transition failure errors appear in task logs (WARN level)
- [ ] Verify NEXT_STATUS lines are stripped from stored result_summary
- [ ] Run `go test ./backend/cmd/taskguild-agent/...` to confirm new unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)