### PR TITLE
feat: group pending requests by task in Chat view

### DIFF
--- a/frontend/taskguild/src/components/PendingRequestsPanel.tsx
+++ b/frontend/taskguild/src/components/PendingRequestsPanel.tsx
@@ -1,6 +1,15 @@
+import { useMemo } from 'react'
+import { Link } from '@tanstack/react-router'
 import { RequestItem } from './RequestItem'
 import { useRequestKeyboard } from '@/hooks/useRequestKeyboard'
+import { shortId } from '@/lib/id'
 import type { Interaction } from '@taskguild/proto/taskguild/v1/interaction_pb.ts'
+
+interface TaskGroup {
+  taskId: string
+  taskTitle: string
+  interactions: Interaction[]
+}
 
 export function PendingRequestsPanel({
   pendingRequests,
@@ -8,12 +17,16 @@ export function PendingRequestsPanel({
   isRespondPending,
   enabled = true,
   className,
+  taskMap,
+  projectId,
 }: {
   pendingRequests: Interaction[]
   onRespond: (interactionId: string, response: string) => void
   isRespondPending: boolean
   enabled?: boolean
   className?: string
+  taskMap?: Map<string, string>
+  projectId?: string
 }) {
   const { selectedId, setSelectedId } = useRequestKeyboard({
     pendingRequests,
@@ -21,6 +34,27 @@ export function PendingRequestsPanel({
     isRespondPending,
     enabled,
   })
+
+  // Group pending requests by taskId, preserving order by earliest createdAt
+  const taskGroups = useMemo(() => {
+    const groupMap = new Map<string, Interaction[]>()
+    const groupOrder: string[] = []
+
+    for (const interaction of pendingRequests) {
+      const tid = interaction.taskId
+      if (!groupMap.has(tid)) {
+        groupMap.set(tid, [])
+        groupOrder.push(tid)
+      }
+      groupMap.get(tid)!.push(interaction)
+    }
+
+    return groupOrder.map((taskId): TaskGroup => ({
+      taskId,
+      taskTitle: taskMap?.get(taskId) ?? shortId(taskId),
+      interactions: groupMap.get(taskId)!,
+    }))
+  }, [pendingRequests, taskMap])
 
   if (pendingRequests.length === 0) return null
 
@@ -37,16 +71,40 @@ export function PendingRequestsPanel({
           j/k navigate · y allow · Y always · n deny
         </span>
       </div>
-      <div className="space-y-3">
-        {pendingRequests.map((interaction) => (
-          <RequestItem
-            key={interaction.id}
-            interaction={interaction}
-            onRespond={onRespond}
-            isRespondPending={isRespondPending}
-            isSelected={interaction.id === selectedId}
-            onSelect={() => setSelectedId(interaction.id)}
-          />
+      <div className="space-y-4">
+        {taskGroups.map((group) => (
+          <div key={group.taskId}>
+            {/* Task group header */}
+            <div className="flex items-center gap-2 mb-1.5">
+              {projectId ? (
+                <Link
+                  to="/projects/$projectId/tasks/$taskId"
+                  params={{ projectId, taskId: group.taskId }}
+                  className="text-[11px] text-cyan-400 hover:text-cyan-300 font-medium truncate transition-colors"
+                >
+                  {group.taskTitle}
+                </Link>
+              ) : (
+                <span className="text-[11px] text-cyan-400 font-medium truncate">
+                  {group.taskTitle}
+                </span>
+              )}
+              <div className="flex-1 border-t border-slate-700/50" />
+            </div>
+            {/* Request items within this task group */}
+            <div className="space-y-2">
+              {group.interactions.map((interaction) => (
+                <RequestItem
+                  key={interaction.id}
+                  interaction={interaction}
+                  onRespond={onRespond}
+                  isRespondPending={isRespondPending}
+                  isSelected={interaction.id === selectedId}
+                  onSelect={() => setSelectedId(interaction.id)}
+                />
+              ))}
+            </div>
+          </div>
         ))}
       </div>
     </div>

--- a/frontend/taskguild/src/routes/projects/$projectId/chat.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/chat.tsx
@@ -121,6 +121,8 @@ function ProjectChatPage() {
               pendingRequests={pendingRequests}
               onRespond={handleRespond}
               isRespondPending={respondMut.isPending}
+              taskMap={taskMap}
+              projectId={projectId}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Group pending requests by their associated task in the Chat view's PendingRequestsPanel
- Display task name as a section header above each group of requests, with a link to the task detail page
- Preserve chronological ordering within each task group
- Pass `taskMap` and `projectId` props from the Chat page to enable task name resolution and linking

## Test plan
- [ ] Verify pending requests are grouped by task in the Chat view
- [ ] Verify task name headers link to the correct task detail page
- [ ] Verify keyboard navigation (j/k, y/Y/n) still works across grouped requests
- [ ] Verify fallback to short ID when task name is not in taskMap
- [ ] Verify empty state (no pending requests) still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)