### PR TITLE
Fix command line-break display for subshell chains and parentheses

### DIFF
--- a/backend/pkg/shellformat/format_test.go
+++ b/backend/pkg/shellformat/format_test.go
@@ -242,6 +242,18 @@ else
   echo other
 fi`,
 		},
+		{
+			name:  "2-element || with subshell always expands",
+			input: `which buf || (cat Makefile 2> /dev/null | head -50)`,
+			expected: `which buf \
+  || (cat Makefile 2> /dev/null | head -50)`,
+		},
+		{
+			name:  "long command with redirect piped to head",
+			input: `ls /home/ubuntu/taskguild/taskguild/.claude/worktrees/mb7frh_setup-script-execution/proto/node_modules/.bin/ 2> /dev/null | head -20`,
+			expected: `ls /home/ubuntu/taskguild/taskguild/.claude/worktrees/mb7frh_setup-script-execution/proto/node_modules/.bin/ 2> /dev/null \
+  | head -20`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -277,6 +289,8 @@ func TestFormatOutputIsValidBash(t *testing.T) {
 		`a && b && c && d && e && f`,
 		`cat file | grep pattern | awk '{print $1}' && echo done || echo failed`,
 		`arr=(1 2 3); for i in "${arr[@]}"; do echo $i; done`,
+		`which buf || (cat Makefile 2> /dev/null | head -50)`,
+		`ls /home/ubuntu/taskguild/taskguild/.claude/worktrees/mb7frh_setup-script-execution/proto/node_modules/.bin/ 2> /dev/null | head -20`,
 	}
 
 	parser := syntax.NewParser(syntax.KeepComments(true))

--- a/frontend/taskguild/src/components/MarkdownDescription.test.ts
+++ b/frontend/taskguild/src/components/MarkdownDescription.test.ts
@@ -238,4 +238,50 @@ describe('tokenizeBashLine', () => {
     const tokens = nonWsTypes(';;')
     expect(tokens).toEqual([['operator', ';;']])
   })
+
+  it('tokenizes subshell parentheses separately', () => {
+    const tokens = nonWsTypes('|| (cat Makefile 2> /dev/null | head -50)')
+    expect(tokens).toEqual([
+      ['operator', '||'],
+      ['operator', '('],
+      ['command', 'cat'],
+      ['text', 'Makefile'],
+      ['redirect', '2>'],
+      ['text', '/dev/null'],
+      ['operator', '|'],
+      ['command', 'head'],
+      ['flag', '-50'],
+      ['operator', ')'],
+    ])
+  })
+
+  it('tokenizes long command with redirect and pipe continuation', () => {
+    // First line: command with redirect ending in continuation
+    const line1Tokens = nonWsTypes('ls /some/long/path 2> /dev/null \\')
+    expect(line1Tokens).toEqual([
+      ['command', 'ls'],
+      ['text', '/some/long/path'],
+      ['redirect', '2>'],
+      ['text', '/dev/null'],
+      ['continuation', '\\'],
+    ])
+    // Second line: pipe continuation
+    const line2Tokens = nonWsTypes('  | head -20')
+    expect(line2Tokens).toEqual([
+      ['operator', '|'],
+      ['command', 'head'],
+      ['flag', '-20'],
+    ])
+  })
+
+  it('tokenizes braces in block commands', () => {
+    const tokens = nonWsTypes('{ echo hello; }')
+    expect(tokens).toEqual([
+      ['operator', '{'],
+      ['command', 'echo'],
+      ['text', 'hello'],
+      ['operator', ';'],
+      ['operator', '}'],
+    ])
+  })
 })

--- a/frontend/taskguild/src/components/MarkdownDescription.tsx
+++ b/frontend/taskguild/src/components/MarkdownDescription.tsx
@@ -460,8 +460,23 @@ export function tokenizeBashLine(line: string): BashToken[] {
       continue
     }
 
+    // Shell grouping characters: ( ) { }
+    // These are shell metacharacters that delimit subshells and blocks.
+    if (rest[0] === '(' || rest[0] === '{') {
+      pushToken('operator', rest[0])
+      pos += 1
+      expectCommand = true
+      continue
+    }
+    if (rest[0] === ')' || rest[0] === '}') {
+      pushToken('operator', rest[0])
+      pos += 1
+      expectCommand = false
+      continue
+    }
+
     // Word boundary: read a word token (no whitespace, no special chars)
-    const wordMatch = matchAt(/^[^\s'"$|&;><\\#]+/)
+    const wordMatch = matchAt(/^[^\s'"$|&;><\\#(){}]+/)
     if (wordMatch) {
       const word = wordMatch[0]
 


### PR DESCRIPTION
## Summary
- Force multi-line formatting for binary command chains (`&&`, `||`, `|`) when any element contains a compound command (subshell, block, if/for/while/case, function declaration), even if the chain fits within the max width
- Add tokenizer support for shell grouping characters `(`, `)`, `{`, `}` in the frontend bash syntax highlighter, so subshell and block expressions are properly highlighted
- Update word-boundary regex to exclude parentheses and braces from being consumed as part of regular word tokens

## Test plan
- [x] Backend: added test case for `which buf || (cat Makefile 2> /dev/null | head -50)` expanding to multi-line
- [x] Backend: added test case for long command with redirect piped to head
- [x] Backend: added round-trip validity tests for new inputs
- [x] Frontend: added tokenizer tests for subshell parentheses, brace blocks, and redirect+pipe continuation lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)