### PR TITLE
Fix: navigate to workflow page after deleting task from Task Detail

### DIFF
--- a/frontend/taskguild/src/components/TaskDetailModal.tsx
+++ b/frontend/taskguild/src/components/TaskDetailModal.tsx
@@ -28,6 +28,7 @@ interface TaskDetailModalProps {
   currentStatusId: string
   onClose: () => void
   onChanged: () => void
+  onDeleted?: () => void
 }
 
 export function TaskDetailModal({
@@ -37,6 +38,7 @@ export function TaskDetailModal({
   currentStatusId,
   onClose,
   onChanged,
+  onDeleted,
 }: TaskDetailModalProps) {
   const { data: taskData, refetch: refetchTask } = useQuery(getTask, { id: taskId })
   const { data: interactionsData, refetch: refetchInteractions } = useQuery(listInteractions, { taskId })
@@ -147,7 +149,7 @@ export function TaskDetailModal({
     if (!task) return
     deleteMut.mutate(
       { id: task.id },
-      { onSuccess: () => { onChanged(); onClose() } },
+      { onSuccess: () => { if (onDeleted) { onDeleted() } else { onChanged(); onClose() } } },
     )
   }
 

--- a/frontend/taskguild/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { useQuery, useMutation } from '@connectrpc/connect-query'
 import { getTask, updateTaskStatus } from '@taskguild/proto/taskguild/v1/task-TaskService_connectquery.ts'
 import { getProject } from '@taskguild/proto/taskguild/v1/project-ProjectService_connectquery.ts'
@@ -34,6 +34,7 @@ export const Route = createFileRoute('/projects/$projectId/tasks/$taskId')({
 
 function TaskDetailPage() {
   const { projectId, taskId } = Route.useParams()
+  const navigate = useNavigate()
   const [showEditModal, setShowEditModal] = useState(false)
   const timelineScrollRef = useRef<HTMLDivElement>(null)
   const prevTimelineCountRef = useRef(0)
@@ -125,6 +126,14 @@ function TaskDetailPage() {
     }
     prevPendingCountRef.current = pendingRequests.length
   }, [pendingRequests.length])
+
+  const handleDeleted = useCallback(() => {
+    navigate({
+      to: '/projects/$projectId',
+      params: { projectId },
+      search: task?.workflowId ? { workflowId: task.workflowId } : {},
+    })
+  }, [navigate, projectId, task?.workflowId])
 
   const handleStatusChange = (statusId: string) => {
     if (!task) return
@@ -357,6 +366,7 @@ function TaskDetailPage() {
           currentStatusId={task.statusId}
           onClose={() => setShowEditModal(false)}
           onChanged={() => refetchTask()}
+          onDeleted={handleDeleted}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- Add `onDeleted` callback prop to `TaskDetailModal` to handle post-deletion navigation separately from general change handling
- Navigate to the project's workflow page (with the correct `workflowId`) when a task is deleted from the Task Detail page, instead of just closing the modal

## Test plan
- [ ] Open a task from the Task Detail page (`/projects/$projectId/tasks/$taskId`)
- [ ] Delete the task and verify navigation redirects to the workflow page (`/projects/$projectId?workflowId=...`)
- [ ] Verify deleting a task from the board view (via modal) still works as before (closes modal and refreshes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)