### PR TITLE
Fix: move pending requests panel from top to bottom of page

### DIFF
--- a/frontend/taskguild/src/routes/projects/$projectId/chat.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/chat.tsx
@@ -124,21 +124,6 @@ function ProjectChatPage() {
         </p>
       </div>
 
-      {/* Pending requests section — pinned between header and chat */}
-      {pendingRequests.length > 0 && (
-        <div className="shrink-0 border-b border-slate-800 bg-slate-800/50 px-4 md:px-6 py-3">
-          <div className="max-w-3xl mx-auto">
-            <PendingRequestsPanel
-              pendingRequests={pendingRequests}
-              onRespond={handleRespond}
-              isRespondPending={respondMut.isPending}
-              taskMap={taskMap}
-              projectId={projectId}
-            />
-          </div>
-        </div>
-      )}
-
       {/* Chat area */}
       <div ref={scrollRef} className="flex-1 overflow-y-auto">
         <div className="max-w-3xl mx-auto px-4 py-4 md:px-6 md:py-6 space-y-3">
@@ -180,6 +165,21 @@ function ProjectChatPage() {
           })}
         </div>
       </div>
+
+      {/* Pending requests section — pinned above connection bar */}
+      {pendingRequests.length > 0 && (
+        <div className="shrink-0 border-t border-slate-800 bg-slate-800/50 px-4 md:px-6 py-3">
+          <div className="max-w-3xl mx-auto">
+            <PendingRequestsPanel
+              pendingRequests={pendingRequests}
+              onRespond={handleRespond}
+              isRespondPending={respondMut.isPending}
+              taskMap={taskMap}
+              projectId={projectId}
+            />
+          </div>
+        </div>
+      )}
 
       {/* Connection status bar */}
       <div className="shrink-0 border-t border-slate-800 px-6 py-2">

--- a/frontend/taskguild/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -256,19 +256,6 @@ function TaskDetailPage() {
         </div>
       </div>
 
-      {/* Pending requests section — pinned between header and timeline */}
-      {pendingRequests.length > 0 && (
-        <div className="shrink-0 border-b border-slate-800 bg-slate-800/50 px-4 md:px-6 py-3">
-          <div className="max-w-3xl mx-auto">
-            <PendingRequestsPanel
-              pendingRequests={pendingRequests}
-              onRespond={handleRespond}
-              isRespondPending={respondMut.isPending}
-            />
-          </div>
-        </div>
-      )}
-
       {/* Timeline area — full height */}
       <div ref={timelineScrollRef} className="flex-1 overflow-y-auto">
         <div className="max-w-3xl mx-auto px-4 py-4 md:px-6 md:py-6 space-y-4">
@@ -333,6 +320,19 @@ function TaskDetailPage() {
           )}
         </div>
       </div>
+
+      {/* Pending requests section — pinned above input bar */}
+      {pendingRequests.length > 0 && (
+        <div className="shrink-0 border-t border-slate-800 bg-slate-800/50 px-4 md:px-6 py-3">
+          <div className="max-w-3xl mx-auto">
+            <PendingRequestsPanel
+              pendingRequests={pendingRequests}
+              onRespond={handleRespond}
+              isRespondPending={respondMut.isPending}
+            />
+          </div>
+        </div>
+      )}
 
       {/* InputBar pinned to bottom */}
       <div className="shrink-0 border-t border-slate-800 px-4 py-3 md:px-6">


### PR DESCRIPTION
## Summary
- Move the Pending Requests panel from the top of the page (between header and content) to the bottom (above the input/connection bar) on both the project chat page and the task detail page
- This improves UX by keeping pending requests closer to the user's input area, making them more visible and actionable without scrolling up

## Test plan
- [ ] Verify pending requests panel appears above the connection status bar on the project chat page
- [ ] Verify pending requests panel appears above the input bar on the task detail page
- [ ] Verify the panel is hidden when there are no pending requests
- [ ] Verify responding to a pending request still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)