### PR TITLE
Fix: Make sidebar and content scroll independently

### DIFF
--- a/frontend/taskguild/src/routes/__root.tsx
+++ b/frontend/taskguild/src/routes/__root.tsx
@@ -28,7 +28,7 @@ function RootComponent() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-950 text-gray-200 flex">
+    <div className="h-screen bg-slate-950 text-gray-200 flex">
       {/* Mobile header bar */}
       <div className="fixed top-0 left-0 right-0 z-40 md:hidden bg-slate-900 border-b border-slate-800 flex items-center px-4 py-3">
         <button


### PR DESCRIPTION
## Summary
- Change root container from `min-h-screen` to `h-screen` to fix sidebar and content area scrolling independently
- With `min-h-screen`, the entire page would scroll as one unit, preventing independent scroll behavior for the sidebar navigation and main content area

## Test plan
- [ ] Verify sidebar scrolls independently when content overflows
- [ ] Verify main content area scrolls independently when it overflows
- [ ] Verify layout works correctly on mobile view
- [ ] Verify no layout breakage on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)