### PR TITLE
Fix: content clipping on iPad Chrome by using dvh units

### DIFF
--- a/frontend/taskguild/src/components/SetupScreen.tsx
+++ b/frontend/taskguild/src/components/SetupScreen.tsx
@@ -15,7 +15,7 @@ export function SetupScreen() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-950 flex items-center justify-center p-4">
+    <div className="min-h-dvh bg-slate-950 flex items-center justify-center p-4">
       <div className="w-full max-w-md">
         <div className="flex items-center justify-center gap-3 mb-8">
           <FolderKanban className="w-10 h-10 text-cyan-400" />

--- a/frontend/taskguild/src/routes/__root.tsx
+++ b/frontend/taskguild/src/routes/__root.tsx
@@ -28,7 +28,7 @@ function RootComponent() {
   }
 
   return (
-    <div className="h-screen bg-slate-950 text-gray-200 flex">
+    <div className="h-dvh bg-slate-950 text-gray-200 flex">
       {/* Mobile header bar */}
       <div className="fixed top-0 left-0 right-0 z-40 md:hidden bg-slate-900 border-b border-slate-800 flex items-center px-4 py-3">
         <button

--- a/frontend/taskguild/src/routes/projects/$projectId/chat.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/chat.tsx
@@ -104,7 +104,7 @@ function ProjectChatPage() {
   }, [respondMut, refetchInteractions])
 
   return (
-    <div className="flex flex-col h-screen">
+    <div className="flex flex-col h-dvh">
       {/* Header */}
       <div className="shrink-0 border-b border-slate-800 px-4 py-3 md:px-6 md:py-4">
         <div className="flex items-center gap-3 text-sm text-gray-400 mb-1">

--- a/frontend/taskguild/src/routes/projects/$projectId/index.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/index.tsx
@@ -62,7 +62,7 @@ function ProjectDetailPage() {
   }
 
   return (
-    <div className="flex flex-col h-screen">
+    <div className="flex flex-col h-dvh">
       {/* Header */}
       <div className="shrink-0 border-b border-slate-800 px-4 py-3 md:px-6 md:py-4">
         <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">


### PR DESCRIPTION
## Summary
- Replace `h-screen` / `min-h-screen` with `h-dvh` / `min-h-dvh` across 4 components
- Fixes bottom content being clipped on iPad Chrome where `100vh` does not account for the browser chrome
- Affected files: `SetupScreen.tsx`, `__root.tsx`, `chat.tsx`, `projects/$projectId/index.tsx`

## Test plan
- [ ] Verify on iPad Chrome that the bottom content is no longer clipped
- [ ] Verify on desktop browsers that layout is unchanged
- [ ] Verify on other mobile browsers (Safari, Android Chrome) for correct behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)