### PR TITLE
Fix Always Allow permissions not being persisted across tool calls

### DIFF
--- a/backend/cmd/taskguild-agent/permission_cache.go
+++ b/backend/cmd/taskguild-agent/permission_cache.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+
+	"connectrpc.com/connect"
+	claudeagent "github.com/kazz187/claude-agent-sdk-go"
+	v1 "github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1"
+	"github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1/taskguildv1connect"
+)
+
+// permissionCache maintains an in-memory cache of project-level allow rules.
+// It is shared across all tasks within the same agent-manager, providing
+// immediate permission checks without backend round-trips. When new rules are
+// added (via "Always Allow"), they are persisted to the backend and broadcast
+// to all connected agent-managers.
+type permissionCache struct {
+	mu          sync.RWMutex
+	allowRules  []string
+	projectName string
+	client      taskguildv1connect.AgentManagerServiceClient
+}
+
+// newPermissionCache creates a new permission cache.
+func newPermissionCache(projectName string, client taskguildv1connect.AgentManagerServiceClient) *permissionCache {
+	return &permissionCache{
+		projectName: projectName,
+		client:      client,
+	}
+}
+
+// Update replaces the cached allow rules (called after backend sync).
+func (c *permissionCache) Update(rules []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.allowRules = make([]string, len(rules))
+	copy(c.allowRules, rules)
+	log.Printf("permission cache updated: %d allow rules", len(rules))
+}
+
+// Check returns true if the given tool call is allowed by any cached rule.
+func (c *permissionCache) Check(toolName string, input map[string]any) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	for _, rule := range c.allowRules {
+		if matchPermissionRule(rule, toolName, input) {
+			return true
+		}
+	}
+	return false
+}
+
+// AddAndSync adds new permission rules to the cache and synchronises them
+// with the backend via the SyncPermissions RPC (union merge). The resulting
+// merged allow list from the backend replaces the local cache.
+func (c *permissionCache) AddAndSync(ctx context.Context, newRules []string) {
+	if len(newRules) == 0 {
+		return
+	}
+
+	// Optimistically add to cache first for immediate effect.
+	c.mu.Lock()
+	c.allowRules = unionDedupRules(c.allowRules, newRules)
+	c.mu.Unlock()
+
+	log.Printf("permission cache: added %d rule(s), syncing to backend", len(newRules))
+
+	// Sync to backend – send only the new rules; the backend merges them.
+	resp, err := c.client.SyncPermissions(ctx, connect.NewRequest(&v1.SyncPermissionsRequest{
+		ProjectName: c.projectName,
+		LocalAllow:  newRules,
+	}))
+	if err != nil {
+		log.Printf("permission cache: failed to sync rules to backend: %v", err)
+		return
+	}
+
+	// Replace cache with the backend's authoritative merged list.
+	merged := resp.Msg.GetPermissions()
+	c.mu.Lock()
+	c.allowRules = merged.GetAllow()
+	c.mu.Unlock()
+
+	log.Printf("permission cache: backend sync complete, allow=%d", len(merged.GetAllow()))
+}
+
+// extractRuleStrings converts PermissionUpdate objects into human-readable
+// rule strings matching the Claude Code settings format.
+//
+// Examples:
+//   - PermissionRuleValue{ToolName: "Read"}             → "Read"
+//   - PermissionRuleValue{ToolName: "Bash", RuleContent: "git *"} → "Bash(git *)"
+func extractRuleStrings(updates []*claudeagent.PermissionUpdate) []string {
+	var rules []string
+	for _, u := range updates {
+		for _, rule := range u.Rules {
+			rules = append(rules, ruleValueToString(rule))
+		}
+	}
+	return rules
+}
+
+// ruleValueToString converts a single PermissionRuleValue to the string format
+// used in .claude/settings.json: "ToolName" or "ToolName(ruleContent)".
+func ruleValueToString(rule *claudeagent.PermissionRuleValue) string {
+	if rule.RuleContent == "" {
+		return rule.ToolName
+	}
+	return fmt.Sprintf("%s(%s)", rule.ToolName, rule.RuleContent)
+}
+
+// unionDedupRules merges two string slices, removing duplicates while preserving order.
+func unionDedupRules(a, b []string) []string {
+	seen := make(map[string]bool, len(a)+len(b))
+	result := make([]string, 0, len(a)+len(b))
+	for _, s := range a {
+		if !seen[s] {
+			seen[s] = true
+			result = append(result, s)
+		}
+	}
+	for _, s := range b {
+		if !seen[s] {
+			seen[s] = true
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// matchPermissionRule checks whether a permission rule (e.g. "Read",
+// "Bash(git *)") matches the given tool call.
+func matchPermissionRule(rule string, toolName string, input map[string]any) bool {
+	// Parse rule: "ToolName" or "ToolName(pattern)".
+	rTool, rPattern, hasPattern := parsePermissionRule(rule)
+
+	if rTool != toolName {
+		return false
+	}
+
+	// No pattern → tool name match is sufficient (allow all invocations).
+	if !hasPattern {
+		return true
+	}
+
+	// For Bash tools, match the command input against the pattern.
+	if toolName == "Bash" {
+		cmd, _ := input["command"].(string)
+		return matchGlob(rPattern, cmd)
+	}
+
+	// For other tools with a pattern, attempt a generic match against a
+	// well-known input field (file_path for Read/Write/Edit, pattern for Glob, etc.).
+	for _, key := range []string{"file_path", "pattern", "path", "query", "url"} {
+		if val, ok := input[key].(string); ok {
+			if matchGlob(rPattern, val) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// parsePermissionRule splits a rule string into its tool name, optional
+// pattern, and whether a pattern was present.
+//
+//	"Read"           → ("Read", "", false)
+//	"Bash(git *)"    → ("Bash", "git *", true)
+func parsePermissionRule(rule string) (toolName, pattern string, hasPattern bool) {
+	idx := strings.Index(rule, "(")
+	if idx < 0 {
+		return rule, "", false
+	}
+	// Ensure it ends with ")".
+	if !strings.HasSuffix(rule, ")") {
+		return rule, "", false
+	}
+	return rule[:idx], rule[idx+1 : len(rule)-1], true
+}
+
+// matchGlob performs simple glob matching where "*" matches any sequence of
+// characters. It supports multiple wildcards (e.g. "git * --*").
+func matchGlob(pattern, value string) bool {
+	// Fast paths.
+	if pattern == "*" {
+		return true
+	}
+	if pattern == "" {
+		return value == ""
+	}
+	if !strings.Contains(pattern, "*") {
+		return pattern == value
+	}
+
+	parts := strings.Split(pattern, "*")
+
+	// First segment must match as a prefix.
+	if !strings.HasPrefix(value, parts[0]) {
+		return false
+	}
+	remaining := value[len(parts[0]):]
+
+	// Middle segments must appear in order.
+	for i := 1; i < len(parts)-1; i++ {
+		idx := strings.Index(remaining, parts[i])
+		if idx < 0 {
+			return false
+		}
+		remaining = remaining[idx+len(parts[i]):]
+	}
+
+	// Last segment must match as a suffix.
+	last := parts[len(parts)-1]
+	return strings.HasSuffix(remaining, last)
+}

--- a/backend/cmd/taskguild-agent/permission_cache_test.go
+++ b/backend/cmd/taskguild-agent/permission_cache_test.go
@@ -1,0 +1,228 @@
+package main
+
+import "testing"
+
+func TestMatchGlob(t *testing.T) {
+	tests := []struct {
+		pattern string
+		value   string
+		want    bool
+	}{
+		// Exact match
+		{"foo", "foo", true},
+		{"foo", "bar", false},
+		{"foo", "foobar", false},
+		{"foo", "", false},
+
+		// Wildcard only
+		{"*", "anything", true},
+		{"*", "", true},
+
+		// Trailing wildcard (prefix match)
+		{"git *", "git status", true},
+		{"git *", "git commit -m 'test'", true},
+		{"git *", "git", false}, // no space after "git"
+		{"npm test *", "npm test --watch", true},
+		{"npm test *", "npm install", false},
+
+		// Leading wildcard (suffix match)
+		{"*.go", "main.go", true},
+		{"*.go", "main.py", false},
+
+		// Middle wildcard
+		{"git * --force", "git push --force", true},
+		{"git * --force", "git push origin main --force", true},
+		{"git * --force", "git push", false},
+
+		// Multiple wildcards
+		{"*test*", "run test suite", true},
+		{"*test*", "testing", true},
+		{"*test*", "foo", false},
+
+		// Empty pattern
+		{"", "", true},
+		{"", "foo", false},
+
+		// No wildcard
+		{"npm test", "npm test", true},
+		{"npm test", "npm test --watch", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"_"+tt.value, func(t *testing.T) {
+			got := matchGlob(tt.pattern, tt.value)
+			if got != tt.want {
+				t.Errorf("matchGlob(%q, %q) = %v, want %v", tt.pattern, tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePermissionRule(t *testing.T) {
+	tests := []struct {
+		rule       string
+		wantTool   string
+		wantPat    string
+		wantHasPat bool
+	}{
+		{"Read", "Read", "", false},
+		{"Write", "Write", "", false},
+		{"Bash(git *)", "Bash", "git *", true},
+		{"Bash(npm test --watch)", "Bash", "npm test --watch", true},
+		{"Edit", "Edit", "", false},
+		// Malformed: no closing paren → treated as no-pattern
+		{"Bash(git *", "Bash(git *", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.rule, func(t *testing.T) {
+			tool, pat, hasPat := parsePermissionRule(tt.rule)
+			if tool != tt.wantTool || pat != tt.wantPat || hasPat != tt.wantHasPat {
+				t.Errorf("parsePermissionRule(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tt.rule, tool, pat, hasPat, tt.wantTool, tt.wantPat, tt.wantHasPat)
+			}
+		})
+	}
+}
+
+func TestMatchPermissionRule(t *testing.T) {
+	tests := []struct {
+		rule     string
+		toolName string
+		input    map[string]any
+		want     bool
+	}{
+		// Simple tool name match
+		{"Read", "Read", nil, true},
+		{"Read", "Write", nil, false},
+
+		// Bash with glob pattern
+		{"Bash(git *)", "Bash", map[string]any{"command": "git status"}, true},
+		{"Bash(git *)", "Bash", map[string]any{"command": "git commit -m 'test'"}, true},
+		{"Bash(git *)", "Bash", map[string]any{"command": "npm install"}, false},
+		{"Bash(git *)", "Read", map[string]any{"command": "git status"}, false},
+
+		// Bash exact command
+		{"Bash(npm test)", "Bash", map[string]any{"command": "npm test"}, true},
+		{"Bash(npm test)", "Bash", map[string]any{"command": "npm test --watch"}, false},
+
+		// Bash without pattern (allow all bash)
+		{"Bash", "Bash", map[string]any{"command": "anything"}, true},
+		{"Bash", "Bash", nil, true},
+
+		// Write (no pattern — allows all)
+		{"Write", "Write", map[string]any{"file_path": "/tmp/foo.txt"}, true},
+	}
+
+	for _, tt := range tests {
+		name := tt.rule + "_" + tt.toolName
+		if cmd, ok := tt.input["command"].(string); ok {
+			name += "_" + cmd
+		}
+		t.Run(name, func(t *testing.T) {
+			got := matchPermissionRule(tt.rule, tt.toolName, tt.input)
+			if got != tt.want {
+				t.Errorf("matchPermissionRule(%q, %q, %v) = %v, want %v",
+					tt.rule, tt.toolName, tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRuleValueToString(t *testing.T) {
+	tests := []struct {
+		toolName    string
+		ruleContent string
+		want        string
+	}{
+		{"Read", "", "Read"},
+		{"Bash", "git *", "Bash(git *)"},
+		{"Bash", "npm test", "Bash(npm test)"},
+		{"Write", "", "Write"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			// Simulate PermissionRuleValue (avoid importing the SDK in test)
+			got := ruleValueToStringHelper(tt.toolName, tt.ruleContent)
+			if got != tt.want {
+				t.Errorf("ruleValueToString(%q, %q) = %q, want %q", tt.toolName, tt.ruleContent, got, tt.want)
+			}
+		})
+	}
+}
+
+// ruleValueToStringHelper is a test helper that mimics ruleValueToString
+// without requiring a claudeagent.PermissionRuleValue.
+func ruleValueToStringHelper(toolName, ruleContent string) string {
+	if ruleContent == "" {
+		return toolName
+	}
+	return toolName + "(" + ruleContent + ")"
+}
+
+func TestPermissionCacheCheck(t *testing.T) {
+	cache := newPermissionCache("test-project", nil)
+	cache.Update([]string{"Read", "Bash(git *)", "Write"})
+
+	tests := []struct {
+		toolName string
+		input    map[string]any
+		want     bool
+	}{
+		{"Read", nil, true},
+		{"Write", map[string]any{"file_path": "/tmp/test.txt"}, true},
+		{"Bash", map[string]any{"command": "git status"}, true},
+		{"Bash", map[string]any{"command": "git push origin main"}, true},
+		{"Bash", map[string]any{"command": "npm install"}, false},
+		{"Edit", nil, false},
+		{"Task", nil, false},
+	}
+
+	for _, tt := range tests {
+		name := tt.toolName
+		if cmd, ok := tt.input["command"].(string); ok {
+			name += "_" + cmd
+		}
+		t.Run(name, func(t *testing.T) {
+			got := cache.Check(tt.toolName, tt.input)
+			if got != tt.want {
+				t.Errorf("cache.Check(%q, %v) = %v, want %v", tt.toolName, tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnionDedupRules(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []string
+		b    []string
+		want []string
+	}{
+		{"empty", nil, nil, nil},
+		{"a only", []string{"Read"}, nil, []string{"Read"}},
+		{"b only", nil, []string{"Write"}, []string{"Write"}},
+		{"no overlap", []string{"Read"}, []string{"Write"}, []string{"Read", "Write"}},
+		{"with overlap", []string{"Read", "Write"}, []string{"Write", "Edit"}, []string{"Read", "Write", "Edit"}},
+		{"identical", []string{"Read", "Write"}, []string{"Read", "Write"}, []string{"Read", "Write"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := unionDedupRules(tt.a, tt.b)
+			// nil vs empty: both are "no results"
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("unionDedupRules(%v, %v) length = %d, want %d", tt.a, tt.b, len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("unionDedupRules(%v, %v)[%d] = %q, want %q", tt.a, tt.b, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `permissionCache` to maintain an in-memory cache of project-level "Always Allow" rules, shared across all tasks within an agent-manager
- Auto-allow tool calls that match cached permission rules, eliminating repeated permission prompts
- When a user selects "Always Allow", persist the rule to both the local cache and the backend via `SyncPermissions` RPC
- Update the permission cache during `syncPermissions` so that backend-synced rules are immediately effective
- Include comprehensive unit tests for glob matching, rule parsing, cache operations, and permission rule matching

## Test plan
- [ ] Verify "Always Allow" for a tool persists and does not re-prompt on subsequent calls
- [ ] Verify permission sync from backend correctly populates the in-memory cache
- [ ] Verify `go test ./backend/cmd/taskguild-agent/...` passes all new unit tests
- [ ] Verify multi-task scenarios share the permission cache correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)