### PR TITLE
Rename _session_id metadata key to session_id with migration

### DIFF
--- a/backend/cmd/taskguild-agent/directive.go
+++ b/backend/cmd/taskguild-agent/directive.go
@@ -361,7 +361,7 @@ func handleStatusTransition(
 func saveSessionID(ctx context.Context, taskClient taskguildv1connect.TaskServiceClient, taskID, sessionID string) {
 	_, err := taskClient.UpdateTask(ctx, connect.NewRequest(&v1.UpdateTaskRequest{
 		Id:       taskID,
-		Metadata: map[string]string{"_session_id": sessionID},
+		Metadata: map[string]string{"session_id": sessionID},
 	}))
 	if err != nil {
 		log.Printf("[task:%s] failed to save session_id: %v", taskID, err)

--- a/backend/cmd/taskguild-agent/runner.go
+++ b/backend/cmd/taskguild-agent/runner.go
@@ -105,7 +105,7 @@ func runTask(
 	waiter := newInteractionWaiter()
 	go runInteractionListener(ctx, interClient, taskID, waiter)
 
-	sessionID := metadata["_session_id"]
+	sessionID := metadata["session_id"]
 	prompt := buildUserPrompt(metadata, workDir)
 	hasTransitions := metadata["_available_transitions"] != ""
 

--- a/backend/cmd/taskguild-server/main.go
+++ b/backend/cmd/taskguild-server/main.go
@@ -12,6 +12,7 @@ var (
 
 	runCmd      = app.Command("run", "Run the server")
 	sentinelCmd = app.Command("sentinel", "Supervisor that manages 'run' with auto-restart and binary watching")
+	migrateCmd  = app.Command("migrate", "Run data migrations")
 )
 
 func main() {
@@ -21,5 +22,7 @@ func main() {
 		runServer()
 	case sentinelCmd.FullCommand():
 		runSentinel()
+	case migrateCmd.FullCommand():
+		runMigrate()
 	}
 }

--- a/backend/cmd/taskguild-server/migrate.go
+++ b/backend/cmd/taskguild-server/migrate.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/kazz187/taskguild/backend/internal/config"
+	"github.com/kazz187/taskguild/backend/internal/task"
+	"github.com/kazz187/taskguild/backend/pkg/storage"
+)
+
+const tasksPrefix = "tasks"
+
+func runMigrate() {
+	env, err := config.LoadEnv()
+	if err != nil {
+		slog.Error("failed to load env", "error", err)
+		os.Exit(1)
+	}
+
+	var store storage.Storage
+	switch env.StorageEnv.Type {
+	case "s3":
+		store, err = storage.NewS3Storage(context.Background(), env.StorageEnv.S3Bucket, env.StorageEnv.S3Prefix, env.StorageEnv.S3Region)
+		if err != nil {
+			slog.Error("failed to create S3 storage", "error", err)
+			os.Exit(1)
+		}
+	default:
+		store, err = storage.NewLocalStorage(env.StorageEnv.BaseDir)
+		if err != nil {
+			slog.Error("failed to create local storage", "error", err)
+			os.Exit(1)
+		}
+	}
+
+	ctx := context.Background()
+
+	paths, err := store.List(ctx, tasksPrefix)
+	if err != nil {
+		slog.Error("failed to list tasks", "error", err)
+		os.Exit(1)
+	}
+
+	migrated := 0
+	for _, p := range paths {
+		data, err := store.Read(ctx, p)
+		if err != nil {
+			slog.Warn("failed to read task file", "path", p, "error", err)
+			continue
+		}
+
+		var t task.Task
+		if err := yaml.Unmarshal(data, &t); err != nil {
+			slog.Warn("failed to unmarshal task", "path", p, "error", err)
+			continue
+		}
+
+		oldVal, hasOld := t.Metadata["_session_id"]
+		if !hasOld {
+			continue
+		}
+
+		// Rename _session_id -> session_id
+		t.Metadata["session_id"] = oldVal
+		delete(t.Metadata, "_session_id")
+
+		out, err := yaml.Marshal(&t)
+		if err != nil {
+			slog.Warn("failed to marshal task", "path", p, "error", err)
+			continue
+		}
+
+		if err := store.Write(ctx, p, out); err != nil {
+			slog.Warn("failed to write task file", "path", p, "error", err)
+			continue
+		}
+
+		migrated++
+		slog.Info("migrated task metadata", "task_id", t.ID, "session_id", oldVal)
+	}
+
+	fmt.Printf("Migration complete: %d/%d tasks migrated (_session_id -> session_id)\n", migrated, len(paths))
+}


### PR DESCRIPTION
## Summary
- Rename `_session_id` metadata key to `session_id` in the agent runner for consistency (remove underscore prefix)
- Add `migrate` subcommand to `taskguild-server` that batch-renames `_session_id` → `session_id` in existing task data
- Supports both local and S3 storage backends

## Test plan
- [ ] Verify agent correctly reads/writes `session_id` (without underscore prefix)
- [ ] Run `taskguild-server migrate` against test data with `_session_id` keys and confirm they are renamed
- [ ] Confirm tasks without `_session_id` are skipped gracefully
- [ ] Test with both local and S3 storage backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)