### PR TITLE
Fix: Use Web Audio API for notification sound to avoid stealing audio focus on Android

### DIFF
--- a/frontend/taskguild/src/hooks/useNotificationSound.ts
+++ b/frontend/taskguild/src/hooks/useNotificationSound.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from 'react'
+
+// ── Singleton AudioContext & cached AudioBuffer ──────────────────────
+// Using Web Audio API instead of HTMLAudioElement so that playing a short
+// notification sound does NOT acquire Android's system audio focus, which
+// would otherwise pause music apps like Spotify / YouTube Music.
+
+let audioCtx: AudioContext | null = null
+let bufferPromise: Promise<AudioBuffer> | null = null
+
+function getContext(): AudioContext {
+  if (!audioCtx) {
+    audioCtx = new AudioContext()
+  }
+  return audioCtx
+}
+
+function loadBuffer(): Promise<AudioBuffer> {
+  if (!bufferPromise) {
+    bufferPromise = fetch('/bell.mp3')
+      .then((res) => res.arrayBuffer())
+      .then((arr) => getContext().decodeAudioData(arr))
+      .catch((err) => {
+        // Allow retry on next play attempt
+        bufferPromise = null
+        throw err
+      })
+  }
+  return bufferPromise
+}
+
+async function playBell(): Promise<void> {
+  try {
+    const ctx = getContext()
+    if (ctx.state === 'suspended') {
+      await ctx.resume()
+    }
+    const buffer = await loadBuffer()
+    const source = ctx.createBufferSource()
+    source.buffer = buffer
+    source.connect(ctx.destination)
+    source.start(0)
+  } catch {
+    // Silently ignore – notification sound is non-critical
+  }
+}
+
+/**
+ * Plays a notification bell sound whenever `count` increases.
+ *
+ * Uses Web Audio API (AudioContext) instead of HTMLAudioElement to avoid
+ * stealing audio focus on Android, which would pause other media apps.
+ */
+export function useNotificationSound(count: number): void {
+  const prevCountRef = useRef(count)
+
+  useEffect(() => {
+    if (count > prevCountRef.current) {
+      playBell()
+    }
+    prevCountRef.current = count
+  }, [count])
+}

--- a/frontend/taskguild/src/routes/projects/$projectId/chat.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/chat.tsx
@@ -7,6 +7,7 @@ import { InteractionStatus, InteractionType } from '@taskguild/proto/taskguild/v
 import { getProject } from '@taskguild/proto/taskguild/v1/project-ProjectService_connectquery.ts'
 import { EventType } from '@taskguild/proto/taskguild/v1/event_pb.ts'
 import { useEventSubscription } from '@/hooks/useEventSubscription'
+import { useNotificationSound } from '@/hooks/useNotificationSound'
 import { ChatBubble } from '@/components/ChatBubble'
 import { PendingRequestsPanel } from '@/components/PendingRequestsPanel'
 import { shortId } from '@/lib/id'
@@ -20,8 +21,6 @@ export const Route = createFileRoute('/projects/$projectId/chat')({
 function ProjectChatPage() {
   const { projectId } = Route.useParams()
   const scrollRef = useRef<HTMLDivElement>(null)
-  const bellAudioRef = useRef<HTMLAudioElement | null>(null)
-  const prevPendingCountRef = useRef(0)
 
   const { data: projectData } = useQuery(getProject, { id: projectId })
   const { data: tasksData, refetch: refetchTasks } = useQuery(listTasks, { projectId })
@@ -67,16 +66,7 @@ function ProjectChatPage() {
   const pendingRequestCount = pendingRequests.length
 
   // Play notification sound when new pending requests arrive
-  useEffect(() => {
-    if (pendingRequestCount > prevPendingCountRef.current) {
-      if (!bellAudioRef.current) {
-        bellAudioRef.current = new Audio('/bell.mp3')
-      }
-      bellAudioRef.current.currentTime = 0
-      bellAudioRef.current.play().catch(() => {})
-    }
-    prevPendingCountRef.current = pendingRequestCount
-  }, [pendingRequestCount])
+  useNotificationSound(pendingRequestCount)
 
   // Auto-scroll to bottom when new interactions arrive
   useEffect(() => {

--- a/frontend/taskguild/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -10,6 +10,7 @@ import { InteractionStatus, InteractionType } from '@taskguild/proto/taskguild/v
 import { EventType } from '@taskguild/proto/taskguild/v1/event_pb.ts'
 import { useEventSubscription } from '@/hooks/useEventSubscription'
 import { useTaskLogs } from '@/hooks/useTaskLogs'
+import { useNotificationSound } from '@/hooks/useNotificationSound'
 import { TaskDetailModal } from '@/components/TaskDetailModal'
 import { shortId } from '@/lib/id'
 import { InputBar } from '@/components/ChatBubble'
@@ -38,8 +39,6 @@ function TaskDetailPage() {
   const [showEditModal, setShowEditModal] = useState(false)
   const timelineScrollRef = useRef<HTMLDivElement>(null)
   const prevTimelineCountRef = useRef(0)
-  const prevPendingCountRef = useRef(0)
-  const bellAudioRef = useRef<HTMLAudioElement | null>(null)
 
   const { data: taskData, refetch: refetchTask } = useQuery(getTask, { id: taskId })
   const { data: projectData } = useQuery(getProject, { id: projectId })
@@ -116,16 +115,7 @@ function TaskDetailPage() {
   }, [timelineItems.length])
 
   // Play notification sound when new pending requests arrive
-  useEffect(() => {
-    if (pendingRequests.length > prevPendingCountRef.current) {
-      if (!bellAudioRef.current) {
-        bellAudioRef.current = new Audio('/bell.mp3')
-      }
-      bellAudioRef.current.currentTime = 0
-      bellAudioRef.current.play().catch(() => {})
-    }
-    prevPendingCountRef.current = pendingRequests.length
-  }, [pendingRequests.length])
+  useNotificationSound(pendingRequests.length)
 
   const handleDeleted = useCallback(() => {
     navigate({


### PR DESCRIPTION
## Summary
- Replace `HTMLAudioElement` with Web Audio API (`AudioContext`) for playing notification sounds
- Extract shared `useNotificationSound` hook from duplicated inline implementations in `chat.tsx` and `tasks/$taskId.tsx`
- This prevents Android from acquiring system audio focus when a short notification bell plays, which was causing music apps (Spotify, YouTube Music, etc.) to pause unexpectedly

## Test plan
- [ ] Verify notification sound plays correctly on desktop browsers when new pending requests arrive
- [ ] Verify notification sound plays on Android without pausing background music apps
- [ ] Verify sound plays on both the project chat page and task detail page
- [ ] Verify no console errors when AudioContext is suspended and needs to be resumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)