### PR TITLE
refactor: Move Clean button to page header via Portal

### DIFF
--- a/frontend/taskguild/src/components/TaskBoard.tsx
+++ b/frontend/taskguild/src/components/TaskBoard.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState, type RefObject } from 'react'
+import { createPortal } from 'react-dom'
 import { useQuery, useMutation } from '@connectrpc/connect-query'
 import { listTasks, updateTaskStatus } from '@taskguild/proto/taskguild/v1/task-TaskService_connectquery.ts'
 import { listAgents } from '@taskguild/proto/taskguild/v1/agent-AgentService_connectquery.ts'
@@ -28,6 +29,8 @@ import { Plus, ChevronDown, ChevronRight, Sparkles } from 'lucide-react'
 interface TaskBoardProps {
   projectId: string
   workflow: Workflow
+  /** Portal target in the page header for the Clean button */
+  headerActionsRef?: RefObject<HTMLDivElement | null>
 }
 
 const TASK_EVENT_TYPES = [
@@ -49,7 +52,7 @@ interface ForceTransitionState {
   toStatusName: string
 }
 
-export function TaskBoard({ projectId, workflow }: TaskBoardProps) {
+export function TaskBoard({ projectId, workflow, headerActionsRef }: TaskBoardProps) {
   const { data, refetch } = useQuery(listTasks, {
     projectId,
     workflowId: workflow.id,
@@ -335,25 +338,25 @@ export function TaskBoard({ projectId, workflow }: TaskBoardProps) {
       onDragEnd={handleDragEnd}
     >
       <div className="flex flex-col flex-1 overflow-hidden">
+        {/* Portal Clean button into page header */}
+        {headerActionsRef?.current && createPortal(
+          <button
+            onClick={() => setShowCleanDialog(true)}
+            disabled={terminalTasks.length === 0}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs md:text-sm md:px-3 text-gray-400 hover:text-amber-300 border border-slate-700 hover:border-amber-500/40 rounded-lg transition-colors disabled:opacity-50 disabled:hover:text-gray-400 disabled:hover:border-slate-700"
+            title={terminalTasks.length > 0 ? `Archive ${terminalTasks.length} completed tasks` : 'No completed tasks to archive'}
+          >
+            <Sparkles className="w-4 h-4" />
+            <span className="hidden sm:inline">Clean</span>
+            {terminalTasks.length > 0 && (
+              <span className="text-[10px] bg-amber-500/20 text-amber-400 rounded-full px-1.5 py-0.5 font-medium">
+                {terminalTasks.length}
+              </span>
+            )}
+          </button>,
+          headerActionsRef.current,
+        )}
         <div className="flex-1 overflow-x-auto p-4 md:p-6">
-          {/* Toolbar with Clean button */}
-          <div className="flex items-center justify-end mb-3">
-            <button
-              onClick={() => setShowCleanDialog(true)}
-              disabled={terminalTasks.length === 0}
-              className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs md:text-sm md:px-3 text-gray-400 hover:text-amber-300 border border-slate-700 hover:border-amber-500/40 rounded-lg transition-colors disabled:opacity-50 disabled:hover:text-gray-400 disabled:hover:border-slate-700"
-              title={terminalTasks.length > 0 ? `Archive ${terminalTasks.length} completed tasks` : 'No completed tasks to archive'}
-            >
-              <Sparkles className="w-4 h-4" />
-              <span className="hidden sm:inline">Clean</span>
-              {terminalTasks.length > 0 && (
-                <span className="text-[10px] bg-amber-500/20 text-amber-400 rounded-full px-1.5 py-0.5 font-medium">
-                  {terminalTasks.length}
-                </span>
-              )}
-            </button>
-          </div>
-
           {/* Desktop: horizontal flex; Mobile: vertical stack */}
           <div className="flex flex-col md:flex-row gap-4 md:h-full md:min-w-max">
             {sortedStatuses.map((status) => (

--- a/frontend/taskguild/src/routes/projects/$projectId/index.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/index.tsx
@@ -5,7 +5,7 @@ import { listWorkflows } from '@taskguild/proto/taskguild/v1/workflow-WorkflowSe
 import type { Workflow } from '@taskguild/proto/taskguild/v1/workflow_pb.ts'
 import { TaskBoard } from '@/components/TaskBoard'
 import { WorkflowForm } from '@/components/WorkflowForm'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Link } from '@tanstack/react-router'
 import { listAgents } from '@taskguild/proto/taskguild/v1/agent-AgentService_connectquery.ts'
 import { GitBranch, Plus, Settings, Bot } from 'lucide-react'
@@ -24,6 +24,7 @@ function ProjectDetailPage() {
   const { workflowId } = Route.useSearch()
   const [selectedWorkflow, setSelectedWorkflow] = useState<Workflow | null>(null)
   const [formMode, setFormMode] = useState<FormMode | null>(null)
+  const headerActionsRef = useRef<HTMLDivElement>(null)
 
   const { data: projectData } = useQuery(getProject, { id: projectId })
   const { data: workflowsData, refetch: refetchWorkflows } = useQuery(listWorkflows, {
@@ -120,6 +121,8 @@ function ProjectDetailPage() {
               <Plus className="w-4 h-4" />
               <span className="hidden sm:inline">New Workflow</span>
             </button>
+            {/* Portal target for TaskBoard header actions (e.g. Clean button) */}
+            <div ref={headerActionsRef} className="flex items-center gap-2 shrink-0" />
           </div>
         </div>
       </div>
@@ -136,6 +139,7 @@ function ProjectDetailPage() {
         <TaskBoard
           projectId={projectId}
           workflow={selectedWorkflow}
+          headerActionsRef={headerActionsRef}
         />
       ) : (
         <div className="flex-1 flex flex-col items-center justify-center text-gray-500 gap-6 p-4">


### PR DESCRIPTION
## Summary
- Move the task archive "Clean" button from inside the `TaskBoard` toolbar to the project page header using React `createPortal`
- Add a `headerActionsRef` prop to `TaskBoard` so it can portal actions into the parent page layout
- Keep the button visually aligned with other top-level header controls (New Workflow, etc.)

## Test plan
- [ ] Verify the Clean button renders in the page header next to "New Workflow"
- [ ] Verify the Clean button still shows the badge count and opens the archive dialog
- [ ] Verify the button is disabled when there are no terminal tasks
- [ ] Verify responsive behavior (hidden label on small screens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)