### PR TITLE
Fix interaction text truncation to allow word wrapping

### DIFF
--- a/frontend/taskguild/src/components/RequestItem.tsx
+++ b/frontend/taskguild/src/components/RequestItem.tsx
@@ -67,9 +67,9 @@ export function RequestItem({
       }`}
     >
       {/* Header row: icon + title + timestamp */}
-      <div className="flex items-center gap-2">
-        <span className="shrink-0">{icon}</span>
-        <span className="text-sm font-medium text-white truncate flex-1 min-w-0">
+      <div className="flex items-start gap-2">
+        <span className="shrink-0 mt-0.5">{icon}</span>
+        <span className="text-sm font-medium text-white flex-1 min-w-0 break-words">
           {interaction.title}
         </span>
         {interaction.createdAt && (
@@ -166,9 +166,9 @@ export function RequestItem({
 
       {/* Responded inline */}
       {isResponded && interaction.response && (
-        <div className="flex items-center gap-1.5 mt-1.5 ml-6">
-          <CheckCircle className="w-3 h-3 text-green-400 shrink-0" />
-          <span className="text-xs text-green-400 truncate">{interaction.response}</span>
+        <div className="flex items-start gap-1.5 mt-1.5 ml-6">
+          <CheckCircle className="w-3 h-3 text-green-400 shrink-0 mt-0.5" />
+          <span className="text-xs text-green-400 break-words min-w-0">{interaction.response}</span>
         </div>
       )}
     </div>

--- a/frontend/taskguild/src/components/TimelineEntry.tsx
+++ b/frontend/taskguild/src/components/TimelineEntry.tsx
@@ -57,16 +57,16 @@ function InteractionEntry({ interaction }: { interaction: Interaction }) {
 
   return (
     <div
-      className={`flex items-center gap-2 px-2 py-1 rounded text-xs ${
+      className={`flex items-start gap-2 px-2 py-1 rounded text-xs ${
         isPending ? 'bg-amber-500/5' : 'hover:bg-slate-800/50'
       }`}
     >
-      <span className="text-[11px] text-gray-600 font-mono w-12 shrink-0 text-right">
+      <span className="text-[11px] text-gray-600 font-mono w-12 shrink-0 text-right mt-0.5">
         {interaction.createdAt ? formatTime(interaction.createdAt) : ''}
       </span>
-      <span className="shrink-0">{icon}</span>
-      <span className="text-[11px] text-gray-500 w-16 shrink-0">{typeLabel}</span>
-      <span className="text-gray-300 truncate flex-1 min-w-0">{interaction.title}</span>
+      <span className="shrink-0 mt-0.5">{icon}</span>
+      <span className="text-[11px] text-gray-500 w-16 shrink-0 mt-0.5">{typeLabel}</span>
+      <span className="text-gray-300 flex-1 min-w-0 break-words">{interaction.title}</span>
       {statusBadge}
     </div>
   )


### PR DESCRIPTION
## Summary
- Replace `truncate` with `break-words` in `RequestItem` and `TimelineEntry` components so long interaction titles and responses wrap naturally instead of being cut off on a single line
- Change flex alignment from `items-center` to `items-start` for proper multi-line text layout
- Add `mt-0.5` to icons and labels to align them with the first line of wrapped text

## Test plan
- [ ] Verify long interaction titles wrap properly in the request list
- [ ] Verify long response text wraps properly in the responded state
- [ ] Verify long titles wrap properly in the timeline view
- [ ] Confirm short titles still display correctly on a single line
- [ ] Check layout on mobile screen widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)