### PR TITLE
Add auto-scroll to script execution output

### DIFF
--- a/frontend/taskguild/src/components/AutoScrollPre.tsx
+++ b/frontend/taskguild/src/components/AutoScrollPre.tsx
@@ -1,0 +1,85 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { ArrowDown } from 'lucide-react'
+
+/** Threshold in pixels to consider "at the bottom" of scroll container */
+const BOTTOM_THRESHOLD = 30
+
+/**
+ * Hook that manages auto-scroll behavior for a scrollable container.
+ *
+ * - Auto-scrolls to bottom when content changes (if enabled)
+ * - Pauses auto-scroll when user scrolls up
+ * - Resumes auto-scroll when user scrolls back to the bottom
+ */
+function useAutoScroll(content: string | undefined) {
+  const scrollRef = useRef<HTMLPreElement>(null)
+  const isAutoScrollEnabled = useRef(true)
+  const [showScrollButton, setShowScrollButton] = useState(false)
+
+  const isNearBottom = (el: HTMLElement) => {
+    return el.scrollHeight - el.scrollTop - el.clientHeight < BOTTOM_THRESHOLD
+  }
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+
+    const atBottom = isNearBottom(el)
+    isAutoScrollEnabled.current = atBottom
+    setShowScrollButton(!atBottom)
+  }, [])
+
+  // Auto-scroll when content changes
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el || !isAutoScrollEnabled.current) return
+    el.scrollTop = el.scrollHeight
+  }, [content])
+
+  const scrollToBottom = useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+    isAutoScrollEnabled.current = true
+    setShowScrollButton(false)
+  }, [])
+
+  return { scrollRef, handleScroll, showScrollButton, scrollToBottom }
+}
+
+interface AutoScrollPreProps {
+  /** The text content to display and auto-scroll */
+  content: string
+  /** CSS classes for the <pre> element */
+  className: string
+}
+
+/**
+ * A <pre> element with auto-scroll behavior.
+ *
+ * Auto-scrolls to the bottom as content grows.
+ * Pauses auto-scroll when the user scrolls up to view past output.
+ * Resumes auto-scroll when the user scrolls to the bottom.
+ * Shows a "scroll to latest" button when auto-scroll is paused.
+ */
+export function AutoScrollPre({ content, className }: AutoScrollPreProps) {
+  const { scrollRef, handleScroll, showScrollButton, scrollToBottom } =
+    useAutoScroll(content)
+
+  return (
+    <div className="relative">
+      <pre ref={scrollRef} onScroll={handleScroll} className={className}>
+        {content}
+      </pre>
+      {showScrollButton && (
+        <button
+          onClick={scrollToBottom}
+          className="absolute bottom-2 right-4 flex items-center gap-1 px-2 py-1 text-[10px] text-gray-300 bg-slate-800/80 backdrop-blur-sm border border-slate-600/50 rounded-md hover:bg-slate-700/90 hover:text-white transition-colors shadow-lg"
+        >
+          <ArrowDown className="w-3 h-3" />
+          <span>Latest</span>
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/taskguild/src/components/ScriptList.tsx
+++ b/frontend/taskguild/src/components/ScriptList.tsx
@@ -19,6 +19,7 @@ import { Terminal, Plus, Trash2, Edit2, RefreshCw, X, Save, Cloud, Play, CheckCi
 import { createClient } from '@connectrpc/connect'
 import { create } from '@bufbuild/protobuf'
 import { transport } from '@/lib/transport'
+import { AutoScrollPre } from './AutoScrollPre'
 
 interface ScriptFormData {
   name: string
@@ -563,17 +564,19 @@ export function ScriptList({ projectId }: { projectId: string }) {
                       {result.stdout && (
                         <div>
                           <span className="text-[10px] text-gray-500 uppercase tracking-wider">stdout</span>
-                          <pre className="text-xs text-gray-300 font-mono bg-slate-900/50 rounded p-2 mt-0.5 whitespace-pre-wrap max-h-[300px] overflow-y-auto">
-                            {result.stdout}
-                          </pre>
+                          <AutoScrollPre
+                            content={result.stdout}
+                            className="text-xs text-gray-300 font-mono bg-slate-900/50 rounded p-2 mt-0.5 whitespace-pre-wrap max-h-[300px] overflow-y-auto"
+                          />
                         </div>
                       )}
                       {result.stderr && (
                         <div>
                           <span className="text-[10px] text-gray-500 uppercase tracking-wider">stderr</span>
-                          <pre className="text-xs text-red-300 font-mono bg-slate-900/50 rounded p-2 mt-0.5 whitespace-pre-wrap max-h-[300px] overflow-y-auto">
-                            {result.stderr}
-                          </pre>
+                          <AutoScrollPre
+                            content={result.stderr}
+                            className="text-xs text-red-300 font-mono bg-slate-900/50 rounded p-2 mt-0.5 whitespace-pre-wrap max-h-[300px] overflow-y-auto"
+                          />
                         </div>
                       )}
                     </div>


### PR DESCRIPTION
## Summary
- Add `AutoScrollPre` component that provides auto-scroll behavior for scrollable `<pre>` elements
- Replace plain `<pre>` tags in `ScriptList` for stdout/stderr output with `AutoScrollPre`
- Auto-scrolls to bottom as script output grows in real-time
- Pauses auto-scroll when user scrolls up to review past output
- Shows a "scroll to latest" button to resume auto-scroll

## Test plan
- [ ] Run a script that produces long output and verify it auto-scrolls to the bottom
- [ ] Scroll up during output and verify auto-scroll pauses
- [ ] Verify "Latest" button appears when scrolled up and clicking it scrolls to bottom
- [ ] Verify stderr output also has auto-scroll behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)