### PR TITLE
Add dynamic document titles to all pages

### DIFF
--- a/frontend/taskguild/index.html
+++ b/frontend/taskguild/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0f172a" />
     <link rel="manifest" href="/manifest.json" />
-    <title>taskguild</title>
+    <title>TaskGuild</title>
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/taskguild/src/hooks/useDocumentTitle.ts
+++ b/frontend/taskguild/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+
+const APP_NAME = 'TaskGuild'
+
+/**
+ * Sets the document title to `TaskGuild | {subtitle}`.
+ * When subtitle is undefined or empty, the title is just `TaskGuild`.
+ * Restores the base title on unmount.
+ */
+export function useDocumentTitle(subtitle?: string) {
+  useEffect(() => {
+    document.title = subtitle ? `${APP_NAME} | ${subtitle}` : APP_NAME
+    return () => {
+      document.title = APP_NAME
+    }
+  }, [subtitle])
+}

--- a/frontend/taskguild/src/routes/index.tsx
+++ b/frontend/taskguild/src/routes/index.tsx
@@ -1,12 +1,14 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useQuery, useMutation } from '@connectrpc/connect-query'
 import { listProjects, createProject } from '@taskguild/proto/taskguild/v1/project-ProjectService_connectquery.ts'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 import { Folder, ArrowRight, Plus, X } from 'lucide-react'
 import { useState } from 'react'
 
 export const Route = createFileRoute('/')({ component: ProjectsPage })
 
 function ProjectsPage() {
+  useDocumentTitle('Projects')
   const { data, isLoading, error, refetch } = useQuery(listProjects, {})
   const [showForm, setShowForm] = useState(false)
 

--- a/frontend/taskguild/src/routes/projects/$projectId/agents.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/agents.tsx
@@ -1,11 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { AgentList } from '@/components/AgentList'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 export const Route = createFileRoute('/projects/$projectId/agents')({
   component: AgentsPage,
 })
 
 function AgentsPage() {
+  useDocumentTitle('Agents')
   const { projectId } = Route.useParams()
   return <AgentList projectId={projectId} />
 }

--- a/frontend/taskguild/src/routes/projects/$projectId/chat.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/chat.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useEffect, useMemo } from 'react'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useQuery, useMutation } from '@connectrpc/connect-query'
 import { listTasks } from '@taskguild/proto/taskguild/v1/task-TaskService_connectquery.ts'
@@ -19,6 +20,7 @@ export const Route = createFileRoute('/projects/$projectId/chat')({
 })
 
 function ProjectChatPage() {
+  useDocumentTitle('Chat')
   const { projectId } = Route.useParams()
   const scrollRef = useRef<HTMLDivElement>(null)
 

--- a/frontend/taskguild/src/routes/projects/$projectId/index.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/index.tsx
@@ -8,6 +8,7 @@ import { WorkflowForm } from '@/components/WorkflowForm'
 import { useState, useEffect, useRef } from 'react'
 import { Link } from '@tanstack/react-router'
 import { listAgents } from '@taskguild/proto/taskguild/v1/agent-AgentService_connectquery.ts'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 import { GitBranch, Plus, Settings, Bot } from 'lucide-react'
 
 type FormMode = { kind: 'create' } | { kind: 'edit'; workflow: Workflow }
@@ -34,6 +35,8 @@ function ProjectDetailPage() {
 
   const project = projectData?.project
   const workflows = workflowsData?.workflows ?? []
+
+  useDocumentTitle(project?.name)
 
   // Select workflow from search params or auto-select first.
   // Always sync selectedWorkflow with the latest workflows data so that

--- a/frontend/taskguild/src/routes/projects/$projectId/permissions.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/permissions.tsx
@@ -1,11 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { PermissionList } from '@/components/PermissionList'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 export const Route = createFileRoute('/projects/$projectId/permissions')({
   component: PermissionsPage,
 })
 
 function PermissionsPage() {
+  useDocumentTitle('Permissions')
   const { projectId } = Route.useParams()
   return <PermissionList projectId={projectId} />
 }

--- a/frontend/taskguild/src/routes/projects/$projectId/scripts.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/scripts.tsx
@@ -1,11 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ScriptList } from '@/components/ScriptList'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 export const Route = createFileRoute('/projects/$projectId/scripts')({
   component: ScriptsPage,
 })
 
 function ScriptsPage() {
+  useDocumentTitle('Scripts')
   const { projectId } = Route.useParams()
   return <ScriptList projectId={projectId} />
 }

--- a/frontend/taskguild/src/routes/projects/$projectId/skills.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/skills.tsx
@@ -1,11 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { SkillList } from '@/components/SkillList'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 export const Route = createFileRoute('/projects/$projectId/skills')({
   component: SkillsPage,
 })
 
 function SkillsPage() {
+  useDocumentTitle('Skills')
   const { projectId } = Route.useParams()
   return <SkillList projectId={projectId} />
 }

--- a/frontend/taskguild/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { useQuery, useMutation } from '@connectrpc/connect-query'
 import { getTask, updateTaskStatus } from '@taskguild/proto/taskguild/v1/task-TaskService_connectquery.ts'
@@ -53,6 +54,8 @@ function TaskDetailPage() {
   const project = projectData?.project
   const workflows = workflowsData?.workflows ?? []
   const interactions = interactionsData?.interactions ?? []
+
+  useDocumentTitle(task?.title)
 
   const workflow = workflows.find((w) => w.id === task?.workflowId)
   const sortedStatuses = workflow ? [...workflow.statuses].sort((a, b) => a.order - b.order) : []

--- a/frontend/taskguild/src/routes/projects/$projectId/worktrees.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/worktrees.tsx
@@ -1,11 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { WorktreeList } from '@/components/WorktreeList'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 export const Route = createFileRoute('/projects/$projectId/worktrees')({
   component: WorktreesPage,
 })
 
 function WorktreesPage() {
+  useDocumentTitle('Worktrees')
   const { projectId } = Route.useParams()
   return <WorktreeList projectId={projectId} />
 }

--- a/frontend/taskguild/src/routes/templates.tsx
+++ b/frontend/taskguild/src/routes/templates.tsx
@@ -1,10 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { TemplateList } from '@/components/TemplateList'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 export const Route = createFileRoute('/templates')({
   component: TemplatesPage,
 })
 
 function TemplatesPage() {
+  useDocumentTitle('Templates')
   return <TemplateList />
 }


### PR DESCRIPTION
## Summary
- Add `useDocumentTitle` custom hook that sets browser tab title to `TaskGuild | {page name}`
- Apply the hook to all route pages (Projects, Agents, Chat, Permissions, Scripts, Skills, Worktrees, Templates, Project detail, Task detail)
- Fix base HTML title from lowercase `taskguild` to `TaskGuild`
- On unmount, the title reverts to the base `TaskGuild` title

## Test plan
- [ ] Verify each page displays the correct title in the browser tab
- [ ] Verify navigating between pages updates the tab title
- [ ] Verify Project detail page shows the project name in the title
- [ ] Verify Task detail page shows the task title in the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)