### PR TITLE
Fix: Move modal action buttons from fixed footer to inline form content

### DIFF
--- a/frontend/taskguild/src/components/TaskCreateModal.tsx
+++ b/frontend/taskguild/src/components/TaskCreateModal.tsx
@@ -144,23 +144,23 @@ export function TaskCreateModal({ projectId, workflowId, defaultPermissionMode, 
               </select>
             </div>
           )}
-        </div>
 
-        {/* Footer */}
-        <div className="border-t border-slate-800 px-4 py-2 flex justify-end items-center gap-2">
-          <button
-            onClick={onClose}
-            className="px-3 py-1.5 text-xs text-gray-400 hover:text-white transition-colors"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handleCreate}
-            disabled={createMut.isPending || !title.trim()}
-            className="px-4 py-1.5 text-xs bg-cyan-600 hover:bg-cyan-500 text-white rounded-lg disabled:opacity-50 transition-colors"
-          >
-            {createMut.isPending ? 'Creating...' : 'Create'}
-          </button>
+          {/* Action buttons */}
+          <div className="border-t border-slate-800 mt-4 pt-3 flex justify-end items-center gap-2">
+            <button
+              onClick={onClose}
+              className="px-3 py-1.5 text-xs text-gray-400 hover:text-white transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleCreate}
+              disabled={createMut.isPending || !title.trim()}
+              className="px-4 py-1.5 text-xs bg-cyan-600 hover:bg-cyan-500 text-white rounded-lg disabled:opacity-50 transition-colors"
+            >
+              {createMut.isPending ? 'Creating...' : 'Create'}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/taskguild/src/components/TaskDetailModal.tsx
+++ b/frontend/taskguild/src/components/TaskDetailModal.tsx
@@ -368,32 +368,32 @@ export function TaskDetailModal({
               </div>
             </div>
           )}
-        </div>
 
-        {/* Footer */}
-        <div className="border-t border-slate-800 px-4 py-2 flex justify-between items-center">
-          <button
-            onClick={handleDelete}
-            disabled={deleteMut.isPending}
-            className="flex items-center gap-1 text-xs text-gray-500 hover:text-red-400 transition-colors disabled:opacity-50 p-1"
-          >
-            <Trash2 className="w-3.5 h-3.5" />
-            Delete
-          </button>
-          <div className="flex items-center gap-2">
+          {/* Action buttons */}
+          <div className="border-t border-slate-800 mt-4 pt-3 flex justify-between items-center">
             <button
-              onClick={handleCancel}
-              className="px-3 py-1.5 text-xs text-gray-400 hover:text-white transition-colors"
+              onClick={handleDelete}
+              disabled={deleteMut.isPending}
+              className="flex items-center gap-1 text-xs text-gray-500 hover:text-red-400 transition-colors disabled:opacity-50 p-1"
             >
-              Cancel
+              <Trash2 className="w-3.5 h-3.5" />
+              Delete
             </button>
-            <button
-              onClick={handleSave}
-              disabled={!hasChanges || !titleDraft.trim() || updateMut.isPending}
-              className="px-4 py-1.5 text-xs bg-cyan-600 hover:bg-cyan-500 text-white rounded-lg disabled:opacity-50 transition-colors"
-            >
-              {updateMut.isPending ? 'Saving...' : 'Save'}
-            </button>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={handleCancel}
+                className="px-3 py-1.5 text-xs text-gray-400 hover:text-white transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={!hasChanges || !titleDraft.trim() || updateMut.isPending}
+                className="px-4 py-1.5 text-xs bg-cyan-600 hover:bg-cyan-500 text-white rounded-lg disabled:opacity-50 transition-colors"
+              >
+                {updateMut.isPending ? 'Saving...' : 'Save'}
+              </button>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Move Save/Cancel/Create buttons from fixed footer to end of form content in TaskCreateModal and TaskDetailModal
- Buttons now scroll with the form instead of being pinned to the bottom of the modal
- Fixes layout issues where the fixed footer could overlap form content

## Test plan
- [ ] Open task create modal and verify Cancel/Create buttons are visible at the end of the form
- [ ] Open task detail modal and verify Save/Cancel/Delete buttons are visible at the end of the form
- [ ] Verify buttons scroll with form content when the modal content overflows
- [ ] Confirm no visual regressions in button styling and spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)