### PR TITLE
Fix re-authentication handling and add exponential backoff for reconnection

### DIFF
--- a/backend/cmd/taskguild-agent/run.go
+++ b/backend/cmd/taskguild-agent/run.go
@@ -175,7 +175,13 @@ func runAgent() {
 		heartbeat(ctx, client, cfg.AgentManagerID)
 	}()
 
-	// Subscribe loop with reconnection
+	// Subscribe loop with reconnection and exponential backoff.
+	const (
+		subscribeInitialBackoff = 5 * time.Second
+		subscribeMaxBackoff     = 5 * time.Minute
+	)
+	subscribeBackoff := subscribeInitialBackoff
+
 	for {
 		if ctx.Err() != nil {
 			break
@@ -191,11 +197,19 @@ func runAgent() {
 			break
 		}
 		if err != nil {
-			log.Printf("subscribe stream error: %v, reconnecting in 5s...", err)
+			log.Printf("subscribe stream error: %v, reconnecting in %s...", err, subscribeBackoff)
 			select {
-			case <-time.After(5 * time.Second):
+			case <-time.After(subscribeBackoff):
 			case <-ctx.Done():
 			}
+			// Exponential backoff, capped.
+			subscribeBackoff *= 2
+			if subscribeBackoff > subscribeMaxBackoff {
+				subscribeBackoff = subscribeMaxBackoff
+			}
+		} else {
+			// Successful connection (clean disconnect) — reset backoff.
+			subscribeBackoff = subscribeInitialBackoff
 		}
 	}
 

--- a/backend/cmd/taskguild-agent/runner.go
+++ b/backend/cmd/taskguild-agent/runner.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -185,6 +186,19 @@ func runTask(
 		}
 
 		if isError {
+			// Authentication errors (e.g. expired OAuth token) are not
+			// recoverable by retrying. Fail immediately and tell the user
+			// to run 'claude login' to re-authenticate.
+			if isAuthenticationError(errMsg) {
+				authErrMsg := fmt.Sprintf("Authentication failed: %s\nRun 'claude login' to re-authenticate.", errMsg)
+				log.Printf("[task:%s] authentication error detected, not retrying: %s", taskID, errMsg)
+				tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_ERROR, v1.TaskLogLevel_TASK_LOG_LEVEL_ERROR,
+					authErrMsg, nil)
+				reportTaskResult(ctx, client, taskID, "", authErrMsg)
+				reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_ERROR, authErrMsg)
+				return
+			}
+
 			consecutiveErrors++
 			log.Printf("[task:%s] error (%d/%d): %s", taskID, consecutiveErrors, maxConsecutiveErrors, errMsg)
 
@@ -436,4 +450,24 @@ func reportAgentStatus(
 	if err != nil {
 		log.Printf("[task:%s] failed to report agent status: %v", taskID, err)
 	}
+}
+
+// isAuthenticationError checks whether an error message from Claude CLI
+// indicates an authentication failure (e.g. expired OAuth token).
+// These errors cannot be resolved by retrying and require the user to
+// run 'claude login' to re-authenticate.
+func isAuthenticationError(errMsg string) bool {
+	lower := strings.ToLower(errMsg)
+	authPatterns := []string{
+		"authentication_error",
+		"authentication_failed",
+		"oauth token has expired",
+		"failed to authenticate",
+	}
+	for _, pattern := range authPatterns {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- Detect authentication errors (e.g. expired OAuth tokens) in the task runner and fail immediately instead of retrying endlessly, prompting the user to run `claude login` to re-authenticate
- Add exponential backoff (5s → 5min cap) to the subscribe loop reconnection to avoid hammering the server on persistent errors
- Reset backoff on successful connection

## Test plan
- [ ] Verify that expired OAuth token triggers immediate failure with a clear error message
- [ ] Verify that non-auth subscribe errors use exponential backoff (5s, 10s, 20s, … up to 5min)
- [ ] Verify that backoff resets after a successful reconnection
- [ ] Verify normal task execution is not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)