### PR TITLE
Allow force-move for pending tasks (agent not yet started)

### DIFF
--- a/backend/internal/task/server.go
+++ b/backend/internal/task/server.go
@@ -203,8 +203,9 @@ func (s *Server) UpdateTaskStatus(ctx context.Context, req *connect.Request[task
 	}
 
 	// Block force-move when an agent is actively running on the task.
+	// Pending tasks (agent not yet started) are allowed to be force-moved.
 	if req.Msg.Force {
-		if t.AssignmentStatus == AssignmentStatusPending || t.AssignmentStatus == AssignmentStatusAssigned {
+		if t.AssignmentStatus == AssignmentStatusAssigned {
 			return nil, cerr.NewError(
 				cerr.FailedPrecondition,
 				fmt.Sprintf("cannot force-move a task while an agent is running (status: %s)", t.AssignmentStatus),

--- a/frontend/taskguild/src/components/TaskBoard.tsx
+++ b/frontend/taskguild/src/components/TaskBoard.tsx
@@ -167,11 +167,9 @@ export function TaskBoard({ projectId, workflow, headerActionsRef }: TaskBoardPr
   // Force-move targets: all statuses except the current one and normal targets
   const forceTargetIds = useMemo(() => {
     if (!activeTask) return new Set<string>()
-    const isAgentRunning =
-      activeTask.assignmentStatus === TaskAssignmentStatus.ASSIGNED ||
-      activeTask.assignmentStatus === TaskAssignmentStatus.PENDING
-    // Don't allow force targets if agent is running
-    if (isAgentRunning) return new Set<string>()
+    // Don't allow force targets if agent is actively running (assigned).
+    // Pending tasks (agent not yet started) are allowed to be force-moved.
+    if (activeTask.assignmentStatus === TaskAssignmentStatus.ASSIGNED) return new Set<string>()
     const set = new Set<string>()
     for (const s of sortedStatuses) {
       if (s.id !== activeTask.statusId && !normalTargetIds.has(s.id)) {
@@ -313,11 +311,9 @@ export function TaskBoard({ projectId, workflow, headerActionsRef }: TaskBoardPr
       const task = tasks.find((t) => t.id === taskId)
       if (!task) return
 
-      // Block force-move when agent is running
-      const isAgentRunning =
-        task.assignmentStatus === TaskAssignmentStatus.ASSIGNED ||
-        task.assignmentStatus === TaskAssignmentStatus.PENDING
-      if (isAgentRunning) return
+      // Block force-move when agent is actively running (assigned).
+      // Pending tasks (agent not yet started) are allowed to be force-moved.
+      if (task.assignmentStatus === TaskAssignmentStatus.ASSIGNED) return
 
       const fromName = statusById.get(task.statusId)?.name ?? task.statusId
       const toName = statusById.get(targetStatusId)?.name ?? targetStatusId

--- a/frontend/taskguild/src/components/TaskCard.tsx
+++ b/frontend/taskguild/src/components/TaskCard.tsx
@@ -50,9 +50,10 @@ export function TaskCard({ task, onEdit, isDragOverlay, transitionTargets, onTra
 
   const hasTransitions = transitionTargets && transitionTargets.length > 0
 
+  // Only block force-move when agent is actively running (assigned).
+  // Pending tasks (agent not yet started) are allowed to be force-moved.
   const isAgentRunning =
-    task.assignmentStatus === TaskAssignmentStatus.ASSIGNED ||
-    task.assignmentStatus === TaskAssignmentStatus.PENDING
+    task.assignmentStatus === TaskAssignmentStatus.ASSIGNED
 
   return (
     <div

--- a/frontend/taskguild/src/components/TaskDetailModal.tsx
+++ b/frontend/taskguild/src/components/TaskDetailModal.tsx
@@ -60,6 +60,9 @@ export function TaskDetailModal({
   const interactions = interactionsData?.interactions ?? []
 
   const isTaskLocked = task?.assignmentStatus === TaskAssignmentStatus.ASSIGNED || task?.assignmentStatus === TaskAssignmentStatus.PENDING
+  // Force-move is only blocked when agent is actively running (assigned).
+  // Pending tasks (agent not yet started) are allowed to be force-moved.
+  const isForceMoveBlocked = task?.assignmentStatus === TaskAssignmentStatus.ASSIGNED
 
   // Query cached worktree list (only when worktree is enabled and task is not locked)
   const { data: wtData, refetch: refetchWorktrees } = useQuery(getWorktreeList, { projectId }, {
@@ -337,7 +340,7 @@ export function TaskDetailModal({
                 </button>
               )
             })}
-            {!isTaskLocked && forceTransitions.map((target) => (
+            {!isForceMoveBlocked && forceTransitions.map((target) => (
               <button
                 key={target.id}
                 onClick={() => handleForceTransitionClick(target)}

--- a/frontend/taskguild/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -12,6 +12,7 @@ import { useEventSubscription } from '@/hooks/useEventSubscription'
 import { useTaskLogs } from '@/hooks/useTaskLogs'
 import { useNotificationSound } from '@/hooks/useNotificationSound'
 import { TaskDetailModal } from '@/components/TaskDetailModal'
+import { ForceTransitionDialog } from '@/components/ForceTransitionDialog'
 import { shortId } from '@/lib/id'
 import { InputBar } from '@/components/ChatBubble'
 import { MarkdownDescription } from '@/components/MarkdownDescription'
@@ -19,6 +20,7 @@ import { TimelineEntry, type TimelineItem } from '@/components/TimelineEntry'
 import { PendingRequestsPanel } from '@/components/PendingRequestsPanel'
 import { ConnectionIndicator } from '@/components/ConnectionIndicator'
 import {
+  AlertTriangle,
   ArrowLeft,
   ArrowRight,
   Bot,
@@ -58,6 +60,22 @@ function TaskDetailPage() {
   const sortedStatuses = workflow ? [...workflow.statuses].sort((a, b) => a.order - b.order) : []
   const currentStatus = sortedStatuses.find((s) => s.id === task?.statusId)
   const allowedTransitions = currentStatus?.transitionsTo ?? []
+
+  // Force transition targets: all statuses except current and normal transitions
+  const forceTransitions = useMemo(() => {
+    if (!currentStatus) return []
+    const normalSet = new Set(allowedTransitions)
+    return sortedStatuses
+      .filter((s) => s.id !== currentStatus.id && !normalSet.has(s.id))
+      .map((s) => ({ id: s.id, name: s.name }))
+  }, [currentStatus, allowedTransitions, sortedStatuses])
+
+  // Force-move is only blocked when agent is actively running (assigned).
+  // Pending tasks (agent not yet started) are allowed to be force-moved.
+  const isForceMoveBlocked = task?.assignmentStatus === TaskAssignmentStatus.ASSIGNED
+
+  // Force-transition confirmation dialog state
+  const [forceTransitionTarget, setForceTransitionTarget] = useState<{ id: string; name: string } | null>(null)
 
   // Fetch task logs
   const { logs } = useTaskLogs(taskId, projectId)
@@ -125,12 +143,26 @@ function TaskDetailPage() {
     })
   }, [navigate, projectId, task?.workflowId])
 
-  const handleStatusChange = (statusId: string) => {
+  const handleStatusChange = (statusId: string, force = false) => {
     if (!task) return
     statusMut.mutate(
-      { id: task.id, statusId },
+      { id: task.id, statusId, force },
       { onSuccess: () => refetchTask() },
     )
+  }
+
+  const handleForceTransitionClick = (target: { id: string; name: string }) => {
+    setForceTransitionTarget(target)
+  }
+
+  const handleForceConfirm = () => {
+    if (!forceTransitionTarget) return
+    handleStatusChange(forceTransitionTarget.id, true)
+    setForceTransitionTarget(null)
+  }
+
+  const handleForceCancel = () => {
+    setForceTransitionTarget(null)
   }
 
   // Synchronous guard to prevent duplicate responses (survives across renders before mutation state propagates)
@@ -230,6 +262,18 @@ function TaskDetailPage() {
                 </button>
               )
             })}
+            {!isForceMoveBlocked && forceTransitions.map((target) => (
+              <button
+                key={target.id}
+                onClick={() => handleForceTransitionClick(target)}
+                disabled={statusMut.isPending}
+                className="flex items-center gap-1 px-3 py-1 text-xs bg-slate-800 border border-slate-700 rounded-lg text-gray-400 hover:border-amber-500/50 hover:text-amber-300 transition-colors disabled:opacity-50"
+                title="Force move (not defined in workflow)"
+              >
+                <AlertTriangle className="w-3 h-3 text-amber-500/70" />
+                {target.name}
+              </button>
+            ))}
 
             <span className="text-[11px] text-gray-600 font-mono ml-auto hidden sm:inline">{task.id}</span>
 
@@ -355,6 +399,16 @@ function TaskDetailPage() {
           onClose={() => setShowEditModal(false)}
           onChanged={() => refetchTask()}
           onDeleted={handleDeleted}
+        />
+      )}
+
+      {/* Force-transition confirmation dialog */}
+      {forceTransitionTarget && currentStatus && (
+        <ForceTransitionDialog
+          fromStatusName={currentStatus.name}
+          toStatusName={forceTransitionTarget.name}
+          onConfirm={handleForceConfirm}
+          onCancel={handleForceCancel}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- Previously, force-move was blocked for both `pending` and `assigned` tasks. This was overly restrictive since pending tasks have no agent actively running yet.
- Updated backend validation to only block force-move when agent is actively running (`assigned` status), allowing pending tasks to be force-moved.
- Applied the same policy change across all frontend components: `TaskBoard`, `TaskCard`, `TaskDetailModal`.
- Added force-transition UI (buttons + confirmation dialog) to the standalone task detail page (`/$projectId/tasks/$taskId`), which was previously missing this functionality.

## Test plan
- [ ] Verify that force-move is allowed for tasks with `pending` assignment status
- [ ] Verify that force-move is still blocked for tasks with `assigned` assignment status
- [ ] Verify force-transition buttons appear on TaskBoard for pending tasks
- [ ] Verify force-transition buttons appear on the standalone task detail page
- [ ] Verify force-transition confirmation dialog works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)