### PR TITLE
Fix agent nil command error from proxy-injected frames

### DIFF
--- a/backend/cmd/taskguild-agent/run.go
+++ b/backend/cmd/taskguild-agent/run.go
@@ -267,6 +267,12 @@ func runSubscribeLoop(
 	for stream.Receive() {
 		cmd := stream.Msg()
 
+		// Skip empty commands (e.g. caused by proxy-injected frames or
+		// partial envelope reads from intermediaries).
+		if cmd.GetCommand() == nil {
+			continue
+		}
+
 		switch c := cmd.GetCommand().(type) {
 		case *v1.AgentCommand_TaskAvailable:
 			taskAvail := c.TaskAvailable
@@ -415,6 +421,12 @@ func runSubscribeLoop(
 
 				runTask(taskCtx, client, taskClient, interClient, cfg.AgentManagerID, tID, instructions, metadata, cfg.WorkDir, permCache)
 			}(taskID)
+
+		case *v1.AgentCommand_InteractionResponse:
+			// Interaction responses are handled per-task via SubscribeInteractions.
+			// Log and ignore if received on the global subscribe stream.
+			log.Printf("received interaction_response on subscribe stream (interaction_id: %s), ignoring",
+				c.InteractionResponse.GetInteractionId())
 
 		case *v1.AgentCommand_Ping:
 			// Server-side keepalive ping — silently ignore.


### PR DESCRIPTION
## Summary
- Add nil check for `cmd.GetCommand()` in the agent subscribe loop to skip empty commands caused by proxy-injected frames or partial envelope reads from intermediaries
- Add explicit handler for `InteractionResponse` on the global subscribe stream to log and ignore instead of falling through

## Test plan
- [ ] Verify agent does not panic when receiving nil/empty commands from proxy
- [ ] Verify interaction responses on subscribe stream are logged and ignored gracefully
- [ ] Confirm normal task assignment and execution flow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)