### PR TITLE
Harden nil command guard with debug log and default-case fallback

### DIFF
--- a/backend/cmd/taskguild-agent/run.go
+++ b/backend/cmd/taskguild-agent/run.go
@@ -270,6 +270,7 @@ func runSubscribeLoop(
 		// Skip empty commands (e.g. caused by proxy-injected frames or
 		// partial envelope reads from intermediaries).
 		if cmd.GetCommand() == nil {
+			log.Println("skipping empty command (nil oneof)")
 			continue
 		}
 
@@ -432,6 +433,11 @@ func runSubscribeLoop(
 			// Server-side keepalive ping — silently ignore.
 
 		default:
+			// Nil should be caught by the guard above; if it still reaches
+			// here, silently skip to avoid noisy logs from proxy artefacts.
+			if cmd.GetCommand() == nil {
+				continue
+			}
 			log.Printf("unknown command type: %T", cmd.GetCommand())
 		}
 	}


### PR DESCRIPTION
## Summary
- Add debug log when skipping nil commands in the subscribe loop to aid troubleshooting proxy-injected frame issues
- Add a secondary nil-command guard in the `default` switch case as a safety net, in case a nil command bypasses the initial guard

## Test plan
- [ ] Verify agent starts and processes commands normally
- [ ] Confirm nil/empty commands from proxy-injected frames are silently skipped with a log message
- [ ] Check that the default case does not panic or produce noisy logs for nil commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)