### PR TITLE
backend ロギングを log/slog に統一

### DIFF
--- a/backend/cmd/taskguild-agent/directive.go
+++ b/backend/cmd/taskguild-agent/directive.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"connectrpc.com/connect"
 	v1 "github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1"
 	"github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1/taskguildv1connect"
+	"github.com/kazz187/taskguild/backend/pkg/clog"
 )
 
 // createTaskDirective holds parsed CREATE_TASK directive fields.
@@ -118,11 +118,13 @@ func createTaskFromDirective(
 	metadata map[string]string,
 	directive createTaskDirective,
 ) {
+	logger := clog.LoggerFromContext(ctx)
+
 	projectID := metadata["_project_id"]
 	workflowID := metadata["_workflow_id"]
 
 	if projectID == "" || workflowID == "" {
-		log.Printf("[task:%s] cannot create task: missing _project_id or _workflow_id", sourceTaskID)
+		logger.Error("cannot create task: missing _project_id or _workflow_id")
 		return
 	}
 
@@ -162,15 +164,15 @@ func createTaskFromDirective(
 
 	resp, err := taskClient.CreateTask(ctx, connect.NewRequest(req))
 	if err != nil {
-		log.Printf("[task:%s] failed to create task %q: %v", sourceTaskID, directive.Title, err)
+		logger.Error("failed to create task", "title", directive.Title, "error", err)
 		return
 	}
 
 	newTask := resp.Msg.GetTask()
 	if newTask != nil {
-		log.Printf("[task:%s] created child task %s: %q", sourceTaskID, newTask.GetId(), directive.Title)
+		logger.Info("created child task", "child_task_id", newTask.GetId(), "title", directive.Title)
 	} else {
-		log.Printf("[task:%s] created child task (no task in response): %q", sourceTaskID, directive.Title)
+		logger.Info("created child task (no task in response)", "title", directive.Title)
 	}
 }
 
@@ -295,6 +297,8 @@ func handleStatusTransition(
 	metadata map[string]string,
 	tl *taskLogger,
 ) error {
+	logger := clog.LoggerFromContext(ctx)
+
 	transitionsJSON := metadata["_available_transitions"]
 	if transitionsJSON == "" {
 		return fmt.Errorf("no available transitions in metadata")
@@ -316,7 +320,7 @@ func handleStatusTransition(
 		// Auto-transition if exactly one transition is available.
 		if len(transitions) == 1 {
 			nextStatusID = transitions[0].ID
-			log.Printf("[task:%s] no NEXT_STATUS found, auto-transitioning to %s (%s)", taskID, nextStatusID, transitions[0].Name)
+			logger.Info("no NEXT_STATUS found, auto-transitioning", "next_status_id", nextStatusID, "next_status_name", transitions[0].Name)
 			tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
 				fmt.Sprintf("Auto-transitioning to %s (%s)", nextStatusID, transitions[0].Name), nil)
 		} else {
@@ -352,42 +356,45 @@ func handleStatusTransition(
 		return fmt.Errorf("UpdateTaskStatus RPC failed for %s: %w", nextStatusID, err)
 	}
 
-	log.Printf("[task:%s] status transitioned to %s", taskID, nextStatusID)
+	logger.Info("status transitioned", "next_status_id", nextStatusID)
 	tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
 		fmt.Sprintf("Status transitioned to %s", nextStatusID), nil)
 	return nil
 }
 
 func saveSessionID(ctx context.Context, taskClient taskguildv1connect.TaskServiceClient, taskID, sessionID string) {
+	logger := clog.LoggerFromContext(ctx)
 	_, err := taskClient.UpdateTask(ctx, connect.NewRequest(&v1.UpdateTaskRequest{
 		Id:       taskID,
 		Metadata: map[string]string{"session_id": sessionID},
 	}))
 	if err != nil {
-		log.Printf("[task:%s] failed to save session_id: %v", taskID, err)
+		logger.Error("failed to save session_id", "error", err)
 	}
 }
 
 func saveWorktreeName(ctx context.Context, taskClient taskguildv1connect.TaskServiceClient, taskID, name string) {
+	logger := clog.LoggerFromContext(ctx)
 	_, err := taskClient.UpdateTask(ctx, connect.NewRequest(&v1.UpdateTaskRequest{
 		Id:       taskID,
 		Metadata: map[string]string{"worktree": name},
 	}))
 	if err != nil {
-		log.Printf("[task:%s] failed to save worktree_name: %v", taskID, err)
+		logger.Error("failed to save worktree_name", "error", err)
 	} else {
-		log.Printf("[task:%s] worktree name: %s", taskID, name)
+		logger.Info("worktree name saved", "worktree_name", name)
 	}
 }
 
 func saveTaskDescription(ctx context.Context, taskClient taskguildv1connect.TaskServiceClient, taskID, description string) {
+	logger := clog.LoggerFromContext(ctx)
 	_, err := taskClient.UpdateTask(ctx, connect.NewRequest(&v1.UpdateTaskRequest{
 		Id:          taskID,
 		Description: description,
 	}))
 	if err != nil {
-		log.Printf("[task:%s] failed to save task description: %v", taskID, err)
+		logger.Error("failed to save task description", "error", err)
 	} else {
-		log.Printf("[task:%s] task description updated (%d chars)", taskID, len(description))
+		logger.Info("task description updated", "description_length", len(description))
 	}
 }

--- a/backend/cmd/taskguild-agent/execute_script.go
+++ b/backend/cmd/taskguild-agent/execute_script.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -31,7 +31,7 @@ func handleExecuteScript(ctx context.Context, client taskguildv1connect.AgentMan
 	filename := cmd.GetFilename()
 	content := cmd.GetContent()
 
-	log.Printf("executing script %s (request_id: %s, filename: %s)", scriptID, requestID, filename)
+	slog.Info("executing script", "script_id", scriptID, "request_id", requestID, "filename", filename)
 
 	reportResult := func(success bool, exitCode int32, stdout, stderr, errMsg string) {
 		_, err := client.ReportScriptExecutionResult(ctx, connect.NewRequest(&v1.ReportScriptExecutionResultRequest{
@@ -45,7 +45,7 @@ func handleExecuteScript(ctx context.Context, client taskguildv1connect.AgentMan
 			ErrorMessage: errMsg,
 		}))
 		if err != nil {
-			log.Printf("failed to report script execution result: %v", err)
+			slog.Error("failed to report script execution result", "request_id", requestID, "error", err)
 		}
 	}
 
@@ -57,7 +57,7 @@ func handleExecuteScript(ctx context.Context, client taskguildv1connect.AgentMan
 	scriptTracker.mu.Lock()
 	if scriptTracker.reject {
 		scriptTracker.mu.Unlock()
-		log.Printf("script %s rejected: agent is shutting down for hot reload (request_id: %s)", filename, requestID)
+		slog.Warn("script rejected: agent is shutting down for hot reload", "filename", filename, "request_id", requestID)
 		reportResult(false, -1, "", "", "script execution rejected: agent is shutting down for hot reload")
 		return
 	}
@@ -123,12 +123,12 @@ func handleExecuteScript(ctx context.Context, client taskguildv1connect.AgentMan
 		if exitErr, ok := cmdErr.(*exec.ExitError); ok {
 			exitCode = int32(exitErr.ExitCode())
 		}
-		log.Printf("script %s failed (exit_code: %d, request_id: %s)", filename, exitCode, requestID)
+		slog.Error("script failed", "filename", filename, "exit_code", exitCode, "request_id", requestID)
 		reportResult(false, exitCode, stdout, stderr, "")
 		return
 	}
 
-	log.Printf("script %s succeeded (request_id: %s)", filename, requestID)
+	slog.Info("script succeeded", "filename", filename, "request_id", requestID)
 	reportResult(true, 0, stdout, stderr, "")
 }
 
@@ -228,6 +228,6 @@ func flushOutputChunk(
 		StderrChunk: stderrChunk,
 	}))
 	if err != nil {
-		log.Printf("failed to send output chunk (request_id: %s): %v", requestID, err)
+		slog.Error("failed to send output chunk", "request_id", requestID, "error", err)
 	}
 }

--- a/backend/cmd/taskguild-agent/hooks.go
+++ b/backend/cmd/taskguild-agent/hooks.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,6 +17,7 @@ import (
 	claudeagent "github.com/kazz187/claude-agent-sdk-go"
 	v1 "github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1"
 	"github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1/taskguildv1connect"
+	"github.com/kazz187/taskguild/backend/pkg/clog"
 )
 
 // hookEntry represents a resolved hook from metadata.
@@ -35,6 +36,8 @@ type hookEntry struct {
 // If taskClient is provided, hook results containing TASK_METADATA directives
 // will be used to update the task's metadata.
 func executeHooks(ctx context.Context, taskID string, trigger string, metadata map[string]string, workDir string, taskClient taskguildv1connect.TaskServiceClient, tl *taskLogger) {
+	logger := clog.LoggerFromContext(ctx)
+
 	hooksJSON := metadata["_hooks"]
 	if hooksJSON == "" {
 		return
@@ -42,7 +45,7 @@ func executeHooks(ctx context.Context, taskID string, trigger string, metadata m
 
 	var hooks []hookEntry
 	if err := json.Unmarshal([]byte(hooksJSON), &hooks); err != nil {
-		log.Printf("[task:%s] failed to parse _hooks metadata: %v", taskID, err)
+		logger.Error("failed to parse _hooks metadata", "error", err)
 		return
 	}
 
@@ -61,10 +64,10 @@ func executeHooks(ctx context.Context, taskID string, trigger string, metadata m
 		return
 	}
 
-	log.Printf("[task:%s] executing %d hook(s) for trigger %s", taskID, len(filtered), trigger)
+	logger.Info("executing hooks", "count", len(filtered), "trigger", trigger)
 
 	for _, h := range filtered {
-		log.Printf("[task:%s] running hook %q (id=%s, skill=%s)", taskID, h.Name, h.ID, h.SkillID)
+		logger.Info("running hook", "name", h.Name, "hook_id", h.ID, "skill_id", h.SkillID)
 		if tl != nil {
 			tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_HOOK, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
 				fmt.Sprintf("Executing hook: %s (%s)", h.Name, trigger), nil)
@@ -83,15 +86,15 @@ func executeHooks(ctx context.Context, taskID string, trigger string, metadata m
 		cancel()
 
 		if err != nil {
-			log.Printf("[task:%s] hook %q failed: %v", taskID, h.Name, err)
+			logger.Error("hook failed", "name", h.Name, "error", err)
 			continue
 		}
 		if result.Result != nil && result.Result.IsError {
-			log.Printf("[task:%s] hook %q returned error: %s", taskID, h.Name, result.Result.Result)
+			logger.Error("hook returned error", "name", h.Name, "result", result.Result.Result)
 			continue
 		}
 
-		log.Printf("[task:%s] hook %q completed successfully", taskID, h.Name)
+		logger.Info("hook completed successfully", "name", h.Name)
 
 		// Parse TASK_METADATA directives from hook output and update the task.
 		if taskClient != nil && result.Result != nil {
@@ -106,6 +109,8 @@ var taskMetadataRegex = regexp.MustCompile(`(?m)^TASK_METADATA:\s*(\S+?)=(.+)$`)
 // applyHookMetadata extracts TASK_METADATA directives from hook output and
 // updates the task's metadata via the TaskService API.
 func applyHookMetadata(ctx context.Context, taskID string, output string, taskClient taskguildv1connect.TaskServiceClient) {
+	logger := clog.LoggerFromContext(ctx)
+
 	matches := taskMetadataRegex.FindAllStringSubmatch(output, -1)
 	if len(matches) == 0 {
 		return
@@ -116,7 +121,7 @@ func applyHookMetadata(ctx context.Context, taskID string, output string, taskCl
 		key := strings.TrimSpace(m[1])
 		value := strings.TrimSpace(m[2])
 		meta[key] = value
-		log.Printf("[task:%s] hook metadata: %s=%s", taskID, key, value)
+		logger.Debug("hook metadata", "key", key, "value", value)
 	}
 
 	_, err := taskClient.UpdateTask(ctx, connect.NewRequest(&v1.UpdateTaskRequest{
@@ -124,7 +129,7 @@ func applyHookMetadata(ctx context.Context, taskID string, output string, taskCl
 		Metadata: meta,
 	}))
 	if err != nil {
-		log.Printf("[task:%s] failed to update task metadata from hook: %v", taskID, err)
+		logger.Error("failed to update task metadata from hook", "error", err)
 	}
 }
 
@@ -167,6 +172,8 @@ func slugifyASCII(s string) string {
 // ensureWorktree creates a git worktree if the directory does not already exist.
 // It uses "git worktree add" with a new branch based on HEAD.
 func ensureWorktree(ctx context.Context, workDir, worktreeName, taskID string) (string, error) {
+	logger := clog.LoggerFromContext(ctx)
+
 	wtDir := filepath.Join(workDir, ".claude", "worktrees", worktreeName)
 	if info, err := os.Stat(wtDir); err == nil && info.IsDir() {
 		return wtDir, nil
@@ -187,7 +194,7 @@ func ensureWorktree(ctx context.Context, workDir, worktreeName, taskID string) (
 			return "", fmt.Errorf("git worktree add: %w: %s / %s", err2, out, out2)
 		}
 	}
-	log.Printf("[task:%s] created worktree at %s (branch: %s)", taskID, wtDir, branchName)
+	logger.Info("created worktree", "worktree_dir", wtDir, "branch", branchName)
 	return wtDir, nil
 }
 
@@ -242,7 +249,7 @@ func translateToEnglishSlug(ctx context.Context, title, workDir string) string {
 
 	result, err := claudeagent.RunQuerySync(timeoutCtx, prompt, opts)
 	if err != nil || result.Result == nil {
-		log.Printf("translateToEnglishSlug failed: %v", err)
+		slog.Warn("translateToEnglishSlug failed", "error", err)
 		return ""
 	}
 

--- a/backend/cmd/taskguild-agent/interaction.go
+++ b/backend/cmd/taskguild-agent/interaction.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -11,6 +11,7 @@ import (
 	claudeagent "github.com/kazz187/claude-agent-sdk-go"
 	v1 "github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1"
 	"github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1/taskguildv1connect"
+	"github.com/kazz187/taskguild/backend/pkg/clog"
 )
 
 // interactionWaiter dispatches streamed interaction responses to waiting goroutines.
@@ -74,6 +75,8 @@ func (w *interactionWaiter) Deliver(inter *v1.Interaction) {
 // responses that may have been missed during disconnections.
 // It returns only when ctx is cancelled (task finished).
 func runInteractionListener(ctx context.Context, client taskguildv1connect.AgentManagerServiceClient, interClient taskguildv1connect.InteractionServiceClient, taskID string, waiter *interactionWaiter) {
+	logger := clog.LoggerFromContext(ctx)
+
 	// Start a polling fallback that periodically checks pending interactions.
 	// This ensures responses are delivered even if the stream is temporarily down.
 	go runInteractionPoller(ctx, client, taskID, waiter)
@@ -91,9 +94,9 @@ func runInteractionListener(ctx context.Context, client taskguildv1connect.Agent
 			return
 		}
 		if err != nil {
-			log.Printf("[task:%s] interaction stream error: %v, reconnecting in %s...", taskID, err, backoff)
+			logger.Warn("interaction stream error, reconnecting", "error", err, "backoff", backoff)
 		} else {
-			log.Printf("[task:%s] interaction stream ended, reconnecting in %s...", taskID, backoff)
+			logger.Info("interaction stream ended, reconnecting", "backoff", backoff)
 		}
 
 		select {
@@ -113,6 +116,8 @@ func runInteractionListener(ctx context.Context, client taskguildv1connect.Agent
 // runInteractionStream connects once and processes interaction events until
 // the stream ends or ctx is cancelled. Returns the stream error (if any).
 func runInteractionStream(ctx context.Context, interClient taskguildv1connect.InteractionServiceClient, taskID string, waiter *interactionWaiter) error {
+	logger := clog.LoggerFromContext(ctx)
+
 	stream, err := interClient.SubscribeInteractions(ctx, connect.NewRequest(&v1.SubscribeInteractionsRequest{
 		TaskId: taskID,
 	}))
@@ -121,7 +126,7 @@ func runInteractionStream(ctx context.Context, interClient taskguildv1connect.In
 	}
 	defer stream.Close()
 
-	log.Printf("[task:%s] interaction stream connected", taskID)
+	logger.Debug("interaction stream connected")
 
 	for stream.Receive() {
 		deliverInteraction(taskID, stream.Msg().GetInteraction(), waiter, "stream")
@@ -186,12 +191,13 @@ func deliverInteraction(taskID string, inter *v1.Interaction, waiter *interactio
 	if inter == nil {
 		return
 	}
+	logger := slog.Default().With("task_id", taskID)
 	switch inter.GetStatus() {
 	case v1.InteractionStatus_INTERACTION_STATUS_RESPONDED:
-		log.Printf("[task:%s] interaction %s responded via %s", taskID, inter.GetId(), source)
+		logger.Debug("interaction responded", "interaction_id", inter.GetId(), "source", source)
 		waiter.Deliver(inter)
 	case v1.InteractionStatus_INTERACTION_STATUS_EXPIRED:
-		log.Printf("[task:%s] interaction %s expired via %s", taskID, inter.GetId(), source)
+		logger.Debug("interaction expired", "interaction_id", inter.GetId(), "source", source)
 		waiter.Deliver(inter)
 	}
 }
@@ -213,6 +219,8 @@ func waitForUserResponse(
 	claudeOutput string,
 	waiter *interactionWaiter,
 ) (string, error) {
+	logger := clog.LoggerFromContext(ctx)
+
 	resp, err := client.CreateInteraction(ctx, connect.NewRequest(&v1.CreateInteractionRequest{
 		TaskId:      taskID,
 		AgentId:     agentManagerID,
@@ -225,7 +233,7 @@ func waitForUserResponse(
 	}
 
 	interactionID := resp.Msg.GetInteraction().GetId()
-	log.Printf("[task:%s] waiting for user response (interaction: %s)", taskID, interactionID)
+	logger.Info("waiting for user response", "interaction_id", interactionID)
 
 	ch := waiter.Register(interactionID)
 	defer waiter.Unregister(interactionID)
@@ -234,19 +242,19 @@ func waitForUserResponse(
 	case <-ctx.Done():
 		return "", ctx.Err()
 	case <-time.After(waitForUserResponseTimeout):
-		log.Printf("[task:%s] user response timeout (interaction: %s), expiring", taskID, interactionID)
+		logger.Warn("user response timeout, expiring interaction", "interaction_id", interactionID)
 		// Expire the pending interaction so it disappears from the UI.
 		if _, expErr := interClient.ExpireInteraction(ctx, connect.NewRequest(&v1.ExpireInteractionRequest{
 			Id: interactionID,
 		})); expErr != nil {
-			log.Printf("[task:%s] failed to expire interaction %s: %v", taskID, interactionID, expErr)
+			logger.Error("failed to expire interaction", "interaction_id", interactionID, "error", expErr)
 		}
 		return "", errWaitTimeout
 	case inter := <-ch:
 		if inter.GetStatus() == v1.InteractionStatus_INTERACTION_STATUS_EXPIRED {
 			return "", fmt.Errorf("interaction expired")
 		}
-		log.Printf("[task:%s] user responded to interaction %s", taskID, interactionID)
+		logger.Info("user responded to interaction", "interaction_id", interactionID)
 		return inter.GetResponse(), nil
 	}
 }
@@ -322,15 +330,17 @@ func handleAskUserQuestion(
 	input map[string]any,
 	waiter *interactionWaiter,
 ) (claudeagent.PermissionResult, error) {
+	logger := clog.LoggerFromContext(ctx)
+
 	questionsRaw, ok := input["questions"]
 	if !ok {
-		log.Printf("[task:%s] AskUserQuestion: no questions field", taskID)
+		logger.Warn("AskUserQuestion: no questions field")
 		return claudeagent.PermissionResultAllow{}, nil
 	}
 
 	questionsSlice, ok := questionsRaw.([]any)
 	if !ok {
-		log.Printf("[task:%s] AskUserQuestion: questions is not an array", taskID)
+		logger.Warn("AskUserQuestion: questions is not an array")
 		return claudeagent.PermissionResultAllow{}, nil
 	}
 
@@ -339,7 +349,7 @@ func handleAskUserQuestion(
 	for i, qRaw := range questionsSlice {
 		qMap, ok := qRaw.(map[string]any)
 		if !ok {
-			log.Printf("[task:%s] AskUserQuestion: question[%d] is not a map", taskID, i)
+			logger.Warn("AskUserQuestion: question is not a map", "index", i)
 			continue
 		}
 
@@ -396,7 +406,7 @@ func handleAskUserQuestion(
 		}
 
 		interactionID := resp.Msg.GetInteraction().GetId()
-		log.Printf("[task:%s] AskUserQuestion: waiting for answer to question %d (interaction: %s)", taskID, i, interactionID)
+		logger.Info("AskUserQuestion: waiting for answer", "question_index", i, "interaction_id", interactionID)
 
 		ch := waiter.Register(interactionID)
 
@@ -427,7 +437,7 @@ func handleAskUserQuestion(
 			}
 
 			followID := followResp.Msg.GetInteraction().GetId()
-			log.Printf("[task:%s] AskUserQuestion: waiting for free-text answer (interaction: %s)", taskID, followID)
+			logger.Info("AskUserQuestion: waiting for free-text answer", "interaction_id", followID)
 
 			followCh := waiter.Register(followID)
 
@@ -445,7 +455,7 @@ func handleAskUserQuestion(
 		}
 
 		answers[questionText] = selectedAnswer
-		log.Printf("[task:%s] AskUserQuestion: question %d answered: %q", taskID, i, selectedAnswer)
+		logger.Debug("AskUserQuestion: question answered", "question_index", i, "answer", selectedAnswer)
 	}
 
 	// Inject answers into the input and return as UpdatedInput.
@@ -472,21 +482,23 @@ func handlePermissionRequest(
 	toolCtx claudeagent.ToolPermissionContext,
 	permCache *permissionCache,
 ) (claudeagent.PermissionResult, error) {
+	logger := clog.LoggerFromContext(ctx)
+
 	// bypassPermissions: allow everything
 	if permMode == claudeagent.PermissionModeBypassPermissions {
-		log.Printf("[task:%s] auto-allowing %s (bypassPermissions)", taskID, toolName)
+		logger.Debug("auto-allowing tool (bypassPermissions)", "tool", toolName)
 		return claudeagent.PermissionResultAllow{}, nil
 	}
 
 	// Read-only tools: always allowed
 	if readOnlyTools[toolName] {
-		log.Printf("[task:%s] auto-allowing read-only tool %s", taskID, toolName)
+		logger.Debug("auto-allowing read-only tool", "tool", toolName)
 		return claudeagent.PermissionResultAllow{}, nil
 	}
 
 	// Edit tools: allowed in acceptEdits mode
 	if editTools[toolName] && permMode == claudeagent.PermissionModeAcceptEdits {
-		log.Printf("[task:%s] auto-allowing edit tool %s (acceptEdits)", taskID, toolName)
+		logger.Debug("auto-allowing edit tool (acceptEdits)", "tool", toolName)
 		return claudeagent.PermissionResultAllow{}, nil
 	}
 
@@ -497,7 +509,7 @@ func handlePermissionRequest(
 
 	// Check permission cache: auto-allow if a matching "always allow" rule exists.
 	if permCache != nil && permCache.Check(toolName, input) {
-		log.Printf("[task:%s] auto-allowing %s (permission cache hit)", taskID, toolName)
+		logger.Debug("auto-allowing tool (permission cache hit)", "tool", toolName)
 		return claudeagent.PermissionResultAllow{}, nil
 	}
 
@@ -520,7 +532,7 @@ func handlePermissionRequest(
 	}
 
 	interactionID := resp.Msg.GetInteraction().GetId()
-	log.Printf("[task:%s] waiting for permission response (interaction: %s, tool: %s)", taskID, interactionID, toolName)
+	logger.Info("waiting for permission response", "interaction_id", interactionID, "tool", toolName)
 
 	ch := waiter.Register(interactionID)
 	defer waiter.Unregister(interactionID)
@@ -530,16 +542,16 @@ func handlePermissionRequest(
 		return claudeagent.PermissionResultDeny{Message: "context cancelled"}, nil
 	case inter := <-ch:
 		if inter.GetStatus() == v1.InteractionStatus_INTERACTION_STATUS_EXPIRED {
-			log.Printf("[task:%s] permission request expired for %s", taskID, toolName)
+			logger.Info("permission request expired", "tool", toolName)
 			return claudeagent.PermissionResultDeny{Message: "permission request expired"}, nil
 		}
 		switch inter.GetResponse() {
 		case "allow":
-			log.Printf("[task:%s] permission granted for %s", taskID, toolName)
+			logger.Info("permission granted", "tool", toolName)
 			return claudeagent.PermissionResultAllow{}, nil
 		case "always_allow":
 			updates := buildPermissionUpdate(toolName, input, toolCtx.Suggestions)
-			log.Printf("[task:%s] permission granted (always allow) for %s, updating %d rule(s)", taskID, toolName, len(updates))
+			logger.Info("permission granted (always allow)", "tool", toolName, "rules", len(updates))
 
 			// Persist to cache and backend so future calls are auto-allowed.
 			if permCache != nil {
@@ -551,7 +563,7 @@ func handlePermissionRequest(
 				UpdatedPermissions: updates,
 			}, nil
 		default:
-			log.Printf("[task:%s] permission denied for %s", taskID, toolName)
+			logger.Info("permission denied", "tool", toolName)
 			return claudeagent.PermissionResultDeny{Message: "user denied permission"}, nil
 		}
 	}

--- a/backend/cmd/taskguild-agent/permission_cache.go
+++ b/backend/cmd/taskguild-agent/permission_cache.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 	"sync"
 
@@ -39,7 +39,7 @@ func (c *permissionCache) Update(rules []string) {
 	defer c.mu.Unlock()
 	c.allowRules = make([]string, len(rules))
 	copy(c.allowRules, rules)
-	log.Printf("permission cache updated: %d allow rules", len(rules))
+	slog.Info("permission cache updated", "allow_rules", len(rules))
 }
 
 // Check returns true if the given tool call is allowed by any cached rule.
@@ -68,7 +68,7 @@ func (c *permissionCache) AddAndSync(ctx context.Context, newRules []string) {
 	c.allowRules = unionDedupRules(c.allowRules, newRules)
 	c.mu.Unlock()
 
-	log.Printf("permission cache: added %d rule(s), syncing to backend", len(newRules))
+	slog.Info("permission cache: added rules, syncing to backend", "new_rules", len(newRules))
 
 	// Sync to backend – send only the new rules; the backend merges them.
 	resp, err := c.client.SyncPermissions(ctx, connect.NewRequest(&v1.SyncPermissionsRequest{
@@ -76,7 +76,7 @@ func (c *permissionCache) AddAndSync(ctx context.Context, newRules []string) {
 		LocalAllow:  newRules,
 	}))
 	if err != nil {
-		log.Printf("permission cache: failed to sync rules to backend: %v", err)
+		slog.Error("permission cache: failed to sync rules to backend", "error", err)
 		return
 	}
 
@@ -86,7 +86,7 @@ func (c *permissionCache) AddAndSync(ctx context.Context, newRules []string) {
 	c.allowRules = merged.GetAllow()
 	c.mu.Unlock()
 
-	log.Printf("permission cache: backend sync complete, allow=%d", len(merged.GetAllow()))
+	slog.Info("permission cache: backend sync complete", "allow", len(merged.GetAllow()))
 }
 
 // extractRuleStrings converts PermissionUpdate objects into human-readable

--- a/backend/cmd/taskguild-agent/run.go
+++ b/backend/cmd/taskguild-agent/run.go
@@ -3,8 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -39,6 +38,8 @@ type config struct {
 	MaxConcurrentTasks int
 	WorkDir            string
 	ProjectName        string
+	Env                string
+	LogLevel           string
 }
 
 func loadConfig() (*config, error) {
@@ -47,6 +48,8 @@ func loadConfig() (*config, error) {
 		AgentManagerID:     ulid.Make().String(),
 		MaxConcurrentTasks: 10,
 		WorkDir:            ".",
+		Env:                "local",
+		LogLevel:           "debug",
 	}
 
 	if v := os.Getenv("TASKGUILD_SERVER_URL"); v != "" {
@@ -85,6 +88,13 @@ func loadConfig() (*config, error) {
 		}
 	}
 
+	if v := os.Getenv("TASKGUILD_ENV"); v != "" {
+		cfg.Env = v
+	}
+	if v := os.Getenv("TASKGUILD_LOG_LEVEL"); v != "" {
+		cfg.LogLevel = v
+	}
+
 	return cfg, nil
 }
 
@@ -92,22 +102,32 @@ func loadConfig() (*config, error) {
 // It contains the original main() logic: connects to the TaskGuild server,
 // subscribes for task assignments, and executes tasks.
 func runAgent() {
-	// Set up log file: write to both stderr and file.
-	logFile, err := os.OpenFile("agent-manager.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-	if err != nil {
-		log.Fatalf("failed to open log file: %v", err)
-	}
-	defer logFile.Close()
-	log.SetOutput(io.MultiWriter(os.Stderr, logFile))
-	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
-
 	cfg, err := loadConfig()
 	if err != nil {
-		log.Fatalf("configuration error: %v", err)
+		fmt.Fprintf(os.Stderr, "configuration error: %v\n", err)
+		os.Exit(1)
 	}
 
-	log.Printf("agent-manager starting (id: %s, server: %s, max_tasks: %d, work_dir: %s, project_name: %s)",
-		cfg.AgentManagerID, cfg.ServerURL, cfg.MaxConcurrentTasks, cfg.WorkDir, cfg.ProjectName)
+	// Initialize slog.
+	var slogLevel slog.Level
+	if err := slogLevel.UnmarshalText([]byte(cfg.LogLevel)); err != nil {
+		slogLevel = slog.LevelDebug
+	}
+	var handler slog.Handler
+	if cfg.Env == "local" {
+		handler = slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slogLevel})
+	} else {
+		handler = slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slogLevel})
+	}
+	slog.SetDefault(slog.New(handler))
+
+	slog.Info("agent-manager starting",
+		"agent_manager_id", cfg.AgentManagerID,
+		"server_url", cfg.ServerURL,
+		"max_tasks", cfg.MaxConcurrentTasks,
+		"work_dir", cfg.WorkDir,
+		"project_name", cfg.ProjectName,
+	)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -117,7 +137,7 @@ func runAgent() {
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		sig := <-sigCh
-		log.Printf("received signal %v, shutting down...", sig)
+		slog.Info("received signal, shutting down", "signal", sig)
 		cancel()
 	}()
 
@@ -129,12 +149,12 @@ func runAgent() {
 	signal.Notify(usr1Ch, syscall.SIGUSR1)
 	go func() {
 		<-usr1Ch
-		log.Println("received SIGUSR1 (hot reload), waiting for running scripts to complete...")
+		slog.Info("received SIGUSR1 (hot reload), waiting for running scripts to complete")
 		scriptTracker.mu.Lock()
 		scriptTracker.reject = true
 		scriptTracker.mu.Unlock()
 		scriptTracker.wg.Wait()
-		log.Println("all scripts completed, shutting down for hot reload restart")
+		slog.Info("all scripts completed, shutting down for hot reload restart")
 		cancel()
 	}()
 
@@ -197,7 +217,7 @@ func runAgent() {
 			break
 		}
 		if err != nil {
-			log.Printf("subscribe stream error: %v, reconnecting in %s...", err, subscribeBackoff)
+			slog.Error("subscribe stream error, reconnecting", "error", err, "backoff", subscribeBackoff)
 			select {
 			case <-time.After(subscribeBackoff):
 			case <-ctx.Done():
@@ -213,17 +233,17 @@ func runAgent() {
 		}
 	}
 
-	log.Println("waiting for active tasks to finish...")
+	slog.Info("waiting for active tasks to finish")
 	// Cancel all active tasks
 	mu.Lock()
 	for taskID, cancelFn := range activeTasks {
-		log.Printf("cancelling task %s", taskID)
+		slog.Info("cancelling task", "task_id", taskID)
 		cancelFn()
 	}
 	mu.Unlock()
 
 	wg.Wait()
-	log.Println("agent-manager stopped")
+	slog.Info("agent-manager stopped")
 }
 
 func runSubscribeLoop(
@@ -248,7 +268,7 @@ func runSubscribeLoop(
 	mu.Unlock()
 
 	if len(activeTaskIDs) > 0 {
-		log.Printf("reconnecting with %d active task(s): %v", len(activeTaskIDs), activeTaskIDs)
+		slog.Info("reconnecting with active tasks", "count", len(activeTaskIDs), "task_ids", activeTaskIDs)
 	}
 
 	stream, err := client.Subscribe(ctx, connect.NewRequest(&v1.AgentManagerSubscribeRequest{
@@ -262,7 +282,7 @@ func runSubscribeLoop(
 	}
 	defer stream.Close()
 
-	log.Println("subscribe stream connected")
+	slog.Info("subscribe stream connected")
 
 	for stream.Receive() {
 		cmd := stream.Msg()
@@ -270,7 +290,7 @@ func runSubscribeLoop(
 		// Skip empty commands (e.g. caused by proxy-injected frames or
 		// partial envelope reads from intermediaries).
 		if cmd.GetCommand() == nil {
-			log.Println("skipping empty command (nil oneof)")
+			slog.Debug("skipping empty command (nil oneof)")
 			continue
 		}
 
@@ -278,13 +298,13 @@ func runSubscribeLoop(
 		case *v1.AgentCommand_TaskAvailable:
 			taskAvail := c.TaskAvailable
 			taskID := taskAvail.GetTaskId()
-			log.Printf("task available: %s (title: %s)", taskID, taskAvail.GetTitle())
+			slog.Info("task available", "task_id", taskID, "title", taskAvail.GetTitle())
 
 			// Skip if this task is already running (prevents semaphore deadlock on re-assignment).
 			mu.Lock()
 			if prevCancel, ok := activeTasks[taskID]; ok {
 				mu.Unlock()
-				log.Printf("task %s already active, cancelling previous run and re-claiming", taskID)
+				slog.Info("task already active, cancelling previous run and re-claiming", "task_id", taskID)
 				prevCancel()
 			} else {
 				mu.Unlock()
@@ -296,15 +316,15 @@ func runSubscribeLoop(
 				AgentManagerId: cfg.AgentManagerID,
 			}))
 			if err != nil {
-				log.Printf("failed to claim task %s: %v", taskID, err)
+				slog.Error("failed to claim task", "task_id", taskID, "error", err)
 				continue
 			}
 			if !claimResp.Msg.GetSuccess() {
-				log.Printf("task %s already claimed by another agent", taskID)
+				slog.Info("task already claimed by another agent", "task_id", taskID)
 				continue
 			}
 
-			log.Printf("claimed task %s", taskID)
+			slog.Info("claimed task", "task_id", taskID)
 			instructions := claimResp.Msg.GetInstructions()
 			metadata := claimResp.Msg.GetMetadata()
 
@@ -336,43 +356,49 @@ func runSubscribeLoop(
 
 		case *v1.AgentCommand_ListWorktrees:
 			listCmd := c.ListWorktrees
-			log.Printf("received list worktrees command (request_id: %s)", listCmd.GetRequestId())
+			slog.Info("received list worktrees command", "request_id", listCmd.GetRequestId())
 			go handleListWorktrees(ctx, client, cfg, listCmd.GetRequestId())
 
 		case *v1.AgentCommand_DeleteWorktree:
 			deleteCmd := c.DeleteWorktree
-			log.Printf("received delete worktree command (request_id: %s, name: %s, force: %v)",
-				deleteCmd.GetRequestId(), deleteCmd.GetWorktreeName(), deleteCmd.GetForce())
+			slog.Info("received delete worktree command",
+				"request_id", deleteCmd.GetRequestId(),
+				"worktree_name", deleteCmd.GetWorktreeName(),
+				"force", deleteCmd.GetForce(),
+			)
 			go handleDeleteWorktree(ctx, client, cfg, deleteCmd)
 
 		case *v1.AgentCommand_GitPullMain:
 			pullCmd := c.GitPullMain
-			log.Printf("received git pull main command (request_id: %s)", pullCmd.GetRequestId())
+			slog.Info("received git pull main command", "request_id", pullCmd.GetRequestId())
 			go handleGitPullMain(ctx, client, cfg, pullCmd.GetRequestId())
 
 		case *v1.AgentCommand_SyncAgents:
-			log.Println("received sync agents command, re-syncing...")
+			slog.Info("received sync agents command, re-syncing")
 			syncAgents(ctx, client, cfg)
 
 		case *v1.AgentCommand_SyncPermissions:
-			log.Println("received sync permissions command, re-syncing...")
+			slog.Info("received sync permissions command, re-syncing")
 			syncPermissions(ctx, client, cfg, permCache)
 
 		case *v1.AgentCommand_SyncScripts:
-			log.Println("received sync scripts command, re-syncing...")
+			slog.Info("received sync scripts command, re-syncing")
 			syncScripts(ctx, client, cfg)
 
 		case *v1.AgentCommand_ExecuteScript:
 			execCmd := c.ExecuteScript
-			log.Printf("received execute script command (request_id: %s, script_id: %s, filename: %s)",
-				execCmd.GetRequestId(), execCmd.GetScriptId(), execCmd.GetFilename())
+			slog.Info("received execute script command",
+				"request_id", execCmd.GetRequestId(),
+				"script_id", execCmd.GetScriptId(),
+				"filename", execCmd.GetFilename(),
+			)
 			go handleExecuteScript(ctx, client, cfg, execCmd)
 
 		case *v1.AgentCommand_CancelTask:
 			cancelCmd := c.CancelTask
 			taskID := cancelCmd.GetTaskId()
 			reason := cancelCmd.GetReason()
-			log.Printf("cancel request for task %s: %s", taskID, reason)
+			slog.Info("cancel request for task", "task_id", taskID, "reason", reason)
 
 			mu.Lock()
 			if cancelFn, ok := activeTasks[taskID]; ok {
@@ -383,13 +409,13 @@ func runSubscribeLoop(
 		case *v1.AgentCommand_AssignTask:
 			assignCmd := c.AssignTask
 			taskID := assignCmd.GetTaskId()
-			log.Printf("direct task assignment: %s", taskID)
+			slog.Info("direct task assignment", "task_id", taskID)
 
 			// Cancel previous run if the same task is re-assigned.
 			mu.Lock()
 			if prevCancel, ok := activeTasks[taskID]; ok {
 				mu.Unlock()
-				log.Printf("task %s already active, cancelling previous run for re-assignment", taskID)
+				slog.Info("task already active, cancelling previous run for re-assignment", "task_id", taskID)
 				prevCancel()
 			} else {
 				mu.Unlock()
@@ -426,8 +452,9 @@ func runSubscribeLoop(
 		case *v1.AgentCommand_InteractionResponse:
 			// Interaction responses are handled per-task via SubscribeInteractions.
 			// Log and ignore if received on the global subscribe stream.
-			log.Printf("received interaction_response on subscribe stream (interaction_id: %s), ignoring",
-				c.InteractionResponse.GetInteractionId())
+			slog.Debug("received interaction_response on subscribe stream, ignoring",
+				"interaction_id", c.InteractionResponse.GetInteractionId(),
+			)
 
 		case *v1.AgentCommand_Ping:
 			// Server-side keepalive ping — silently ignore.
@@ -438,7 +465,7 @@ func runSubscribeLoop(
 			if cmd.GetCommand() == nil {
 				continue
 			}
-			log.Printf("unknown command type: %T", cmd.GetCommand())
+			slog.Warn("unknown command type", "type", fmt.Sprintf("%T", cmd.GetCommand()))
 		}
 	}
 
@@ -461,7 +488,7 @@ func heartbeat(ctx context.Context, client taskguildv1connect.AgentManagerServic
 				AgentManagerId: agentManagerID,
 			}))
 			if err != nil {
-				log.Printf("heartbeat error: %v", err)
+				slog.Warn("heartbeat error", "error", err)
 			}
 		}
 	}
@@ -474,9 +501,9 @@ func handleListWorktrees(ctx context.Context, client taskguildv1connect.AgentMan
 	entries, err := os.ReadDir(worktreesDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("no worktrees directory found at %s", worktreesDir)
+			slog.Info("no worktrees directory found", "path", worktreesDir)
 		} else {
-			log.Printf("failed to read worktrees directory: %v", err)
+			slog.Error("failed to read worktrees directory", "error", err)
 		}
 		// Report empty list so frontend knows the scan completed.
 		_, _ = client.ReportWorktreeList(ctx, connect.NewRequest(&v1.ReportWorktreeListRequest{
@@ -538,9 +565,9 @@ func handleListWorktrees(ctx context.Context, client taskguildv1connect.AgentMan
 		Worktrees:   worktrees,
 	}))
 	if err != nil {
-		log.Printf("failed to report worktree list: %v", err)
+		slog.Error("failed to report worktree list", "error", err)
 	} else {
-		log.Printf("reported %d worktrees (request_id: %s)", len(worktrees), requestID)
+		slog.Info("reported worktrees", "count", len(worktrees), "request_id", requestID)
 	}
 }
 
@@ -559,7 +586,7 @@ func handleDeleteWorktree(ctx context.Context, client taskguildv1connect.AgentMa
 			ErrorMessage: errMsg,
 		}))
 		if err != nil {
-			log.Printf("failed to report worktree delete result: %v", err)
+			slog.Error("failed to report worktree delete result", "error", err)
 		}
 	}
 
@@ -610,11 +637,11 @@ func handleDeleteWorktree(ctx context.Context, client taskguildv1connect.AgentMa
 	deleteBranchCmd := exec.CommandContext(ctx, "git", "branch", "-D", branchName)
 	deleteBranchCmd.Dir = cfg.WorkDir
 	if out, err := deleteBranchCmd.CombinedOutput(); err != nil {
-		log.Printf("warning: failed to delete branch %s: %v: %s", branchName, err, strings.TrimSpace(string(out)))
+		slog.Warn("failed to delete branch", "branch", branchName, "error", err, "output", strings.TrimSpace(string(out)))
 		// Not fatal – worktree is already removed.
 	}
 
-	log.Printf("deleted worktree %s (branch: %s, force: %v)", worktreeName, branchName, force)
+	slog.Info("deleted worktree", "worktree_name", worktreeName, "branch", branchName, "force", force)
 	reportResult(true, "")
 }
 
@@ -629,7 +656,7 @@ func handleGitPullMain(ctx context.Context, client taskguildv1connect.AgentManag
 			ErrorMessage: errMsg,
 		}))
 		if err != nil {
-			log.Printf("failed to report git pull main result: %v", err)
+			slog.Error("failed to report git pull main result", "error", err)
 		}
 	}
 
@@ -639,12 +666,12 @@ func handleGitPullMain(ctx context.Context, client taskguildv1connect.AgentManag
 	output := strings.TrimSpace(string(out))
 
 	if err != nil {
-		log.Printf("git pull origin main failed: %v: %s", err, output)
+		slog.Error("git pull origin main failed", "error", err, "output", output)
 		reportResult(false, output, fmt.Sprintf("git pull origin main failed: %v", err))
 		return
 	}
 
-	log.Printf("git pull origin main succeeded: %s", output)
+	slog.Info("git pull origin main succeeded", "output", output)
 	reportResult(true, output, "")
 }
 

--- a/backend/cmd/taskguild-agent/runner.go
+++ b/backend/cmd/taskguild-agent/runner.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +14,7 @@ import (
 	claudeagent "github.com/kazz187/claude-agent-sdk-go"
 	v1 "github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1"
 	"github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1/taskguildv1connect"
+	"github.com/kazz187/taskguild/backend/pkg/clog"
 )
 
 func init() {
@@ -59,6 +60,10 @@ func runTask(
 	workDir string,
 	permCache *permissionCache,
 ) {
+	// Create task-scoped logger and embed in context.
+	logger := slog.Default().With("task_id", taskID)
+	ctx = clog.ContextWithLogger(ctx, logger)
+
 	reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_RUNNING, "starting task")
 
 	// Initialize task logger for structured log streaming.
@@ -78,7 +83,7 @@ func runTask(
 	// Cwd is set to the worktree from the very first turn.
 	if metadata["_use_worktree"] == "true" && worktreeName != "" {
 		if _, err := ensureWorktree(ctx, workDir, worktreeName, taskID); err != nil {
-			log.Printf("[task:%s] WARNING: failed to ensure worktree: %v", taskID, err)
+			logger.Warn("failed to ensure worktree", "error", err)
 		}
 	}
 
@@ -129,38 +134,39 @@ func runTask(
 		opts := buildClaudeOptions(instructions, workDir, metadata, sessionID, worktreeName, client, ctx, taskID, agentManagerID, waiter, permCache, tl)
 		// Override StderrCallback to also send to task logger.
 		opts.StderrCallback = func(line string) {
-			log.Printf("[task:%s] [claude-stderr] %s", taskID, line)
+			logger.Debug("claude-stderr", "line", line)
 			tl.LogStderr(line)
 		}
 
 		tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_TURN_START, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
 			fmt.Sprintf("Turn %d started", turn),
 			map[string]string{"turn": fmt.Sprintf("%d", turn)})
-		log.Printf("[task:%s] === Claude SDK Input (turn %d) ===", taskID, turn)
+		logger.Debug("Claude SDK input", "turn", turn)
 		if turn == 0 {
-			log.Printf("[task:%s] SystemPrompt:\n%s", taskID, instructions)
-			log.Printf("[task:%s] Metadata: %v", taskID, metadata)
-			log.Printf("[task:%s] WorkDir: %s", taskID, workDir)
+			logger.Debug("system prompt", "prompt", instructions)
+			logger.Debug("metadata", "metadata", fmt.Sprintf("%v", metadata))
+			logger.Debug("work directory", "work_dir", workDir)
 		}
-		log.Printf("[task:%s] UserPrompt:\n%s", taskID, prompt)
+		logger.Debug("user prompt", "prompt", prompt)
 		if sessionID != "" {
-			log.Printf("[task:%s] Resume: %s", taskID, sessionID)
+			logger.Debug("resuming session", "session_id", sessionID)
 		}
-		log.Printf("[task:%s] === End Claude SDK Input (turn %d) ===", taskID, turn)
 
 		result, err := claudeagent.RunQuerySync(ctx, prompt, opts)
 
-		log.Printf("[task:%s] === Claude SDK Output (turn %d) ===", taskID, turn)
+		logger.Debug("Claude SDK output", "turn", turn)
 		if err != nil {
-			log.Printf("[task:%s] Error: %v", taskID, err)
+			logger.Error("Claude SDK error", "turn", turn, "error", err)
 		} else if result.Result != nil {
-			log.Printf("[task:%s] IsError: %v", taskID, result.Result.IsError)
-			log.Printf("[task:%s] SessionID: %s", taskID, result.Result.SessionID)
-			log.Printf("[task:%s] Result: %s", taskID, result.Result.Result)
+			logger.Debug("Claude SDK result",
+				"turn", turn,
+				"is_error", result.Result.IsError,
+				"session_id", result.Result.SessionID,
+				"result", result.Result.Result,
+			)
 		} else {
-			log.Printf("[task:%s] Result is nil", taskID)
+			logger.Debug("Claude SDK result is nil", "turn", turn)
 		}
-		log.Printf("[task:%s] === End Claude SDK Output (turn %d) ===", taskID, turn)
 
 		if err != nil {
 			tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_TURN_END, v1.TaskLogLevel_TASK_LOG_LEVEL_ERROR,
@@ -199,7 +205,7 @@ func runTask(
 			// to run 'claude login' to re-authenticate.
 			if isAuthenticationError(errMsg) {
 				authErrMsg := fmt.Sprintf("Authentication failed: %s\nRun 'claude login' to re-authenticate.", errMsg)
-				log.Printf("[task:%s] authentication error detected, not retrying: %s", taskID, errMsg)
+				logger.Error("authentication error detected, not retrying", "error", errMsg)
 				tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_ERROR, v1.TaskLogLevel_TASK_LOG_LEVEL_ERROR,
 					authErrMsg, nil)
 				reportTaskResult(ctx, client, taskID, "", authErrMsg)
@@ -208,11 +214,11 @@ func runTask(
 			}
 
 			consecutiveErrors++
-			log.Printf("[task:%s] error (%d/%d): %s", taskID, consecutiveErrors, maxConsecutiveErrors, errMsg)
+			logger.Error("task error", "consecutive_errors", consecutiveErrors, "max_errors", maxConsecutiveErrors, "error", errMsg)
 
 			// If resume keeps failing, clear session and start fresh.
 			if sessionID != "" && consecutiveErrors >= maxResumeRetries {
-				log.Printf("[task:%s] resume failed %d times, clearing session to start fresh", taskID, consecutiveErrors)
+				logger.Warn("resume failed, clearing session to start fresh", "consecutive_errors", consecutiveErrors)
 				tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_STATUS_CHANGE, v1.TaskLogLevel_TASK_LOG_LEVEL_WARN,
 					"Resume failed, restarting with fresh session", nil)
 				sessionID = ""
@@ -224,7 +230,7 @@ func runTask(
 			}
 
 			if consecutiveErrors >= maxConsecutiveErrors {
-				log.Printf("[task:%s] max consecutive errors reached, giving up", taskID)
+				logger.Error("max consecutive errors reached, giving up")
 				tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_ERROR, v1.TaskLogLevel_TASK_LOG_LEVEL_ERROR,
 					fmt.Sprintf("Max consecutive errors reached, giving up: %s", errMsg), nil)
 				reportTaskResult(ctx, client, taskID, "", errMsg)
@@ -256,7 +262,7 @@ func runTask(
 		// Extract and persist task description updates from agent output.
 		if result.Result != nil {
 			if newDesc := parseTaskDescription(result.Result.Result); newDesc != "" {
-				log.Printf("[task:%s] detected TASK_DESCRIPTION update (turn %d)", taskID, turn)
+				logger.Info("detected TASK_DESCRIPTION update", "turn", turn)
 				saveTaskDescription(ctx, taskClient, taskID, newDesc)
 				// Update local metadata so subsequent prompts reflect the new description.
 				metadata["_task_description"] = newDesc
@@ -274,7 +280,7 @@ func runTask(
 		if result.Result != nil {
 			ctDirectives := parseCreateTasks(result.Result.Result)
 			for _, d := range ctDirectives {
-				log.Printf("[task:%s] detected CREATE_TASK directive: %q (turn %d)", taskID, d.Title, turn)
+				logger.Info("detected CREATE_TASK directive", "title", d.Title, "turn", turn)
 				createTaskFromDirective(ctx, taskClient, taskID, metadata, d)
 				// Log the directive execution to timeline.
 				tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_DIRECTIVE, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
@@ -326,7 +332,7 @@ func runTask(
 		nextStatusID := parseNextStatus(summary)
 		if nextStatusID != "" {
 			displaySummary := stripNextStatus(summary)
-			log.Printf("[task:%s] completed with NEXT_STATUS %q (turn %d)", taskID, nextStatusID, turn)
+			logger.Info("completed with NEXT_STATUS", "next_status", nextStatusID, "turn", turn)
 			// Log the NEXT_STATUS directive to timeline.
 			tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_DIRECTIVE, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
 				fmt.Sprintf("Status transition: %s", nextStatusID),
@@ -345,7 +351,7 @@ func runTask(
 			// only after all hooks complete.
 			afterHooks()
 			if err := handleStatusTransition(ctx, taskClient, taskID, nextStatusID, metadata, tl); err != nil {
-				log.Printf("[task:%s] status transition failed: %v", taskID, err)
+				logger.Error("status transition failed", "error", err)
 				tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_WARN,
 					fmt.Sprintf("Status transition to %q failed: %v", nextStatusID, err), nil)
 			}
@@ -354,7 +360,7 @@ func runTask(
 
 		// No transitions available (terminal status) means task is done.
 		if !hasTransitions {
-			log.Printf("[task:%s] completed at terminal status (turn %d)", taskID, turn)
+			logger.Info("completed at terminal status", "turn", turn)
 			tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
 				fmt.Sprintf("Task completed at terminal status (turn %d)", turn), nil)
 			reportTaskResult(ctx, client, taskID, summary, "")
@@ -363,21 +369,21 @@ func runTask(
 		}
 
 		// Claude hasn't completed — wait for user input.
-		log.Printf("[task:%s] waiting for user input (turn %d)", taskID, turn)
+		logger.Info("waiting for user input", "turn", turn)
 		reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_RUNNING, "waiting for user input")
 
 		userResponse, err := waitForUserResponse(ctx, client, interClient, taskID, agentManagerID, summary, waiter)
 		if err == errWaitTimeout {
 			userResponseRetries++
 			if userResponseRetries > maxUserResponseRetries {
-				log.Printf("[task:%s] max user response retries reached (%d), force-completing task", taskID, userResponseRetries-1)
+				logger.Warn("max user response retries reached, force-completing task", "retries", userResponseRetries-1)
 				tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_WARN,
 					"Max user response retries reached, force-completing task", nil)
 				reportTaskResult(ctx, client, taskID, summary, "")
 				reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_IDLE, "task force-completed (no NEXT_STATUS after retries)")
 				return
 			}
-			log.Printf("[task:%s] user response timeout (retry %d/%d), prompting for NEXT_STATUS", taskID, userResponseRetries, maxUserResponseRetries)
+			logger.Warn("user response timeout, prompting for NEXT_STATUS", "retry", userResponseRetries, "max_retries", maxUserResponseRetries)
 			tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_WARN,
 				fmt.Sprintf("User response timeout, retrying with NEXT_STATUS prompt (retry %d/%d)", userResponseRetries, maxUserResponseRetries), nil)
 			reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_RUNNING, "retrying: requesting NEXT_STATUS")
@@ -388,7 +394,7 @@ func runTask(
 			continue
 		}
 		if err != nil {
-			log.Printf("[task:%s] user response error: %v, completing task", taskID, err)
+			logger.Error("user response error, completing task", "error", err)
 			reportTaskResult(ctx, client, taskID, summary, "")
 			reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_IDLE, "task completed (no user response)")
 			return
@@ -416,6 +422,8 @@ func buildClaudeOptions(
 	permCache *permissionCache,
 	tl *taskLogger,
 ) *claudeagent.ClaudeAgentOptions {
+	logger := clog.LoggerFromContext(ctx)
+
 	// Permission mode from agent config (default if empty)
 	permMode := claudeagent.PermissionModeDefault
 	if pm := metadata["_permission_mode"]; pm != "" {
@@ -430,7 +438,7 @@ func buildClaudeOptions(
 		wtDir := filepath.Join(workDir, ".claude", "worktrees", worktreeName)
 		if info, err := os.Stat(wtDir); err == nil && info.IsDir() {
 			cwd = wtDir
-			log.Printf("[task:%s] using existing worktree directory: %s", taskID, wtDir)
+			logger.Debug("using existing worktree directory", "worktree_dir", wtDir)
 		}
 	}
 
@@ -442,7 +450,7 @@ func buildClaudeOptions(
 			return handlePermissionRequest(ctx, client, taskID, agentManagerID, toolName, input, waiter, permMode, toolCtx, permCache)
 		},
 		StderrCallback: func(line string) {
-			log.Printf("[task:%s] [claude-stderr] %s", taskID, line)
+			logger.Debug("claude-stderr", "line", line)
 		},
 		Hooks: buildToolUseHooks(tl, taskID),
 	}
@@ -475,13 +483,14 @@ func reportTaskResult(
 	summary string,
 	errMsg string,
 ) {
+	logger := clog.LoggerFromContext(ctx)
 	_, err := client.ReportTaskResult(ctx, connect.NewRequest(&v1.ReportTaskResultRequest{
 		TaskId:       taskID,
 		Summary:      summary,
 		ErrorMessage: errMsg,
 	}))
 	if err != nil {
-		log.Printf("[task:%s] failed to report task result: %v", taskID, err)
+		logger.Error("failed to report task result", "error", err)
 	}
 }
 
@@ -493,6 +502,7 @@ func reportAgentStatus(
 	status v1.AgentStatus,
 	message string,
 ) {
+	logger := clog.LoggerFromContext(ctx)
 	_, err := client.ReportAgentStatus(ctx, connect.NewRequest(&v1.ReportAgentStatusRequest{
 		AgentManagerId: agentManagerID,
 		TaskId:         taskID,
@@ -500,7 +510,7 @@ func reportAgentStatus(
 		Message:        message,
 	}))
 	if err != nil {
-		log.Printf("[task:%s] failed to report agent status: %v", taskID, err)
+		logger.Error("failed to report agent status", "error", err)
 	}
 }
 

--- a/backend/cmd/taskguild-agent/sync.go
+++ b/backend/cmd/taskguild-agent/sync.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,7 +17,7 @@ import (
 // It also removes stale .md files that no longer exist on the server.
 func syncAgents(ctx context.Context, client taskguildv1connect.AgentManagerServiceClient, cfg *config) {
 	if cfg.ProjectName == "" {
-		log.Println("skipping agent sync: no project name configured")
+		slog.Info("skipping agent sync: no project name configured")
 		return
 	}
 
@@ -25,16 +25,16 @@ func syncAgents(ctx context.Context, client taskguildv1connect.AgentManagerServi
 		ProjectName: cfg.ProjectName,
 	}))
 	if err != nil {
-		log.Printf("agent sync failed: %v", err)
+		slog.Error("agent sync failed", "error", err)
 		return
 	}
 
 	agents := resp.Msg.GetAgents()
-	log.Printf("syncing %d agent(s) from server", len(agents))
+	slog.Info("syncing agents from server", "count", len(agents))
 
 	agentsDir := filepath.Join(cfg.WorkDir, ".claude", "agents")
 	if err := os.MkdirAll(agentsDir, 0755); err != nil {
-		log.Printf("failed to create agents directory: %v", err)
+		slog.Error("failed to create agents directory", "error", err)
 		return
 	}
 
@@ -44,7 +44,7 @@ func syncAgents(ctx context.Context, client taskguildv1connect.AgentManagerServi
 
 		// Skip agents with unsafe names.
 		if strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
-			log.Printf("skipping agent with unsafe name: %q", name)
+			slog.Warn("skipping agent with unsafe name", "name", name)
 			continue
 		}
 
@@ -53,10 +53,10 @@ func syncAgents(ctx context.Context, client taskguildv1connect.AgentManagerServi
 		content := buildAgentMDContent(ag)
 
 		if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
-			log.Printf("failed to write agent file %s: %v", filePath, err)
+			slog.Error("failed to write agent file", "path", filePath, "error", err)
 			continue
 		}
-		log.Printf("synced agent: %s", filename)
+		slog.Debug("synced agent", "filename", filename)
 		writtenFiles[filename] = true
 	}
 
@@ -124,9 +124,9 @@ func cleanupStaleAgentFiles(agentsDir string, writtenFiles map[string]bool) {
 		if !writtenFiles[entry.Name()] {
 			filePath := filepath.Join(agentsDir, entry.Name())
 			if err := os.Remove(filePath); err != nil {
-				log.Printf("failed to remove stale agent file %s: %v", filePath, err)
+				slog.Error("failed to remove stale agent file", "path", filePath, "error", err)
 			} else {
-				log.Printf("removed stale agent: %s", entry.Name())
+				slog.Debug("removed stale agent", "filename", entry.Name())
 			}
 		}
 	}

--- a/backend/cmd/taskguild-agent/sync_permissions.go
+++ b/backend/cmd/taskguild-agent/sync_permissions.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -18,7 +18,7 @@ import (
 // permission cache so that subsequent tool calls can be auto-allowed.
 func syncPermissions(ctx context.Context, client taskguildv1connect.AgentManagerServiceClient, cfg *config, cache *permissionCache) {
 	if cfg.ProjectName == "" {
-		log.Println("skipping permission sync: no project name configured")
+		slog.Info("skipping permission sync: no project name configured")
 		return
 	}
 
@@ -35,13 +35,16 @@ func syncPermissions(ctx context.Context, client taskguildv1connect.AgentManager
 		LocalDeny:   localDeny,
 	}))
 	if err != nil {
-		log.Printf("permission sync failed: %v", err)
+		slog.Error("permission sync failed", "error", err)
 		return
 	}
 
 	merged := resp.Msg.GetPermissions()
-	log.Printf("permission sync: allow=%d, ask=%d, deny=%d",
-		len(merged.GetAllow()), len(merged.GetAsk()), len(merged.GetDeny()))
+	slog.Info("permission sync complete",
+		"allow", len(merged.GetAllow()),
+		"ask", len(merged.GetAsk()),
+		"deny", len(merged.GetDeny()),
+	)
 
 	// Write merged permissions back to settings.json.
 	writeLocalPermissions(settingsPath, rawSettings, merged)
@@ -64,7 +67,7 @@ func readLocalPermissions(path string) (allow, ask, deny []string, raw map[strin
 	}
 
 	if err := json.Unmarshal(data, &raw); err != nil {
-		log.Printf("failed to parse settings.json: %v", err)
+		slog.Warn("failed to parse settings.json", "error", err)
 		return nil, nil, nil, raw
 	}
 
@@ -93,7 +96,7 @@ func writeLocalPermissions(path string, raw map[string]interface{}, merged *v1.P
 	// Ensure .claude directory exists.
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		log.Printf("failed to create .claude directory: %v", err)
+		slog.Error("failed to create .claude directory", "error", err)
 		return
 	}
 
@@ -121,15 +124,15 @@ func writeLocalPermissions(path string, raw map[string]interface{}, merged *v1.P
 
 	data, err := json.MarshalIndent(raw, "", "    ")
 	if err != nil {
-		log.Printf("failed to marshal settings.json: %v", err)
+		slog.Error("failed to marshal settings.json", "error", err)
 		return
 	}
 
 	if err := os.WriteFile(path, data, 0644); err != nil {
-		log.Printf("failed to write settings.json: %v", err)
+		slog.Error("failed to write settings.json", "error", err)
 		return
 	}
-	log.Printf("updated %s with merged permissions", path)
+	slog.Info("updated settings.json with merged permissions", "path", path)
 }
 
 // toStringSlice converts an interface{} (expected to be []interface{}) to []string.

--- a/backend/cmd/taskguild-agent/sync_scripts.go
+++ b/backend/cmd/taskguild-agent/sync_scripts.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,7 +16,7 @@ import (
 // It also removes stale script files that no longer exist on the server.
 func syncScripts(ctx context.Context, client taskguildv1connect.AgentManagerServiceClient, cfg *config) {
 	if cfg.ProjectName == "" {
-		log.Println("skipping script sync: no project name configured")
+		slog.Info("skipping script sync: no project name configured")
 		return
 	}
 
@@ -24,16 +24,16 @@ func syncScripts(ctx context.Context, client taskguildv1connect.AgentManagerServ
 		ProjectName: cfg.ProjectName,
 	}))
 	if err != nil {
-		log.Printf("script sync failed: %v", err)
+		slog.Error("script sync failed", "error", err)
 		return
 	}
 
 	scripts := resp.Msg.GetScripts()
-	log.Printf("syncing %d script(s) from server", len(scripts))
+	slog.Info("syncing scripts from server", "count", len(scripts))
 
 	scriptsDir := filepath.Join(cfg.WorkDir, ".claude", "scripts")
 	if err := os.MkdirAll(scriptsDir, 0755); err != nil {
-		log.Printf("failed to create scripts directory: %v", err)
+		slog.Error("failed to create scripts directory", "error", err)
 		return
 	}
 
@@ -46,17 +46,17 @@ func syncScripts(ctx context.Context, client taskguildv1connect.AgentManagerServ
 
 		// Skip scripts with unsafe names.
 		if strings.Contains(filename, "/") || strings.Contains(filename, "\\") || strings.Contains(filename, "..") {
-			log.Printf("skipping script with unsafe filename: %q", filename)
+			slog.Warn("skipping script with unsafe filename", "filename", filename)
 			continue
 		}
 
 		filePath := filepath.Join(scriptsDir, filename)
 
 		if err := os.WriteFile(filePath, []byte(sc.GetContent()), 0755); err != nil {
-			log.Printf("failed to write script file %s: %v", filePath, err)
+			slog.Error("failed to write script file", "path", filePath, "error", err)
 			continue
 		}
-		log.Printf("synced script: %s", filename)
+		slog.Debug("synced script", "filename", filename)
 		writtenFiles[filename] = true
 	}
 
@@ -78,9 +78,9 @@ func cleanupStaleScriptFiles(scriptsDir string, writtenFiles map[string]bool) {
 		if !writtenFiles[entry.Name()] {
 			filePath := filepath.Join(scriptsDir, entry.Name())
 			if err := os.Remove(filePath); err != nil {
-				log.Printf("failed to remove stale script file %s: %v", filePath, err)
+				slog.Error("failed to remove stale script file", "path", filePath, "error", err)
 			} else {
-				log.Printf("removed stale script: %s", entry.Name())
+				slog.Debug("removed stale script", "filename", entry.Name())
 			}
 		}
 	}

--- a/backend/cmd/taskguild-agent/tasklogger.go
+++ b/backend/cmd/taskguild-agent/tasklogger.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -21,6 +21,7 @@ const (
 type taskLogger struct {
 	client    taskguildv1connect.AgentManagerServiceClient
 	taskID    string
+	logger    *slog.Logger
 	stderrBuf []string
 	stderrMu  sync.Mutex
 	ctx       context.Context
@@ -33,6 +34,7 @@ func newTaskLogger(ctx context.Context, client taskguildv1connect.AgentManagerSe
 	tl := &taskLogger{
 		client: client,
 		taskID: taskID,
+		logger: slog.Default().With("task_id", taskID),
 		ctx:    ctx,
 		cancel: cancel,
 	}
@@ -51,7 +53,7 @@ func (tl *taskLogger) Log(category v1.TaskLogCategory, level v1.TaskLogLevel, me
 		Metadata: metadata,
 	}))
 	if err != nil {
-		log.Printf("[task:%s] failed to report task log: %v", tl.taskID, err)
+		tl.logger.Error("failed to report task log", "error", err)
 	}
 }
 

--- a/backend/cmd/taskguild-agent/toolhooks.go
+++ b/backend/cmd/taskguild-agent/toolhooks.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 
 	claudeagent "github.com/kazz187/claude-agent-sdk-go"
@@ -78,7 +78,7 @@ func logToolUse(tl *taskLogger, taskID string, input claudeagent.HookInput, isFa
 		}
 	}
 
-	log.Printf("[task:%s] tool_use: %s (fail=%v)", taskID, summary, isFail)
+	slog.Info("tool_use", "task_id", taskID, "summary", summary, "failed", isFail)
 
 	tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_TOOL_USE, level, summary, metadata)
 }

--- a/backend/pkg/clog/logger.go
+++ b/backend/pkg/clog/logger.go
@@ -1,0 +1,22 @@
+package clog
+
+import (
+	"context"
+	"log/slog"
+)
+
+type ctxLoggerKey struct{}
+
+// ContextWithLogger returns a new context carrying the given *slog.Logger.
+func ContextWithLogger(ctx context.Context, logger *slog.Logger) context.Context {
+	return context.WithValue(ctx, ctxLoggerKey{}, logger)
+}
+
+// LoggerFromContext retrieves the *slog.Logger from context.
+// If none is set, returns slog.Default().
+func LoggerFromContext(ctx context.Context) *slog.Logger {
+	if l, ok := ctx.Value(ctxLoggerKey{}).(*slog.Logger); ok {
+		return l
+	}
+	return slog.Default()
+}

--- a/backend/pkg/clog/logger_test.go
+++ b/backend/pkg/clog/logger_test.go
@@ -1,0 +1,24 @@
+package clog
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+func TestContextWithLogger(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil)).With("test_key", "test_value")
+	ctx := ContextWithLogger(context.Background(), logger)
+	got := LoggerFromContext(ctx)
+	if got != logger {
+		t.Error("expected same logger instance from context")
+	}
+}
+
+func TestLoggerFromContext_Default(t *testing.T) {
+	got := LoggerFromContext(context.Background())
+	if got != slog.Default() {
+		t.Error("expected slog.Default() when no logger in context")
+	}
+}

--- a/backend/pkg/sentinel/sentinel.go
+++ b/backend/pkg/sentinel/sentinel.go
@@ -4,11 +4,12 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -59,21 +60,51 @@ func Run() {
 	// Go's default signal handling would terminate the process.
 	signal.Ignore(syscall.SIGUSR1)
 
-	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
-	log.SetPrefix("[sentinel] ")
+	// Initialize slog based on environment.
+	env := os.Getenv("TASKGUILD_ENV")
+	if env == "" {
+		env = "local"
+	}
+	levelStr := os.Getenv("TASKGUILD_LOG_LEVEL")
+	if levelStr == "" {
+		levelStr = "debug"
+	}
+	var level slog.Level
+	switch strings.ToLower(levelStr) {
+	case "debug":
+		level = slog.LevelDebug
+	case "info":
+		level = slog.LevelInfo
+	case "warn":
+		level = slog.LevelWarn
+	case "error":
+		level = slog.LevelError
+	default:
+		level = slog.LevelDebug
+	}
+	handlerOpts := &slog.HandlerOptions{Level: level}
+	var handler slog.Handler
+	if env == "local" {
+		handler = slog.NewTextHandler(os.Stderr, handlerOpts)
+	} else {
+		handler = slog.NewJSONHandler(os.Stderr, handlerOpts)
+	}
+	slog.SetDefault(slog.New(handler).With("component", "sentinel"))
 
 	// Resolve own binary path.
 	binaryPath, err := os.Executable()
 	if err != nil {
-		log.Fatalf("failed to resolve executable path: %v", err)
+		slog.Error("failed to resolve executable path", "error", err)
+		os.Exit(1)
 	}
 	// Resolve symlinks so we watch the real file location.
 	binaryPath, err = filepath.EvalSymlinks(binaryPath)
 	if err != nil {
-		log.Fatalf("failed to resolve symlinks for binary: %v", err)
+		slog.Error("failed to resolve symlinks for binary", "error", err)
+		os.Exit(1)
 	}
 
-	log.Printf("starting sentinel (binary: %s)", binaryPath)
+	slog.Info("starting sentinel", "binary", binaryPath)
 
 	s := &Sentinel{
 		binaryPath: binaryPath,
@@ -84,9 +115,10 @@ func Run() {
 	// Compute initial SHA256 hash of the binary.
 	s.lastHash, err = HashFile(binaryPath)
 	if err != nil {
-		log.Fatalf("failed to hash binary: %v", err)
+		slog.Error("failed to hash binary", "error", err)
+		os.Exit(1)
 	}
-	log.Printf("initial binary hash: %x", s.lastHash[:8])
+	slog.Info("initial binary hash computed", "hash", fmt.Sprintf("%x", s.lastHash[:8]))
 
 	// Set up OS signal handler.
 	sigCh := make(chan os.Signal, 1)
@@ -106,7 +138,7 @@ func (s *Sentinel) mainLoop(sigCh <-chan os.Signal, updateCh <-chan struct{}) {
 		// Check if we should stop before starting a new child.
 		select {
 		case <-s.stopCh:
-			log.Println("sentinel stopping (stopCh closed)")
+			slog.Info("sentinel stopping (stopCh closed)")
 			return
 		default:
 		}
@@ -114,7 +146,7 @@ func (s *Sentinel) mainLoop(sigCh <-chan os.Signal, updateCh <-chan struct{}) {
 		// Start child process.
 		child, err := s.startChild()
 		if err != nil {
-			log.Printf("failed to start child: %v", err)
+			slog.Error("failed to start child", "error", err)
 			s.sleepBackoff()
 			s.increaseBackoff()
 			continue
@@ -134,7 +166,7 @@ func (s *Sentinel) mainLoop(sigCh <-chan os.Signal, updateCh <-chan struct{}) {
 			// Child exited on its own.
 			elapsed := time.Since(startTime)
 			if err != nil {
-				log.Printf("child exited with error after %v: %v", elapsed, err)
+				slog.Error("child exited with error", "elapsed", elapsed, "error", err)
 				if elapsed >= SuccessRunTime {
 					// Ran long enough — reset backoff.
 					s.backoff = InitialBackoff
@@ -144,7 +176,7 @@ func (s *Sentinel) mainLoop(sigCh <-chan os.Signal, updateCh <-chan struct{}) {
 			} else {
 				// Clean exit. The "run" subcommand normally runs forever,
 				// so a clean exit is unexpected and warrants a restart.
-				log.Printf("child exited cleanly after %v", elapsed)
+				slog.Info("child exited cleanly", "elapsed", elapsed)
 				s.backoff = InitialBackoff
 				time.Sleep(1 * time.Second)
 			}
@@ -155,37 +187,37 @@ func (s *Sentinel) mainLoop(sigCh <-chan os.Signal, updateCh <-chan struct{}) {
 			// If the child does not handle SIGUSR1 (e.g. old binary or
 			// taskguild-server), the default OS action terminates the process
 			// immediately — same as the previous SIGTERM behaviour.
-			log.Println("binary update detected, requesting graceful restart...")
+			slog.Info("binary update detected, requesting graceful restart")
 			s.requestGracefulRestart(child)
 			select {
 			case <-childDone:
-				log.Println("child exited gracefully after completing scripts")
+				slog.Info("child exited gracefully after completing scripts")
 			case <-time.After(ScriptWaitTimeout):
-				log.Println("timeout waiting for scripts to complete, force stopping child...")
+				slog.Warn("timeout waiting for scripts to complete, force stopping child")
 				s.stopChild(child)
 				<-childDone
 			case sig := <-sigCh:
 				// OS signal arrived while waiting — force stop and exit sentinel.
-				log.Printf("received %v during restart wait, force stopping child...", sig)
+				slog.Info("received signal during restart wait, force stopping child", "signal", sig)
 				s.stopChild(child)
 				<-childDone
-				log.Println("sentinel exiting")
+				slog.Info("sentinel exiting")
 				return
 			}
 			// Refresh the hash for the new binary.
 			if h, err := HashFile(s.binaryPath); err == nil {
 				s.lastHash = h
-				log.Printf("new binary hash: %x", s.lastHash[:8])
+				slog.Info("new binary hash", "hash", fmt.Sprintf("%x", s.lastHash[:8]))
 			}
 			s.backoff = InitialBackoff
 
 		case sig := <-sigCh:
 			// Sentinel received SIGINT/SIGTERM — forward to child and shut down.
-			log.Printf("received %v, forwarding to child and shutting down...", sig)
+			slog.Info("received signal, forwarding to child and shutting down", "signal", sig)
 			s.stopChild(child)
 			// Wait for child to actually exit.
 			<-childDone
-			log.Println("sentinel exiting")
+			slog.Info("sentinel exiting")
 			return
 		}
 	}
@@ -203,7 +235,7 @@ func (s *Sentinel) startChild() (*exec.Cmd, error) {
 		return nil, fmt.Errorf("exec %s run: %w", s.binaryPath, err)
 	}
 
-	log.Printf("started child process (pid: %d)", cmd.Process.Pid)
+	slog.Info("started child process", "pid", cmd.Process.Pid)
 	return cmd, nil
 }
 
@@ -216,9 +248,9 @@ func (s *Sentinel) stopChild(cmd *exec.Cmd) {
 	}
 
 	pid := cmd.Process.Pid
-	log.Printf("sending SIGTERM to child (pid: %d)", pid)
+	slog.Info("sending SIGTERM to child", "pid", pid)
 	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
-		log.Printf("failed to send SIGTERM (process may have already exited): %v", err)
+		slog.Warn("failed to send SIGTERM (process may have already exited)", "pid", pid, "error", err)
 		return
 	}
 
@@ -227,9 +259,9 @@ func (s *Sentinel) stopChild(cmd *exec.Cmd) {
 		time.Sleep(GracePeriod)
 		// Check if process is still alive by trying to signal it.
 		if err := cmd.Process.Signal(syscall.Signal(0)); err == nil {
-			log.Printf("grace period expired, sending SIGKILL to child (pid: %d)", pid)
+			slog.Warn("grace period expired, sending SIGKILL to child", "pid", pid)
 			if err := cmd.Process.Kill(); err != nil {
-				log.Printf("failed to send SIGKILL: %v", err)
+				slog.Error("failed to send SIGKILL", "pid", pid, "error", err)
 			}
 		}
 	}()
@@ -250,9 +282,9 @@ func (s *Sentinel) requestGracefulRestart(cmd *exec.Cmd) {
 	}
 
 	pid := cmd.Process.Pid
-	log.Printf("sending SIGUSR1 to child (pid: %d) for graceful restart", pid)
+	slog.Info("sending SIGUSR1 to child for graceful restart", "pid", pid)
 	if err := cmd.Process.Signal(syscall.SIGUSR1); err != nil {
-		log.Printf("failed to send SIGUSR1 (process may have already exited): %v", err)
+		slog.Warn("failed to send SIGUSR1 (process may have already exited)", "pid", pid, "error", err)
 	}
 }
 
@@ -262,7 +294,7 @@ func (s *Sentinel) requestGracefulRestart(cmd *exec.Cmd) {
 func (s *Sentinel) watchBinary(updateCh chan<- struct{}) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		log.Printf("failed to create fsnotify watcher: %v", err)
+		slog.Error("failed to create fsnotify watcher", "error", err)
 		return
 	}
 	defer watcher.Close()
@@ -274,10 +306,10 @@ func (s *Sentinel) watchBinary(updateCh chan<- struct{}) {
 	binaryName := filepath.Base(s.binaryPath)
 
 	if err := watcher.Add(watchDir); err != nil {
-		log.Printf("failed to watch directory %s: %v", watchDir, err)
+		slog.Error("failed to watch directory", "dir", watchDir, "error", err)
 		return
 	}
-	log.Printf("watching directory %s for changes to %s", watchDir, binaryName)
+	slog.Info("watching directory for changes", "dir", watchDir, "binary", binaryName)
 
 	// Debounce timer: after a relevant event, wait before computing the checksum
 	// to let multiple rapid events settle (e.g., atomic deploy: write + rename).
@@ -298,7 +330,7 @@ func (s *Sentinel) watchBinary(updateCh chan<- struct{}) {
 				continue
 			}
 
-			log.Printf("detected filesystem event: %s %s", event.Op, event.Name)
+			slog.Debug("detected filesystem event", "op", event.Op, "name", event.Name)
 
 			// Reset debounce timer.
 			if debounceTimer != nil {
@@ -307,19 +339,20 @@ func (s *Sentinel) watchBinary(updateCh chan<- struct{}) {
 			debounceTimer = time.AfterFunc(DebounceInterval, func() {
 				newHash, err := HashFile(s.binaryPath)
 				if err != nil {
-					log.Printf("failed to hash binary after event: %v", err)
+					slog.Error("failed to hash binary after event", "error", err)
 					return
 				}
 				if newHash != s.lastHash {
-					log.Printf("binary checksum changed (old: %x, new: %x)",
-						s.lastHash[:8], newHash[:8])
+					slog.Info("binary checksum changed",
+						"old_hash", fmt.Sprintf("%x", s.lastHash[:8]),
+						"new_hash", fmt.Sprintf("%x", newHash[:8]))
 					// Non-blocking send.
 					select {
 					case updateCh <- struct{}{}:
 					default:
 					}
 				} else {
-					log.Printf("filesystem event but checksum unchanged, ignoring")
+					slog.Debug("filesystem event but checksum unchanged, ignoring")
 				}
 			})
 
@@ -327,7 +360,7 @@ func (s *Sentinel) watchBinary(updateCh chan<- struct{}) {
 			if !ok {
 				return
 			}
-			log.Printf("fsnotify error: %v", err)
+			slog.Error("fsnotify error", "error", err)
 
 		case <-s.stopCh:
 			return
@@ -356,7 +389,7 @@ func HashFile(path string) ([sha256.Size]byte, error) {
 // sleepBackoff waits for the current backoff duration.
 // It can be interrupted by closing stopCh.
 func (s *Sentinel) sleepBackoff() {
-	log.Printf("waiting %v before restart...", s.backoff)
+	slog.Info("waiting before restart", "backoff", s.backoff)
 	select {
 	case <-time.After(s.backoff):
 	case <-s.stopCh:


### PR DESCRIPTION
## Summary
- **taskguild-agent** (12ファイル, ~120コール) と **pkg/sentinel** (~35コール) の標準 `log` パッケージを `log/slog` 構造化ロギングに移行
- `pkg/clog/logger.go` に `ContextWithLogger` / `LoggerFromContext` ヘルパーを追加し、タスクスコープのロガーを `context.Context` 経由で受け渡し
- 環境変数 `TASKGUILD_ENV` でハンドラを切替（`local` → TextHandler、それ以外 → JSONHandler）
- `agent-manager.log` ファイル出力を廃止し stderr のみに統一
- `[task:%s]` プレフィックスパターンを `slog.With("task_id", taskID)` に置換
- sentinel ログは `slog.With("component", "sentinel")` でタグ付け

## Test plan
- [x] `grep '"log"' cmd/taskguild-agent/ pkg/sentinel/` → 0件（標準 log の残存なし）
- [x] `go build ./cmd/taskguild-agent/` 成功
- [x] `go build ./cmd/taskguild-server/` 成功
- [x] `go test ./...` 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)