### PR TITLE
Extract script file filtering into shared ShouldSkipScriptFile utility

### DIFF
--- a/backend/cmd/taskguild-agent/compare_scripts.go
+++ b/backend/cmd/taskguild-agent/compare_scripts.go
@@ -10,6 +10,7 @@ import (
 	"connectrpc.com/connect"
 	v1 "github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1"
 	"github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1/taskguildv1connect"
+	"github.com/kazz187/taskguild/backend/internal/script"
 )
 
 // handleCompareScripts compares local .claude/scripts/* files with server-side
@@ -108,8 +109,8 @@ func readLocalScripts(scriptsDir string) map[string]string {
 		}
 
 		filename := entry.Name()
-		// Skip hidden files and temp files.
-		if strings.HasPrefix(filename, ".") {
+		// Skip editor swap files, backups, and other temporary files.
+		if script.ShouldSkipScriptFile(filename) {
 			continue
 		}
 

--- a/backend/internal/script/filefilter.go
+++ b/backend/internal/script/filefilter.go
@@ -1,0 +1,43 @@
+package script
+
+import "strings"
+
+// blockedSuffixes lists file suffixes that indicate editor swap/backup/temp files.
+var blockedSuffixes = []string{
+	".swp",  // Vim swap file
+	".swo",  // Vim swap file (2nd)
+	"~",     // Vim/Emacs backup
+	".bak",  // Backup file
+	".tmp",  // Temporary file
+	".orig", // Merge conflict original
+	".rej",  // Patch reject file
+}
+
+// ShouldSkipScriptFile returns true if the given filename looks like an editor
+// swap file, backup file, or other temporary file that should not be registered
+// as a script.
+//
+// It checks for:
+//   - Hidden files (filenames starting with ".")
+//   - Known temporary/swap file suffixes (.swp, .swo, ~, .bak, .tmp, .orig, .rej)
+//   - Emacs auto-save files (filenames wrapped in "#", e.g. #deploy.sh#)
+func ShouldSkipScriptFile(filename string) bool {
+	// Skip hidden files (e.g. .deploy.sh.swp, .gitkeep).
+	if strings.HasPrefix(filename, ".") {
+		return true
+	}
+
+	// Skip Emacs auto-save files (e.g. #deploy.sh#).
+	if strings.HasPrefix(filename, "#") && strings.HasSuffix(filename, "#") {
+		return true
+	}
+
+	// Skip files with blocked suffixes.
+	for _, suffix := range blockedSuffixes {
+		if strings.HasSuffix(filename, suffix) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/backend/internal/script/filefilter_test.go
+++ b/backend/internal/script/filefilter_test.go
@@ -1,0 +1,62 @@
+package script
+
+import "testing"
+
+func TestShouldSkipScriptFile(t *testing.T) {
+	tests := []struct {
+		filename string
+		want     bool
+		reason   string
+	}{
+		// Valid script files — should NOT be skipped.
+		{"deploy.sh", false, "normal shell script"},
+		{"build.bash", false, "bash script"},
+		{"setup.py", false, "python script"},
+		{"migrate.rb", false, "ruby script"},
+		{"run", false, "extensionless script"},
+		{"my-script.sh", false, "script with hyphen"},
+		{"my_script.sh", false, "script with underscore"},
+
+		// Hidden files — should be skipped.
+		{".deploy.sh.swp", true, "Vim swap file (hidden)"},
+		{".gitkeep", true, "hidden file"},
+		{".hidden", true, "generic hidden file"},
+
+		// Vim swap files — should be skipped.
+		{"deploy.sh.swp", true, ".swp suffix"},
+		{"file.swp", true, ".swp suffix without double ext"},
+		{"deploy.sh.swo", true, ".swo suffix"},
+		{"file.swo", true, ".swo suffix without double ext"},
+
+		// Backup files — should be skipped.
+		{"deploy.sh~", true, "tilde backup (Vim/Emacs)"},
+		{"file~", true, "tilde backup without ext"},
+		{"deploy.sh.bak", true, ".bak backup"},
+		{"file.bak", true, ".bak backup without double ext"},
+
+		// Temporary files — should be skipped.
+		{"deploy.sh.tmp", true, ".tmp temporary file"},
+		{"file.tmp", true, ".tmp temporary file without double ext"},
+
+		// Merge/patch artifacts — should be skipped.
+		{"deploy.sh.orig", true, ".orig merge conflict file"},
+		{"deploy.sh.rej", true, ".rej patch reject file"},
+
+		// Emacs auto-save files — should be skipped.
+		{"#deploy.sh#", true, "Emacs auto-save file"},
+		{"#file#", true, "Emacs auto-save file without ext"},
+
+		// Edge cases.
+		{"#onlyhash", false, "starts with # but doesn't end with #"},
+		{"onlyhash#", false, "ends with # but doesn't start with #"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			got := ShouldSkipScriptFile(tt.filename)
+			if got != tt.want {
+				t.Errorf("ShouldSkipScriptFile(%q) = %v, want %v (%s)", tt.filename, got, tt.want, tt.reason)
+			}
+		})
+	}
+}

--- a/backend/internal/script/server.go
+++ b/backend/internal/script/server.go
@@ -160,6 +160,12 @@ func (s *Server) SyncScriptsFromDir(ctx context.Context, req *connect.Request[ta
 		}
 
 		filename := entry.Name()
+
+		// Skip editor swap files, backups, and other temporary files.
+		if ShouldSkipScriptFile(filename) {
+			continue
+		}
+
 		filePath := filepath.Join(scriptsDir, filename)
 
 		content, err := os.ReadFile(filePath)


### PR DESCRIPTION
## Summary
- Extract editor swap/backup/temp file detection into a reusable `ShouldSkipScriptFile` function in the `script` package
- `compare_scripts.go` previously only skipped hidden files (dot-prefix); now uses the shared filter which also catches `.swp`, `.swo`, `~`, `.bak`, `.tmp`, `.orig`, `.rej` suffixes and Emacs auto-save files
- `server.go` (`SyncScriptsFromDir`) had no temp file filtering at all; now skips the same set of files
- Add comprehensive unit tests covering valid scripts, hidden files, Vim swap files, backups, temp files, merge artifacts, Emacs auto-save files, and edge cases

## Test plan
- [ ] `go test ./backend/internal/script/...` passes (new filefilter_test.go)
- [ ] `go build ./backend/cmd/taskguild-agent/...` compiles successfully
- [ ] Verify that `.swp` / `~` / `.bak` files in `.claude/scripts/` are ignored during compare and sync operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)