### PR TITLE
Split vendor chunks with manualChunks to eliminate 500 kB warning

### DIFF
--- a/frontend/taskguild/vite.config.ts
+++ b/frontend/taskguild/vite.config.ts
@@ -7,6 +7,18 @@ import { tanstackRouter } from '@tanstack/router-plugin/vite'
 import viteReact from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
+/**
+ * Extract the package name from a module ID resolved under node_modules.
+ * Handles pnpm's `.pnpm/<pkg>/node_modules/<pkg>` layout as well as
+ * regular `node_modules/<pkg>` paths.
+ */
+function getPackageName(id: string): string | undefined {
+  const match = id.match(
+    /node_modules\/(?:\.pnpm\/[^/]+\/node_modules\/)?(@[^/]+\/[^/]+|[^/]+)/,
+  )
+  return match?.[1]
+}
+
 const config = defineConfig({
   plugins: [
     devtools(),
@@ -17,6 +29,45 @@ const config = defineConfig({
   ],
   resolve: {
     dedupe: ['@bufbuild/protobuf'],
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return
+
+          const pkg = getPackageName(id)
+          if (!pkg) return
+
+          // React core
+          if (['react', 'react-dom', 'scheduler'].includes(pkg)) {
+            return 'react-vendor'
+          }
+
+          // Protocol Buffers & Connect RPC
+          if (
+            pkg === '@bufbuild/protobuf' ||
+            pkg === '@taskguild/proto' ||
+            pkg.startsWith('@connectrpc/')
+          ) {
+            return 'rpc'
+          }
+
+          // TanStack Router & React Query (+ internal deps)
+          if (
+            pkg.startsWith('@tanstack/') &&
+            !pkg.includes('devtools')
+          ) {
+            return 'router-query'
+          }
+
+          // Drag-and-drop
+          if (pkg.startsWith('@dnd-kit/')) {
+            return 'dnd'
+          }
+        },
+      },
+    },
   },
 })
 


### PR DESCRIPTION
## Summary
- Add `manualChunks` configuration in `vite.config.ts` to split large vendor bundles into logical groups: `react-vendor`, `rpc`, `router-query`, and `dnd`
- Add helper function `getPackageName()` that correctly resolves package names under both regular and pnpm `node_modules` layouts
- Eliminates the Rollup 500 kB chunk size warning during production builds

## Test plan
- [ ] Run `pnpm build` and verify no 500 kB chunk size warnings appear
- [ ] Verify the output chunks are correctly split (react-vendor, rpc, router-query, dnd)
- [ ] Run the app in production mode and confirm all pages load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)