### PR TITLE
Fix mobile kanban dropdown clipped by overflow container

### DIFF
--- a/frontend/taskguild/package.json
+++ b/frontend/taskguild/package.json
@@ -21,6 +21,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@floating-ui/react": "^0.27.19",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-devtools": "^0.7.0",
     "@tanstack/react-query": "^5.90.21",

--- a/frontend/taskguild/pnpm-lock.yaml
+++ b/frontend/taskguild/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.4)
+      '@floating-ui/react':
+        specifier: ^0.27.19
+        version: 0.27.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.2.0(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
@@ -513,6 +516,27 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/react@0.27.19':
+    resolution: {integrity: sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==}
+    peerDependencies:
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
@@ -1752,6 +1776,9 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tabbable@6.4.0:
+    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
   tailwindcss@4.2.0:
     resolution: {integrity: sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q==}
 
@@ -2353,6 +2380,31 @@ snapshots:
     optional: true
 
   '@exodus/bytes@1.14.1': {}
+
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@floating-ui/react@0.27.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tabbable: 6.4.0
+
+  '@floating-ui/utils@0.2.11': {}
 
   '@img/colour@1.0.0': {}
 
@@ -3518,6 +3570,8 @@ snapshots:
   supports-color@10.2.2: {}
 
   symbol-tree@3.2.4: {}
+
+  tabbable@6.4.0: {}
 
   tailwindcss@4.2.0: {}
 

--- a/frontend/taskguild/src/components/molecules/DropdownMenu.tsx
+++ b/frontend/taskguild/src/components/molecules/DropdownMenu.tsx
@@ -1,4 +1,14 @@
-import { useRef, useEffect, type ReactNode } from 'react'
+import { useLayoutEffect, type ReactNode, type RefObject } from 'react'
+import {
+  useFloating,
+  offset,
+  flip,
+  shift,
+  autoUpdate,
+  FloatingPortal,
+  useDismiss,
+  useInteractions,
+} from '@floating-ui/react'
 
 /* ─── DropdownMenu ─── */
 
@@ -7,6 +17,8 @@ export interface DropdownMenuProps {
   onOpenChange: (open: boolean) => void
   /** @default 'right' */
   align?: 'left' | 'right'
+  /** Reference element (trigger button) to anchor the dropdown */
+  triggerRef?: RefObject<HTMLElement | null>
   children: ReactNode
   className?: string
 }
@@ -15,34 +27,43 @@ export function DropdownMenu({
   open,
   onOpenChange,
   align = 'right',
+  triggerRef,
   children,
   className = '',
 }: DropdownMenuProps) {
-  const menuRef = useRef<HTMLDivElement>(null)
+  const { refs, floatingStyles, context } = useFloating({
+    open,
+    onOpenChange,
+    placement: align === 'left' ? 'bottom-start' : 'bottom-end',
+    middleware: [offset(4), flip(), shift({ padding: 8 })],
+    whileElementsMounted: autoUpdate,
+  })
 
-  // Close on outside click
-  useEffect(() => {
-    if (!open) return
-    const handler = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        onOpenChange(false)
-      }
+  const dismiss = useDismiss(context)
+  const { getFloatingProps } = useInteractions([dismiss])
+
+  // Sync external trigger ref to floating reference element.
+  // useLayoutEffect ensures the reference is set before paint to avoid a
+  // frame at (0,0) when the dropdown first opens.
+  useLayoutEffect(() => {
+    if (triggerRef?.current) {
+      refs.setReference(triggerRef.current)
     }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
-  }, [open, onOpenChange])
+  }, [triggerRef, refs, open])
 
   if (!open) return null
 
-  const alignCls = align === 'left' ? 'left-0' : 'right-0'
-
   return (
-    <div
-      ref={menuRef}
-      className={`absolute ${alignCls} top-full mt-1 z-30 bg-slate-800 border border-slate-600 rounded-lg shadow-xl py-1 min-w-[160px] animate-fade-in-down ${className}`}
-    >
-      {children}
-    </div>
+    <FloatingPortal>
+      <div
+        ref={refs.setFloating}
+        style={floatingStyles}
+        {...getFloatingProps()}
+        className={`z-50 bg-slate-800 border border-slate-600 rounded-lg shadow-xl py-1 min-w-[160px] animate-fade-in-down ${className}`}
+      >
+        {children}
+      </div>
+    </FloatingPortal>
   )
 }
 

--- a/frontend/taskguild/src/components/organisms/TaskCard.tsx
+++ b/frontend/taskguild/src/components/organisms/TaskCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useDraggable } from '@dnd-kit/core'
 import { useNavigate } from '@tanstack/react-router'
 import type { Task } from '@taskguild/proto/taskguild/v1/task_pb.ts'
@@ -31,6 +31,7 @@ export function TaskCard({ task, onEdit, isDragOverlay, transitionTargets, onTra
     data: { task },
   })
   const [showTransitionMenu, setShowTransitionMenu] = useState(false)
+  const transitionBtnRef = useRef<HTMLButtonElement>(null)
 
   const handleClick = () => {
     if (isDragging) return
@@ -61,8 +62,9 @@ export function TaskCard({ task, onEdit, isDragOverlay, transitionTargets, onTra
         <div className="flex items-center gap-1 shrink-0">
           {/* Transition button (visible on mobile when transitions available) */}
           {hasTransitions && onTransition && (
-            <div className="relative">
+            <>
               <button
+                ref={transitionBtnRef}
                 onClick={(e) => {
                   e.stopPropagation()
                   setShowTransitionMenu(!showTransitionMenu)
@@ -73,11 +75,12 @@ export function TaskCard({ task, onEdit, isDragOverlay, transitionTargets, onTra
               >
                 <ArrowRight className="w-3.5 h-3.5" />
               </button>
-              {/* Transition dropdown */}
+              {/* Transition dropdown (rendered via portal by Floating UI) */}
               <DropdownMenu
                 open={showTransitionMenu}
                 onOpenChange={setShowTransitionMenu}
                 align="right"
+                triggerRef={transitionBtnRef}
               >
                 <p className="px-3 py-1.5 text-[10px] text-gray-500 uppercase tracking-wider">Move to</p>
                 {transitionTargets.map((target) => {
@@ -104,7 +107,7 @@ export function TaskCard({ task, onEdit, isDragOverlay, transitionTargets, onTra
                   )
                 })}
               </DropdownMenu>
-            </div>
+            </>
           )}
           {/* Edit button (always visible on mobile, hover on desktop) */}
           {onEdit && (


### PR DESCRIPTION
## Summary
- Replace absolute-positioned `DropdownMenu` with `@floating-ui/react` portal-based positioning to prevent dropdown from being clipped by `overflow: hidden` containers on mobile kanban view
- Add `@floating-ui/react` dependency with `flip()` and `shift()` middleware for automatic repositioning
- Refactor `DropdownMenu` to accept a `triggerRef` prop and render via `FloatingPortal`
- Update `TaskCard` to pass a button ref to the dropdown for proper anchoring

## Test plan
- [ ] Open kanban board on mobile viewport
- [ ] Tap the transition arrow button on a task card near the edge of a column
- [ ] Verify the dropdown menu appears fully visible and not clipped
- [ ] Verify the dropdown repositions (flips/shifts) when near screen edges
- [ ] Verify clicking outside the dropdown dismisses it
- [ ] Verify desktop behavior is unchanged (hover states, drag-and-drop still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)