### PR TITLE
Fix PendingRequestsPanel not displaying in global chat

### DIFF
--- a/frontend/taskguild/src/hooks/useGlobalTimeline.ts
+++ b/frontend/taskguild/src/hooks/useGlobalTimeline.ts
@@ -26,11 +26,13 @@ export function useGlobalTimeline() {
   })
   const tasks = tasksData?.tasks ?? []
 
-  // Fetch all interactions across all projects (empty project_id and task_id = all)
+  // Fetch all interactions across all projects (empty project_id and task_id = all).
+  // Use limit: 0 (no limit) to ensure pending interactions are always included,
+  // matching the approach used by task detail and project chat pages.
   const { data: interactionsData, refetch: refetchInteractions } = useQuery(listInteractions, {
     projectId: '',
     taskId: '',
-    pagination: { limit },
+    pagination: { limit: 0 },
   })
   const interactions = interactionsData?.interactions ?? []
 
@@ -154,10 +156,9 @@ export function useGlobalTimeline() {
 
   const { connectionStatus, reconnect } = useEventSubscription(eventTypes, '', onEvent)
 
-  // Pagination
-  const interactionTotal = interactionsData?.pagination?.total ?? 0
+  // Pagination (interactions are fetched without limit; only logs are paginated)
   const logTotal = logsData?.pagination?.total ?? 0
-  const hasMore = interactionTotal > limit || logTotal > limit
+  const hasMore = logTotal > limit
 
   const loadMore = useCallback(() => {
     setLimit((prev) => prev + INITIAL_LIMIT)

--- a/frontend/taskguild/src/routes/global-chat.tsx
+++ b/frontend/taskguild/src/routes/global-chat.tsx
@@ -68,7 +68,7 @@ function GlobalChatPage() {
   }
 
   return (
-    <div className="flex flex-col h-dvh">
+    <div className="flex flex-col h-full">
       {/* Header */}
       <div className="shrink-0 border-b border-slate-800 px-4 py-3 md:px-6 md:py-4">
         <h1 className="text-lg md:text-xl font-bold text-white">Global Chat</h1>


### PR DESCRIPTION
## Summary
- Fetch all interactions without pagination limit (`limit: 0`) in the global timeline hook so that pending interactions are always included, matching the behavior of task detail and project chat pages
- Fix pagination logic to only paginate logs (interactions are now fetched without limit)
- Change global chat page container from `h-dvh` to `h-full` to fix layout rendering within the app shell

## Test plan
- [ ] Open global chat and verify pending request panels are displayed correctly
- [ ] Verify that interactions from all projects/tasks appear in the global timeline
- [ ] Confirm "Load more" pagination still works for log entries
- [ ] Check global chat layout renders properly without overflow issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)