### PR TITLE
Hide redundant task header in pending requests on task detail page

### DIFF
--- a/frontend/taskguild/src/components/organisms/PendingRequestsPanel.tsx
+++ b/frontend/taskguild/src/components/organisms/PendingRequestsPanel.tsx
@@ -26,6 +26,7 @@ export function PendingRequestsPanel({
   isDismissPending,
   projectMap,
   taskProjectMap,
+  hideTaskHeader = false,
 }: {
   pendingRequests: Interaction[]
   onRespond: (interactionId: string, response: string) => void
@@ -40,6 +41,8 @@ export function PendingRequestsPanel({
   projectMap?: Map<string, string>
   /** taskId → projectId map (global chat). Takes priority over single projectId. */
   taskProjectMap?: Map<string, string>
+  /** Hide the task group header (useful on task detail page where task context is already clear). */
+  hideTaskHeader?: boolean
 }) {
   const { selectedId, setSelectedId } = useRequestKeyboard({
     pendingRequests,
@@ -91,6 +94,7 @@ export function PendingRequestsPanel({
         {taskGroups.map((group) => (
           <div key={group.taskId}>
             {/* Task group header */}
+            {!hideTaskHeader && (
             <div className="flex items-center gap-2 mb-1.5">
               <div className="flex items-center gap-1 min-w-0 shrink">
                 {group.projectName && (
@@ -114,6 +118,7 @@ export function PendingRequestsPanel({
               </div>
               <div className="flex-1 border-t border-slate-700/50" />
             </div>
+            )}
             {/* Request items within this task group */}
             <div className="space-y-2">
               {group.interactions.map((interaction) => (

--- a/frontend/taskguild/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/frontend/taskguild/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -382,6 +382,7 @@ function TaskDetailPage() {
               isRespondPending={respondMut.isPending}
               onDismiss={handleDismiss}
               isDismissPending={expireMut.isPending}
+              hideTaskHeader
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Add `hideTaskHeader` prop to `PendingRequestsPanel` component to optionally hide the task group header
- Pass `hideTaskHeader` on the task detail page where the task context is already clear from the page itself, removing redundant information

## Test plan
- [ ] Open the task detail page and verify the pending requests panel no longer shows the task group header
- [ ] Open the global chat / project page and verify the task group header still appears as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)