### PR TITLE
Add child task (subtask) creation feature

### DIFF
--- a/frontend/taskguild/src/components/organisms/ChildTaskCreateModal.tsx
+++ b/frontend/taskguild/src/components/organisms/ChildTaskCreateModal.tsx
@@ -1,0 +1,228 @@
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useMutation, useQuery } from '@connectrpc/connect-query'
+import { createTask } from '@taskguild/proto/taskguild/v1/task-TaskService_connectquery.ts'
+import { requestWorktreeList, getWorktreeList } from '@taskguild/proto/taskguild/v1/agent_manager-AgentManagerService_connectquery.ts'
+import { EventType } from '@taskguild/proto/taskguild/v1/event_pb.ts'
+import type { Task } from '@taskguild/proto/taskguild/v1/task_pb.ts'
+import { TaskAssignmentStatus } from '@taskguild/proto/taskguild/v1/task_pb.ts'
+import { useEventSubscription } from '@/hooks/useEventSubscription'
+import { X, GitBranch, RefreshCw, AlertTriangle, ArrowUpRight } from 'lucide-react'
+import { shortId } from '@/lib/id'
+import { Button, Input, Textarea, Select, Checkbox, Badge } from '../atoms/index.ts'
+import { Modal, FormField, Card } from '../molecules/index.ts'
+
+interface ChildTaskCreateModalProps {
+  parentTask: Task
+  projectId: string
+  workflowId: string
+  onCreated: () => void
+  onClose: () => void
+}
+
+export function ChildTaskCreateModal({
+  parentTask,
+  projectId,
+  workflowId,
+  onCreated,
+  onClose,
+}: ChildTaskCreateModalProps) {
+  const parentRef = `> Parent: ${parentTask.title} (${shortId(parentTask.id)})\n\n`
+
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState(parentRef)
+  const [permissionMode, setPermissionMode] = useState(parentTask.permissionMode ?? '')
+  const [useWorktree, setUseWorktree] = useState(parentTask.useWorktree ?? false)
+  const [selectedWorktree, setSelectedWorktree] = useState(parentTask.metadata?.['worktree'] ?? '')
+  const [forkSession, setForkSession] = useState(false)
+
+  const createMut = useMutation(createTask)
+  const requestWtMut = useMutation(requestWorktreeList)
+
+  const isParentAgentRunning = parentTask.assignmentStatus === TaskAssignmentStatus.ASSIGNED
+  const parentSessionId = parentTask.metadata?.['session_id'] ?? ''
+
+  // Query cached worktree list
+  const { data: wtData, refetch: refetchWorktrees } = useQuery(getWorktreeList, { projectId }, {
+    enabled: useWorktree,
+  })
+
+  // Subscribe to worktree list events to refetch when a scan completes
+  const worktreeEventTypes = useMemo(() => [EventType.WORKTREE_LIST], [])
+  const onWorktreeEvent = useCallback(() => {
+    refetchWorktrees()
+  }, [refetchWorktrees])
+  useEventSubscription(worktreeEventTypes, projectId, onWorktreeEvent)
+
+  // Request worktree scan when worktree checkbox is toggled on
+  useEffect(() => {
+    if (useWorktree && projectId) {
+      requestWtMut.mutate({ projectId })
+    }
+  }, [useWorktree, projectId])
+
+  const worktrees = wtData?.worktrees ?? []
+
+  const handleCreate = () => {
+    if (!title.trim()) return
+    const metadata: Record<string, string> = {
+      source_task_id: parentTask.id,
+    }
+    if (selectedWorktree && useWorktree) {
+      metadata['worktree'] = selectedWorktree
+    }
+    if (forkSession && parentSessionId) {
+      metadata['session_id'] = parentSessionId
+    }
+    createMut.mutate(
+      {
+        projectId,
+        workflowId,
+        title: title.trim(),
+        description,
+        metadata,
+        permissionMode,
+        useWorktree,
+      },
+      {
+        onSuccess: () => {
+          onCreated()
+          onClose()
+        },
+      },
+    )
+  }
+
+  return (
+    <Modal open={true} onClose={onClose} size="full">
+      {/* Header */}
+      <div className="flex items-start justify-between px-4 pt-4 pb-1">
+        <div className="flex-1 min-w-0 mr-3">
+          <Input
+            autoFocus
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) handleCreate() }}
+            className="!border-slate-600 text-base md:text-lg font-semibold !rounded"
+            placeholder="Subtask title..."
+          />
+        </div>
+        <button onClick={onClose} className="text-gray-500 hover:text-gray-300 transition-colors shrink-0 mt-1 p-1">
+          <X className="w-5 h-5" />
+        </button>
+      </div>
+
+      {/* Body */}
+      <Modal.Body>
+        {/* Parent task reference */}
+        <Card variant="nested" className="!rounded-lg !py-2 !px-3">
+          <div className="flex items-center gap-2 text-xs text-gray-400">
+            <ArrowUpRight className="w-3.5 h-3.5 text-gray-500 shrink-0" />
+            <span className="text-gray-500">Parent:</span>
+            <span className="text-white font-medium truncate">{parentTask.title}</span>
+            <span className="text-gray-600 font-mono shrink-0">{shortId(parentTask.id)}</span>
+            {isParentAgentRunning && (
+              <Badge color="cyan" size="xs" variant="outline" pill>Running</Badge>
+            )}
+          </div>
+        </Card>
+
+        <Textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          textareaSize="md"
+          placeholder="Add description..."
+        />
+
+        {/* Fork session option */}
+        <div>
+          <Checkbox
+            label="Fork Session (inherit parent's conversation context)"
+            checked={forkSession}
+            onChange={(e) => setForkSession(e.target.checked)}
+            disabled={!parentSessionId}
+          />
+          {!parentSessionId && (
+            <p className="ml-6 mt-0.5 text-[11px] text-gray-600">
+              No session available to fork (parent has not been run yet)
+            </p>
+          )}
+          {forkSession && isParentAgentRunning && (
+            <div className="ml-6 mt-1.5 flex items-start gap-1.5 text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded px-2.5 py-1.5">
+              <AlertTriangle className="w-3.5 h-3.5 shrink-0 mt-0.5" />
+              <span>
+                Parent agent is currently running. Forking an active session may cause unexpected behavior
+                if both tasks resume the same session simultaneously.
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* Agent settings */}
+        <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3">
+          <FormField label="Permission Mode" className="flex-1 w-full sm:w-auto" labelSize="xs">
+            <Select
+              value={permissionMode}
+              onChange={(e) => setPermissionMode(e.target.value)}
+              selectSize="xs"
+              className="!rounded"
+            >
+              <option value="">Default (ask for permission)</option>
+              <option value="acceptEdits">Accept Edits (auto-approve file changes)</option>
+              <option value="bypassPermissions">Bypass Permissions (auto-approve all)</option>
+            </Select>
+          </FormField>
+          <Checkbox
+            label="Use Worktree"
+            checked={useWorktree}
+            onChange={(e) => setUseWorktree(e.target.checked)}
+            className="!text-xs sm:pt-4"
+          />
+        </div>
+
+        {/* Worktree selection */}
+        {useWorktree && (
+          <div className="pl-6">
+            <div className="flex items-center gap-2 mb-1">
+              <GitBranch className="w-3.5 h-3.5 text-gray-500" />
+              <label className="text-xs text-gray-400">Worktree</label>
+              <button
+                type="button"
+                onClick={() => requestWtMut.mutate({ projectId })}
+                className="text-gray-500 hover:text-gray-300 transition-colors"
+                title="Refresh worktree list"
+              >
+                <RefreshCw className={`w-3 h-3 ${requestWtMut.isPending ? 'animate-spin' : ''}`} />
+              </button>
+            </div>
+            <Select
+              value={selectedWorktree}
+              onChange={(e) => setSelectedWorktree(e.target.value)}
+            >
+              <option value="">New worktree (auto-generated)</option>
+              {worktrees.map((wt) => (
+                <option key={wt.name} value={wt.name}>
+                  {wt.name} ({wt.branch})
+                </option>
+              ))}
+            </Select>
+          </div>
+        )}
+
+        {/* Action buttons */}
+        <div className="border-t border-slate-800 mt-4 pt-3 flex justify-end items-center gap-2">
+          <Button variant="secondary" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleCreate}
+            disabled={createMut.isPending || !title.trim()}
+          >
+            {createMut.isPending ? 'Creating...' : 'Create Subtask'}
+          </Button>
+        </div>
+      </Modal.Body>
+    </Modal>
+  )
+}

--- a/frontend/taskguild/src/components/organisms/TaskBoard.tsx
+++ b/frontend/taskguild/src/components/organisms/TaskBoard.tsx
@@ -21,6 +21,7 @@ import { useEventSubscription } from '@/hooks/useEventSubscription'
 import { TaskCard } from './TaskCard.tsx'
 import { TaskDetailModal } from './TaskDetailModal.tsx'
 import { TaskCreateModal } from './TaskCreateModal.tsx'
+import { ChildTaskCreateModal } from './ChildTaskCreateModal.tsx'
 import { ForceTransitionDialog } from './ForceTransitionDialog.tsx'
 import { CleanTasksDialog } from './CleanTasksDialog.tsx'
 import { ArchivedTaskList } from './ArchivedTaskList.tsx'
@@ -60,6 +61,7 @@ export function TaskBoard({ projectId, workflow, headerActionsRef }: TaskBoardPr
   })
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null)
   const [activeTask, setActiveTask] = useState<Task | null>(null)
+  const [creatingChildForTask, setCreatingChildForTask] = useState<Task | null>(null)
 
   // Track whether the last drop was a successful status transition (for animation control)
   const lastDropWasSuccessful = useRef(false)
@@ -97,6 +99,34 @@ export function TaskBoard({ projectId, workflow, headerActionsRef }: TaskBoardPr
     }
     return map
   }, [sortedStatuses])
+
+  // Compute parent-child relationships from task metadata
+  const childTasksByParentId = useMemo(() => {
+    const map = new Map<string, { id: string; title: string; statusId: string }[]>()
+    for (const t of tasks) {
+      const parentId = t.metadata?.['source_task_id']
+      if (parentId) {
+        if (!map.has(parentId)) map.set(parentId, [])
+        map.get(parentId)!.push({ id: t.id, title: t.title, statusId: t.statusId })
+      }
+    }
+    return map
+  }, [tasks])
+
+  // Map from task ID to parent task info
+  const parentTaskById = useMemo(() => {
+    const map = new Map<string, { id: string; title: string }>()
+    for (const t of tasks) {
+      const parentId = t.metadata?.['source_task_id']
+      if (parentId) {
+        const parent = tasks.find((p) => p.id === parentId)
+        if (parent) {
+          map.set(t.id, { id: parent.id, title: parent.title })
+        }
+      }
+    }
+    return map
+  }, [tasks])
 
   // Fetch project agents to resolve agent names from status agent_id.
   const { data: agentsData } = useQuery(listAgents, { projectId })
@@ -328,6 +358,26 @@ export function TaskBoard({ projectId, workflow, headerActionsRef }: TaskBoardPr
     [executeTransition, tasks, statusById],
   )
 
+  /** Open child task creation modal from TaskCard or TaskDetailModal */
+  const handleCreateChild = useCallback(
+    (taskOrId: Task | string) => {
+      if (typeof taskOrId === 'string') {
+        // From TaskCard — find the task by ID
+        const task = tasks.find((t) => t.id === taskOrId)
+        if (task) setCreatingChildForTask(task)
+      } else {
+        // From TaskDetailModal — task object passed directly
+        setCreatingChildForTask(taskOrId)
+      }
+    },
+    [tasks],
+  )
+
+  /** Navigate to a related task (open its detail modal) */
+  const handleNavigateTask = useCallback((taskId: string) => {
+    setEditingTaskId(taskId)
+  }, [])
+
   return (
     <DndContext
       sensors={sensors}
@@ -365,6 +415,7 @@ export function TaskBoard({ projectId, workflow, headerActionsRef }: TaskBoardPr
                 tasks={tasksByStatus.get(status.id) ?? []}
                 agentConfigName={agentConfigByStatusId.get(status.id)}
                 onEdit={setEditingTaskId}
+                onCreateChild={handleCreateChild}
                 onCreated={() => refetch()}
                 isNormalTarget={normalTargetIds.has(status.id)}
                 isForceTarget={forceTargetIds.has(status.id)}
@@ -373,6 +424,8 @@ export function TaskBoard({ projectId, workflow, headerActionsRef }: TaskBoardPr
                 onTransition={handleMobileTransition}
                 defaultPermissionMode={workflow.defaultPermissionMode}
                 defaultUseWorktree={workflow.defaultUseWorktree}
+                childTasksByParentId={childTasksByParentId}
+                parentTaskById={parentTaskById}
               />
             ))}
           </div>
@@ -395,6 +448,21 @@ export function TaskBoard({ projectId, workflow, headerActionsRef }: TaskBoardPr
               currentStatusId={tasks.find((t) => t.id === editingTaskId)?.statusId ?? ''}
               onClose={() => setEditingTaskId(null)}
               onChanged={() => refetch()}
+              onCreateChild={handleCreateChild}
+              childTasks={childTasksByParentId.get(editingTaskId)}
+              parentTask={parentTaskById.get(editingTaskId) ?? null}
+              onNavigateTask={handleNavigateTask}
+            />
+          )}
+
+          {/* Child task creation modal */}
+          {creatingChildForTask && (
+            <ChildTaskCreateModal
+              parentTask={creatingChildForTask}
+              projectId={projectId}
+              workflowId={workflow.id}
+              onCreated={() => refetch()}
+              onClose={() => setCreatingChildForTask(null)}
             />
           )}
 
@@ -439,6 +507,7 @@ function StatusColumn({
   tasks,
   agentConfigName,
   onEdit,
+  onCreateChild,
   onCreated,
   isNormalTarget,
   isForceTarget,
@@ -447,6 +516,8 @@ function StatusColumn({
   onTransition,
   defaultPermissionMode,
   defaultUseWorktree,
+  childTasksByParentId,
+  parentTaskById,
 }: {
   projectId: string
   workflowId: string
@@ -454,6 +525,7 @@ function StatusColumn({
   tasks: Task[]
   agentConfigName?: string
   onEdit: (id: string) => void
+  onCreateChild: (taskId: string) => void
   onCreated: () => void
   isNormalTarget: boolean
   isForceTarget: boolean
@@ -462,6 +534,8 @@ function StatusColumn({
   onTransition: (taskId: string, targetStatusId: string, isForce: boolean) => void
   defaultPermissionMode?: string
   defaultUseWorktree?: boolean
+  childTasksByParentId: Map<string, { id: string; title: string; statusId: string }[]>
+  parentTaskById: Map<string, { id: string; title: string }>
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: status.id })
   const [showCreateModal, setShowCreateModal] = useState(false)
@@ -528,8 +602,11 @@ function StatusColumn({
               key={task.id}
               task={task}
               onEdit={onEdit}
+              onCreateChild={onCreateChild}
               transitionTargets={transitionTargets}
               onTransition={onTransition}
+              childCount={childTasksByParentId.get(task.id)?.length}
+              parentTaskTitle={parentTaskById.get(task.id)?.title}
             />
           ))}
           {tasks.length === 0 && (

--- a/frontend/taskguild/src/components/organisms/TaskCard.tsx
+++ b/frontend/taskguild/src/components/organisms/TaskCard.tsx
@@ -3,7 +3,7 @@ import { useDraggable } from '@dnd-kit/core'
 import { useNavigate } from '@tanstack/react-router'
 import type { Task } from '@taskguild/proto/taskguild/v1/task_pb.ts'
 import { TaskAssignmentStatus } from '@taskguild/proto/taskguild/v1/task_pb.ts'
-import { Bot, Clock, GitBranch, Loader, Pencil, ArrowRight, AlertTriangle } from 'lucide-react'
+import { Bot, Clock, GitBranch, Loader, Pencil, ArrowRight, AlertTriangle, CopyPlus, ArrowUpRight, Layers } from 'lucide-react'
 import { shortId } from '@/lib/id'
 import { Badge } from '../atoms/index.ts'
 import { DropdownMenu } from '../molecules/index.ts'
@@ -17,14 +17,19 @@ interface TransitionTarget {
 interface TaskCardProps {
   task: Task
   onEdit?: (taskId: string) => void
+  onCreateChild?: (taskId: string) => void
   isDragOverlay?: boolean
   /** Available status transitions for this task (mobile UI) */
   transitionTargets?: TransitionTarget[]
   /** Callback when a status transition is selected (mobile UI) */
   onTransition?: (taskId: string, targetStatusId: string, isForce: boolean) => void
+  /** Number of child tasks for this task */
+  childCount?: number
+  /** Parent task title (when this task is a child) */
+  parentTaskTitle?: string
 }
 
-export function TaskCard({ task, onEdit, isDragOverlay, transitionTargets, onTransition }: TaskCardProps) {
+export function TaskCard({ task, onEdit, onCreateChild, isDragOverlay, transitionTargets, onTransition, childCount, parentTaskTitle }: TaskCardProps) {
   const navigate = useNavigate()
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: task.id,
@@ -106,6 +111,20 @@ export function TaskCard({ task, onEdit, isDragOverlay, transitionTargets, onTra
               </DropdownMenu>
             </div>
           )}
+          {/* Create subtask button (always visible on mobile, hover on desktop) */}
+          {onCreateChild && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onCreateChild(task.id)
+              }}
+              onPointerDown={(e) => e.stopPropagation()}
+              className="opacity-100 md:opacity-0 md:group-hover:opacity-100 shrink-0 p-1 text-gray-500 hover:text-cyan-400 hover:bg-slate-700 rounded transition-all"
+              title="Create subtask"
+            >
+              <CopyPlus className="w-3.5 h-3.5" />
+            </button>
+          )}
           {/* Edit button (always visible on mobile, hover on desktop) */}
           {onEdit && (
             <button
@@ -128,6 +147,14 @@ export function TaskCard({ task, onEdit, isDragOverlay, transitionTargets, onTra
         </p>
       )}
 
+      {/* Parent task link */}
+      {parentTaskTitle && (
+        <div className="mt-1.5 flex items-center gap-1 text-[11px] text-gray-500 truncate">
+          <ArrowUpRight className="w-3 h-3 shrink-0 text-gray-600" />
+          <span className="truncate">{parentTaskTitle}</span>
+        </div>
+      )}
+
       {/* Worktree indicator */}
       {task.useWorktree && (
         <div className="mt-1.5 flex items-center gap-1 text-xs text-gray-500 truncate">
@@ -136,22 +163,30 @@ export function TaskCard({ task, onEdit, isDragOverlay, transitionTargets, onTra
         </div>
       )}
 
-      {/* Assignment status + ID */}
+      {/* Assignment status + child count + ID */}
       <div className="mt-2 flex items-end justify-between">
-        {task.assignmentStatus === TaskAssignmentStatus.ASSIGNED ? (
-          <Badge color="cyan" variant="outline" pill icon={<Bot className="w-3 h-3" />}>
-            {shortId(task.assignedAgentId)}
-          </Badge>
-        ) : task.assignmentStatus === TaskAssignmentStatus.PENDING ? (
-          <Badge color="yellow" variant="outline" pill icon={<Loader className="w-3 h-3" />}>
-            Pending
-          </Badge>
-        ) : (
-          <span className="inline-flex items-center gap-1 text-xs text-gray-500">
-            <Clock className="w-3 h-3" />
-            Unassigned
-          </span>
-        )}
+        <div className="flex items-center gap-1.5">
+          {task.assignmentStatus === TaskAssignmentStatus.ASSIGNED ? (
+            <Badge color="cyan" variant="outline" pill icon={<Bot className="w-3 h-3" />}>
+              {shortId(task.assignedAgentId)}
+            </Badge>
+          ) : task.assignmentStatus === TaskAssignmentStatus.PENDING ? (
+            <Badge color="yellow" variant="outline" pill icon={<Loader className="w-3 h-3" />}>
+              Pending
+            </Badge>
+          ) : (
+            <span className="inline-flex items-center gap-1 text-xs text-gray-500">
+              <Clock className="w-3 h-3" />
+              Unassigned
+            </span>
+          )}
+          {/* Child task count badge */}
+          {childCount != null && childCount > 0 && (
+            <Badge color="purple" size="xs" variant="outline" pill icon={<Layers className="w-2.5 h-2.5" />}>
+              {childCount}
+            </Badge>
+          )}
+        </div>
         <span className="text-[10px] text-gray-600 font-mono">{shortId(task.id)}</span>
       </div>
     </div>

--- a/frontend/taskguild/src/components/organisms/TaskDetailModal.tsx
+++ b/frontend/taskguild/src/components/organisms/TaskDetailModal.tsx
@@ -4,11 +4,12 @@ import { getTask, updateTask, updateTaskStatus, deleteTask } from '@taskguild/pr
 import { requestWorktreeList, getWorktreeList } from '@taskguild/proto/taskguild/v1/agent_manager-AgentManagerService_connectquery.ts'
 import { listInteractions, respondToInteraction } from '@taskguild/proto/taskguild/v1/interaction-InteractionService_connectquery.ts'
 import { TaskAssignmentStatus } from '@taskguild/proto/taskguild/v1/task_pb.ts'
+import type { Task } from '@taskguild/proto/taskguild/v1/task_pb.ts'
 import { EventType } from '@taskguild/proto/taskguild/v1/event_pb.ts'
 import { InteractionStatus, InteractionType } from '@taskguild/proto/taskguild/v1/interaction_pb.ts'
 import type { WorkflowStatus } from '@taskguild/proto/taskguild/v1/workflow_pb.ts'
 import { useEventSubscription } from '@/hooks/useEventSubscription'
-import { X, Bot, Clock, GitBranch, Loader, Trash2, ArrowRight, AlertTriangle, MessageSquare, Shield, Bell, RefreshCw } from 'lucide-react'
+import { X, Bot, Clock, GitBranch, Loader, Trash2, ArrowRight, AlertTriangle, MessageSquare, Shield, Bell, RefreshCw, CopyPlus, ArrowUpRight, Layers } from 'lucide-react'
 import { MarkdownDescription } from './MarkdownDescription'
 import { ForceTransitionDialog } from './ForceTransitionDialog'
 import { shortId } from '@/lib/id'
@@ -24,6 +25,12 @@ const TASK_DETAIL_EVENT_TYPES = [
   EventType.INTERACTION_RESPONDED,
 ]
 
+interface ChildTaskInfo {
+  id: string
+  title: string
+  statusId: string
+}
+
 interface TaskDetailModalProps {
   taskId: string
   projectId: string
@@ -32,6 +39,14 @@ interface TaskDetailModalProps {
   onClose: () => void
   onChanged: () => void
   onDeleted?: () => void
+  /** Callback to open the child task creation modal */
+  onCreateChild?: (task: Task) => void
+  /** Child tasks of this task */
+  childTasks?: ChildTaskInfo[]
+  /** Parent task info (if this task is a child) */
+  parentTask?: { id: string; title: string } | null
+  /** Callback when clicking on a related task (parent or child) */
+  onNavigateTask?: (taskId: string) => void
 }
 
 export function TaskDetailModal({
@@ -42,6 +57,10 @@ export function TaskDetailModal({
   onClose,
   onChanged,
   onDeleted,
+  onCreateChild,
+  childTasks,
+  parentTask,
+  onNavigateTask,
 }: TaskDetailModalProps) {
   const { data: taskData, refetch: refetchTask } = useQuery(getTask, { id: taskId })
   const { data: interactionsData, refetch: refetchInteractions } = useQuery(listInteractions, { taskId })
@@ -232,6 +251,21 @@ export function TaskDetailModal({
 
       {/* Body */}
       <Modal.Body>
+        {/* Parent task link */}
+        {parentTask && (
+          <Card variant="nested" className="!rounded-lg !py-2 !px-3">
+            <button
+              onClick={() => onNavigateTask?.(parentTask.id)}
+              className="flex items-center gap-2 text-xs text-gray-400 hover:text-white transition-colors w-full text-left"
+            >
+              <ArrowUpRight className="w-3.5 h-3.5 text-gray-500 shrink-0" />
+              <span className="text-gray-500">Parent:</span>
+              <span className="font-medium truncate">{parentTask.title}</span>
+              <span className="text-gray-600 font-mono shrink-0">{shortId(parentTask.id)}</span>
+            </button>
+          </Card>
+        )}
+
         <Textarea
           value={descDraft}
           onChange={(e) => setDescDraft(e.target.value)}
@@ -353,6 +387,40 @@ export function TaskDetailModal({
           <span className="text-[11px] text-gray-600 font-mono ml-auto hidden sm:inline">{task.id}</span>
         </div>
 
+        {/* Child tasks */}
+        {childTasks && childTasks.length > 0 && (
+          <div>
+            <h4 className="text-xs text-gray-500 uppercase tracking-wide mb-2 flex items-center gap-1.5">
+              <Layers className="w-3 h-3" />
+              Subtasks ({childTasks.length})
+            </h4>
+            <div className="space-y-1">
+              {childTasks.map((child) => {
+                const childStatus = statuses.find((s) => s.id === child.statusId)
+                return (
+                  <button
+                    key={child.id}
+                    onClick={() => onNavigateTask?.(child.id)}
+                    className="flex items-center gap-2 w-full text-left px-2.5 py-1.5 text-xs bg-slate-800/50 border border-slate-700/50 rounded-lg hover:border-slate-600 hover:bg-slate-800 transition-colors"
+                  >
+                    <span className="text-white font-medium truncate flex-1">{child.title}</span>
+                    {childStatus && (
+                      <Badge
+                        color={childStatus.isInitial ? 'blue' : childStatus.isTerminal ? 'green' : 'gray'}
+                        size="xs"
+                        pill
+                      >
+                        {childStatus.name}
+                      </Badge>
+                    )}
+                    <span className="text-[10px] text-gray-600 font-mono shrink-0">{shortId(child.id)}</span>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
         {/* Interactions */}
         {interactions.length > 0 && (
           <div>
@@ -372,16 +440,29 @@ export function TaskDetailModal({
 
         {/* Action buttons */}
         <div className="border-t border-slate-800 mt-4 pt-3 flex justify-between items-center">
-          <Button
-            variant="ghost"
-            size="sm"
-            icon={<Trash2 className="w-3.5 h-3.5" />}
-            onClick={handleDelete}
-            disabled={deleteMut.isPending}
-            className="!text-gray-500 hover:!text-red-400"
-          >
-            Delete
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={<Trash2 className="w-3.5 h-3.5" />}
+              onClick={handleDelete}
+              disabled={deleteMut.isPending}
+              className="!text-gray-500 hover:!text-red-400"
+            >
+              Delete
+            </Button>
+            {onCreateChild && task && (
+              <Button
+                variant="ghost"
+                size="sm"
+                icon={<CopyPlus className="w-3.5 h-3.5" />}
+                onClick={() => onCreateChild(task)}
+                className="!text-gray-500 hover:!text-cyan-400"
+              >
+                Subtask
+              </Button>
+            )}
+          </div>
           <div className="flex items-center gap-2">
             <Button variant="secondary" size="sm" onClick={handleCancel}>
               Cancel


### PR DESCRIPTION
## Summary
- Add new `ChildTaskCreateModal` component for creating subtasks linked to a parent task via `source_task_id` metadata
- Display parent-child relationships in `TaskCard` (parent task label, child count badge) and `TaskDetailModal` (parent link, subtask list with status badges)
- Support session forking option to inherit parent agent's conversation context
- Enable navigation between related tasks (click parent/child to open detail modal)
- Inherit parent task settings (permission mode, worktree) as defaults for new subtasks

## Test plan
- [ ] Create a subtask from TaskCard's new subtask button → verify modal opens with parent reference
- [ ] Create a subtask from TaskDetailModal's subtask button → verify modal opens correctly
- [ ] Verify child count badge appears on parent TaskCard after subtask creation
- [ ] Verify parent task link appears on child TaskCard
- [ ] Open TaskDetailModal for parent → verify subtask list with status badges
- [ ] Open TaskDetailModal for child → verify parent link and navigation
- [ ] Click on parent/child links → verify navigation opens correct task detail
- [ ] Test session forking option with running/stopped parent agents
- [ ] Verify worktree selection works in subtask creation modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)