### PR TITLE
Add chat notifier for task status change notifications

### DIFF
--- a/backend/cmd/taskguild-server/run.go
+++ b/backend/cmd/taskguild-server/run.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kazz187/taskguild/backend/internal/agent"
 	agentrepo "github.com/kazz187/taskguild/backend/internal/agent/repositoryimpl"
 	"github.com/kazz187/taskguild/backend/internal/agentmanager"
+	"github.com/kazz187/taskguild/backend/internal/chatnotifier"
 	"github.com/kazz187/taskguild/backend/internal/config"
 	"github.com/kazz187/taskguild/backend/internal/event"
 	"github.com/kazz187/taskguild/backend/internal/eventbus"
@@ -192,6 +193,9 @@ func runServer() {
 	// Setup orchestrator
 	orch := orchestrator.New(bus, taskRepo, workflowRepo, projectRepo, agentManagerRegistry)
 
+	// Setup chat notifier (creates notification interactions on task status changes)
+	chatNotifier := chatnotifier.New(bus, interactionRepo, taskRepo, workflowRepo)
+
 	// Graceful shutdown context: responds to SIGTERM and SIGINT.
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
@@ -220,6 +224,7 @@ func runServer() {
 
 	go orch.Start(ctx)
 	go pushDispatcher.Start(ctx)
+	go chatNotifier.Start(ctx)
 
 	go func() {
 		if err := srv.ListenAndServe(ctx); err != nil && err != http.ErrServerClosed {

--- a/backend/internal/chatnotifier/notifier.go
+++ b/backend/internal/chatnotifier/notifier.go
@@ -1,0 +1,114 @@
+package chatnotifier
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+
+	"github.com/kazz187/taskguild/backend/internal/eventbus"
+	"github.com/kazz187/taskguild/backend/internal/interaction"
+	"github.com/kazz187/taskguild/backend/internal/task"
+	"github.com/kazz187/taskguild/backend/internal/workflow"
+	taskguildv1 "github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1"
+)
+
+// Notifier subscribes to task lifecycle events and creates notification
+// interactions so that status changes appear in Chat and Global Chat.
+type Notifier struct {
+	eventBus        *eventbus.Bus
+	interactionRepo interaction.Repository
+	taskRepo        task.Repository
+	workflowRepo    workflow.Repository
+}
+
+func New(eventBus *eventbus.Bus, interactionRepo interaction.Repository, taskRepo task.Repository, workflowRepo workflow.Repository) *Notifier {
+	return &Notifier{
+		eventBus:        eventBus,
+		interactionRepo: interactionRepo,
+		taskRepo:        taskRepo,
+		workflowRepo:    workflowRepo,
+	}
+}
+
+// Start subscribes to the event bus and creates notification interactions
+// for task status changes. It blocks until ctx is cancelled.
+func (n *Notifier) Start(ctx context.Context) {
+	subID, ch := n.eventBus.Subscribe(256)
+	defer n.eventBus.Unsubscribe(subID)
+
+	slog.Info("chat notifier started")
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("chat notifier stopped")
+			return
+		case event, ok := <-ch:
+			if !ok {
+				return
+			}
+			switch event.Type {
+			case taskguildv1.EventType_EVENT_TYPE_TASK_STATUS_CHANGED:
+				n.handleTaskStatusChanged(ctx, event)
+			}
+		}
+	}
+}
+
+func (n *Notifier) handleTaskStatusChanged(ctx context.Context, event *taskguildv1.Event) {
+	taskID := event.ResourceId
+	newStatusID := event.Metadata["new_status_id"]
+
+	t, err := n.taskRepo.Get(ctx, taskID)
+	if err != nil {
+		slog.Error("chat notifier: failed to get task", "task_id", taskID, "error", err)
+		return
+	}
+
+	// Resolve the new status name from the workflow.
+	statusName := newStatusID
+	wf, err := n.workflowRepo.Get(ctx, t.WorkflowID)
+	if err != nil {
+		slog.Warn("chat notifier: failed to get workflow, using status ID", "workflow_id", t.WorkflowID, "error", err)
+	} else {
+		for _, s := range wf.Statuses {
+			if s.ID == newStatusID {
+				statusName = s.Name
+				break
+			}
+		}
+	}
+
+	// Create a notification interaction.
+	now := time.Now()
+	inter := &interaction.Interaction{
+		ID:          ulid.Make().String(),
+		TaskID:      taskID,
+		Type:        interaction.TypeNotification,
+		Status:      interaction.StatusResponded,
+		Title:       fmt.Sprintf("Task status changed to %s", statusName),
+		CreatedAt:   now,
+		RespondedAt: &now,
+	}
+
+	if err := n.interactionRepo.Create(ctx, inter); err != nil {
+		slog.Error("chat notifier: failed to create notification interaction", "task_id", taskID, "error", err)
+		return
+	}
+
+	// Publish event so that Chat and Global Chat receive the notification in real time.
+	n.eventBus.PublishNew(
+		taskguildv1.EventType_EVENT_TYPE_INTERACTION_CREATED,
+		inter.ID,
+		"",
+		map[string]string{"task_id": inter.TaskID, "project_id": t.ProjectID},
+	)
+
+	slog.Info("chat notifier: status change notification created",
+		"task_id", taskID,
+		"task_title", t.Title,
+		"new_status", statusName,
+	)
+}


### PR DESCRIPTION
## Summary
- Introduce `chatnotifier` package that subscribes to task status change events via the event bus
- Creates notification interactions (`TypeNotification`) when a task's status changes, resolving the status name from the workflow
- Publishes `INTERACTION_CREATED` events so Chat and Global Chat receive real-time updates
- Wire up the notifier in `run.go` to start as a background goroutine

## Test plan
- [ ] Verify that changing a task's status creates a notification interaction in the database
- [ ] Confirm the notification appears in Chat and Global Chat in real time
- [ ] Test with an invalid task ID or workflow ID to ensure graceful error handling
- [ ] Verify the notifier shuts down cleanly on server stop (context cancellation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)