### PR TITLE
Fix DropdownMenu flashing at (0,0) on mobile before positioning

### DIFF
--- a/frontend/taskguild/src/components/molecules/DropdownMenu.tsx
+++ b/frontend/taskguild/src/components/molecules/DropdownMenu.tsx
@@ -31,7 +31,7 @@ export function DropdownMenu({
   children,
   className = '',
 }: DropdownMenuProps) {
-  const { refs, floatingStyles, context } = useFloating({
+  const { refs, floatingStyles, context, isPositioned } = useFloating({
     open,
     onOpenChange,
     placement: align === 'left' ? 'bottom-start' : 'bottom-end',
@@ -57,9 +57,15 @@ export function DropdownMenu({
     <FloatingPortal>
       <div
         ref={refs.setFloating}
-        style={floatingStyles}
+        style={{
+          ...floatingStyles,
+          // Hide the floating element until floating-ui has computed the
+          // correct position.  Without this the element briefly flashes at
+          // (0, 0) on mobile before jumping to the anchor.
+          ...(isPositioned ? {} : { visibility: 'hidden' as const }),
+        }}
         {...getFloatingProps()}
-        className={`z-50 bg-slate-800 border border-slate-600 rounded-lg shadow-xl py-1 min-w-[160px] animate-fade-in-down ${className}`}
+        className={`z-50 bg-slate-800 border border-slate-600 rounded-lg shadow-xl py-1 min-w-[160px] ${isPositioned ? 'animate-fade-in-down' : ''} ${className}`}
       >
         {children}
       </div>


### PR DESCRIPTION
## Summary
- Fix DropdownMenu briefly flashing at coordinates (0, 0) on mobile devices before floating-ui computes the correct position
- Use `isPositioned` from `useFloating` to hide the floating element with `visibility: hidden` until positioning is complete
- Defer `animate-fade-in-down` animation until the element is properly positioned

## Test plan
- [ ] Open a DropdownMenu on a mobile device (or mobile emulator) and verify it no longer flashes at the top-left corner
- [ ] Verify the dropdown still appears with the fade-in animation at the correct anchor position
- [ ] Verify desktop behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)