### PR TITLE
Fix pending tasks stuck and unable to be archived

### DIFF
--- a/backend/internal/task/server.go
+++ b/backend/internal/task/server.go
@@ -286,6 +286,18 @@ func (s *Server) UpdateTaskStatus(ctx context.Context, req *connect.Request[task
 
 	t.StatusID = req.Msg.StatusId
 	t.UpdatedAt = time.Now()
+
+	// If the task is pending assignment and the target status has no agent
+	// configured, reset assignment_status to unassigned. This prevents tasks
+	// from being stuck in "pending" after moving to a status (e.g. terminal)
+	// where no agent will ever claim them.
+	if t.AssignmentStatus == AssignmentStatusPending {
+		if !statusHasAgent(wf, req.Msg.StatusId) {
+			t.AssignmentStatus = AssignmentStatusUnassigned
+			t.AssignedAgentID = ""
+		}
+	}
+
 	if err := s.repo.Update(ctx, t); err != nil {
 		return nil, err
 	}
@@ -355,8 +367,10 @@ func (s *Server) ArchiveTerminalTasks(ctx context.Context, req *connect.Request[
 		if !terminalStatusIDs[t.StatusID] {
 			continue
 		}
-		// Skip tasks that have agents running (pending or assigned).
-		if t.AssignmentStatus == AssignmentStatusPending || t.AssignmentStatus == AssignmentStatusAssigned {
+		// Skip tasks where an agent is actively running (assigned).
+		// Pending tasks in a terminal status are safe to archive because no
+		// agent will ever claim them (terminal statuses have no agent configured).
+		if t.AssignmentStatus == AssignmentStatusAssigned {
 			skipped = append(skipped, toProto(t))
 			continue
 		}
@@ -445,6 +459,22 @@ func toProto(t *Task) *taskguildv1.Task {
 		CreatedAt:        timestamppb.New(t.CreatedAt),
 		UpdatedAt:        timestamppb.New(t.UpdatedAt),
 	}
+}
+
+// statusHasAgent returns true if the given status has an agent configured,
+// either via the status-level AgentID or via the legacy AgentConfig list.
+func statusHasAgent(wf *workflow.Workflow, statusID string) bool {
+	for _, st := range wf.Statuses {
+		if st.ID == statusID && st.AgentID != "" {
+			return true
+		}
+	}
+	for _, cfg := range wf.AgentConfigs {
+		if cfg.WorkflowStatusID == statusID {
+			return true
+		}
+	}
+	return false
 }
 
 func assignmentStatusToProto(s AssignmentStatus) taskguildv1.TaskAssignmentStatus {

--- a/frontend/taskguild/src/components/organisms/CleanTasksDialog.tsx
+++ b/frontend/taskguild/src/components/organisms/CleanTasksDialog.tsx
@@ -33,16 +33,14 @@ export function CleanTasksDialog({
     errors: string[]
   } | null>(null)
 
-  // Split into archivable (unassigned) and skipped (agent running)
+  // Split into archivable and skipped (agent actively running).
+  // Pending tasks in a terminal status are safe to archive because no agent
+  // will ever claim them — only actively assigned tasks should be skipped.
   const archivable = terminalTasks.filter(
-    (t) =>
-      t.assignmentStatus === TaskAssignmentStatus.UNASSIGNED ||
-      t.assignmentStatus === TaskAssignmentStatus.UNSPECIFIED,
+    (t) => t.assignmentStatus !== TaskAssignmentStatus.ASSIGNED,
   )
   const skipped = terminalTasks.filter(
-    (t) =>
-      t.assignmentStatus === TaskAssignmentStatus.PENDING ||
-      t.assignmentStatus === TaskAssignmentStatus.ASSIGNED,
+    (t) => t.assignmentStatus === TaskAssignmentStatus.ASSIGNED,
   )
 
   const handleArchive = () => {


### PR DESCRIPTION
## Summary
- Reset `assignment_status` to `unassigned` when a pending task is moved to a status with no agent configured, preventing tasks from being permanently stuck in "pending"
- Allow pending tasks in terminal statuses to be archived, since no agent will ever claim them — only actively assigned tasks are now skipped
- Add `statusHasAgent` helper to check whether a workflow status has an agent configured (via status-level AgentID or legacy AgentConfig)
- Update frontend `CleanTasksDialog` filtering logic to match the new backend behavior

## Test plan
- [ ] Move a pending task to a terminal status (e.g. Done) and verify its assignment_status resets to unassigned
- [ ] Verify that pending tasks in terminal statuses can be archived via the Clean Tasks dialog
- [ ] Verify that actively assigned tasks in terminal statuses are still skipped during archival
- [ ] Confirm that tasks moving to a status with an agent configured retain their pending assignment status

🤖 Generated with [Claude Code](https://claude.com/claude-code)