### PR TITLE
Fix: Make archived task list scrollable

### DIFF
--- a/frontend/taskguild/src/components/organisms/ArchivedTaskList.tsx
+++ b/frontend/taskguild/src/components/organisms/ArchivedTaskList.tsx
@@ -70,7 +70,7 @@ export function ArchivedTaskList({ projectId, workflowId, statusById }: Archived
       </button>
 
       {expanded && (
-        <div className="mt-3 space-y-2">
+        <div className="mt-3 space-y-2 max-h-[50vh] overflow-y-auto">
           {archivedTasks.map((task) => (
             <ArchivedTaskCard
               key={task.id}


### PR DESCRIPTION
## Summary
- Add `max-h-[50vh]` and `overflow-y-auto` to the ArchivedTaskList expanded container
- Prevents the archived task list from growing unboundedly when many tasks are archived, keeping the UI usable

## Test plan
- [ ] Open a workflow with many archived tasks
- [ ] Expand the archived tasks section
- [ ] Verify the list is constrained to 50vh and scrollable
- [ ] Verify scrolling works smoothly within the archived task list

🤖 Generated with [Claude Code](https://claude.com/claude-code)