### PR TITLE
Fix: align Done badge for Notification items in Chat timeline

### DIFF
--- a/frontend/taskguild/src/components/organisms/TimelineEntry.tsx
+++ b/frontend/taskguild/src/components/organisms/TimelineEntry.tsx
@@ -86,15 +86,17 @@ function InteractionEntry({ interaction }: { interaction: Interaction }) {
           {interaction.title}
         </span>
         {statusBadge}
-        {expandable && (
-          <span className="shrink-0 mt-0.5 text-gray-600">
-            {expanded ? (
+        <span className="shrink-0 mt-0.5 text-gray-600">
+          {expandable ? (
+            expanded ? (
               <ChevronDown className="w-3 h-3" />
             ) : (
               <ChevronRight className="w-3 h-3" />
-            )}
-          </span>
-        )}
+            )
+          ) : (
+            <span className="w-3 h-3 inline-block" />
+          )}
+        </span>
       </div>
 
       {expanded && (


### PR DESCRIPTION
## Summary
- Fix misalignment of the Done badge on Notification items in the Chat timeline
- Always render the chevron icon spacer (even for non-expandable entries) so that badges align consistently across all timeline entry types

## Test plan
- [ ] Verify that Done badge on Notification entries aligns with badges on other timeline entry types
- [ ] Confirm expandable entries still show chevron icons correctly
- [ ] Check that non-expandable entries display a placeholder spacer without visual artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)