### PR TITLE
Fix Hook skill/script select readability in Workflow editor

### DIFF
--- a/frontend/taskguild/src/components/organisms/WorkflowForm.tsx
+++ b/frontend/taskguild/src/components/organisms/WorkflowForm.tsx
@@ -646,7 +646,7 @@ export function WorkflowForm({
                       )}
                       <div className="space-y-2">
                         {s.hooks.map((h, hi) => (
-                          <div key={h.key} className="flex items-center gap-2 bg-slate-900/50 rounded p-2">
+                          <div key={h.key} className="flex items-center gap-2 flex-wrap bg-slate-900/50 rounded p-2">
                             <div className="flex flex-col -my-1">
                               <Button
                                 type="button"
@@ -710,7 +710,7 @@ export function WorkflowForm({
                                   })
                                 }}
                                 selectSize="xs"
-                                className="flex-1 min-w-0 rounded text-[11px]"
+                                className="flex-1 min-w-[140px] rounded text-[11px]"
                               >
                                 <option value="">Select script...</option>
                                 {scripts.map((sc) => (
@@ -731,7 +731,7 @@ export function WorkflowForm({
                                   })
                                 }}
                                 selectSize="xs"
-                                className="flex-1 min-w-0 rounded text-[11px]"
+                                className="flex-1 min-w-[140px] rounded text-[11px]"
                               >
                                 <option value="">Select skill...</option>
                                 {skills.map((sk) => (


### PR DESCRIPTION
## Summary
- Add `flex-wrap` to hook row container to prevent content overflow on narrow screens
- Set `min-w-[140px]` on skill/script select dropdowns (replacing `min-w-0`) to ensure text is readable

## Test plan
- [ ] Open Workflow editor and add a hook with a script select
- [ ] Open Workflow editor and add a hook with a skill select
- [ ] Verify select dropdowns are readable and do not collapse too narrow
- [ ] Verify layout wraps gracefully on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)