### PR TITLE
feat: Add retry logic for invalid status transitions

### DIFF
--- a/backend/cmd/taskguild-agent/directive.go
+++ b/backend/cmd/taskguild-agent/directive.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -11,6 +12,10 @@ import (
 	"github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1/taskguildv1connect"
 	"github.com/kazz187/taskguild/backend/pkg/clog"
 )
+
+// errInvalidTransition is returned when the agent outputs a NEXT_STATUS
+// that does not match any of the available transitions.
+var errInvalidTransition = errors.New("invalid status transition")
 
 // createTaskDirective holds parsed CREATE_TASK directive fields.
 type createTaskDirective struct {
@@ -284,6 +289,84 @@ func stripTaskDescription(resultText string) string {
 	return strings.TrimSpace(resultText[:lineStart] + resultText[fullEndIdx:])
 }
 
+// transitionEntry represents one available status transition.
+type transitionEntry struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// parseAvailableTransitions parses the _available_transitions JSON from metadata.
+func parseAvailableTransitions(metadata map[string]string) ([]transitionEntry, error) {
+	transitionsJSON := metadata["_available_transitions"]
+	if transitionsJSON == "" {
+		return nil, fmt.Errorf("no available transitions in metadata")
+	}
+	var transitions []transitionEntry
+	if err := json.Unmarshal([]byte(transitionsJSON), &transitions); err != nil {
+		return nil, fmt.Errorf("failed to parse available transitions: %w", err)
+	}
+	if len(transitions) == 0 {
+		return nil, fmt.Errorf("available transitions list is empty")
+	}
+	return transitions, nil
+}
+
+// validateAndResolveTransition checks whether nextStatusID matches one of the
+// available transitions in metadata. It first tries an exact ID match, then
+// falls back to case-insensitive name matching. Returns the resolved status ID
+// on success, or errInvalidTransition if no match is found.
+func validateAndResolveTransition(nextStatusID string, metadata map[string]string) (string, error) {
+	transitions, err := parseAvailableTransitions(metadata)
+	if err != nil {
+		return "", err
+	}
+
+	// Exact ID match.
+	for _, t := range transitions {
+		if t.ID == nextStatusID {
+			return t.ID, nil
+		}
+	}
+
+	// Case-insensitive name match.
+	for _, t := range transitions {
+		if strings.EqualFold(t.Name, nextStatusID) {
+			return t.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf("%w: %q (available: %s)", errInvalidTransition, nextStatusID, formatTransitionList(transitions))
+}
+
+// formatTransitionList formats a list of transitions as "ID (Name), ..." for error messages.
+func formatTransitionList(transitions []transitionEntry) string {
+	parts := make([]string, len(transitions))
+	for i, t := range transitions {
+		parts[i] = fmt.Sprintf("%s (%s)", t.ID, t.Name)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// buildTransitionRetryPrompt constructs a corrective prompt to send to the agent
+// when it outputs an invalid NEXT_STATUS value.
+func buildTransitionRetryPrompt(failedStatusID string, metadata map[string]string) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("The status transition to %q failed because it is not a valid transition from the current status.\n\n", failedStatusID))
+
+	transitions, err := parseAvailableTransitions(metadata)
+	if err == nil && len(transitions) > 0 {
+		sb.WriteString("Valid transitions are:\n")
+		for _, t := range transitions {
+			sb.WriteString(fmt.Sprintf("- %s: %s\n", t.ID, t.Name))
+		}
+	}
+
+	sb.WriteString("\nPlease output the correct status on the LAST LINE of your response in the format:\n")
+	sb.WriteString("NEXT_STATUS: <status_id>\n\n")
+	sb.WriteString("Use ONLY one of the status IDs listed above.")
+	return sb.String()
+}
+
 // handleStatusTransition validates and executes a task status transition.
 // nextStatusID is the pre-parsed target status ID (from parseNextStatus).
 // When nextStatusID is empty, auto-transition is attempted if exactly one
@@ -299,21 +382,9 @@ func handleStatusTransition(
 ) error {
 	logger := clog.LoggerFromContext(ctx)
 
-	transitionsJSON := metadata["_available_transitions"]
-	if transitionsJSON == "" {
-		return fmt.Errorf("no available transitions in metadata")
-	}
-
-	type transitionEntry struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-	}
-	var transitions []transitionEntry
-	if err := json.Unmarshal([]byte(transitionsJSON), &transitions); err != nil {
-		return fmt.Errorf("failed to parse available transitions: %w", err)
-	}
-	if len(transitions) == 0 {
-		return fmt.Errorf("available transitions list is empty")
+	transitions, err := parseAvailableTransitions(metadata)
+	if err != nil {
+		return err
 	}
 
 	if nextStatusID == "" {
@@ -324,31 +395,18 @@ func handleStatusTransition(
 			tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
 				fmt.Sprintf("Auto-transitioning to %s (%s)", nextStatusID, transitions[0].Name), nil)
 		} else {
-			var ids []string
-			for _, t := range transitions {
-				ids = append(ids, t.ID)
-			}
-			return fmt.Errorf("no NEXT_STATUS found and %d transitions available (%s), cannot auto-transition", len(transitions), strings.Join(ids, ", "))
+			return fmt.Errorf("no NEXT_STATUS found and %d transitions available (%s), cannot auto-transition", len(transitions), formatTransitionList(transitions))
 		}
 	} else {
-		// Validate the chosen status is in available transitions.
-		valid := false
-		for _, t := range transitions {
-			if t.ID == nextStatusID {
-				valid = true
-				break
-			}
+		// Validate and resolve the chosen status (supports name fallback).
+		resolvedID, err := validateAndResolveTransition(nextStatusID, metadata)
+		if err != nil {
+			return err
 		}
-		if !valid {
-			var ids []string
-			for _, t := range transitions {
-				ids = append(ids, t.ID)
-			}
-			return fmt.Errorf("NEXT_STATUS %q is not a valid transition (available: %s)", nextStatusID, strings.Join(ids, ", "))
-		}
+		nextStatusID = resolvedID
 	}
 
-	_, err := taskClient.UpdateTaskStatus(ctx, connect.NewRequest(&v1.UpdateTaskStatusRequest{
+	_, err = taskClient.UpdateTaskStatus(ctx, connect.NewRequest(&v1.UpdateTaskStatusRequest{
 		Id:       taskID,
 		StatusId: nextStatusID,
 	}))

--- a/backend/cmd/taskguild-agent/directive_test.go
+++ b/backend/cmd/taskguild-agent/directive_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"strings"
 	"testing"
 )
 
@@ -123,4 +125,137 @@ func TestStripNextStatus(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateAndResolveTransition(t *testing.T) {
+	validMetadata := map[string]string{
+		"_available_transitions": `[{"id":"review","name":"Review"},{"id":"develop","name":"Develop"}]`,
+	}
+
+	tests := []struct {
+		name         string
+		nextStatusID string
+		metadata     map[string]string
+		wantID       string
+		wantErr      error
+	}{
+		{
+			name:         "exact ID match",
+			nextStatusID: "review",
+			metadata:     validMetadata,
+			wantID:       "review",
+			wantErr:      nil,
+		},
+		{
+			name:         "case-insensitive name match",
+			nextStatusID: "review",
+			metadata:     validMetadata,
+			wantID:       "review",
+			wantErr:      nil,
+		},
+		{
+			name:         "name match with different case",
+			nextStatusID: "DEVELOP",
+			metadata:     validMetadata,
+			wantID:       "develop",
+			wantErr:      nil,
+		},
+		{
+			name:         "name match mixed case",
+			nextStatusID: "Review",
+			metadata:     validMetadata,
+			wantID:       "review",
+			wantErr:      nil,
+		},
+		{
+			name:         "invalid status ID",
+			nextStatusID: "nonexistent",
+			metadata:     validMetadata,
+			wantID:       "",
+			wantErr:      errInvalidTransition,
+		},
+		{
+			name:         "empty transitions metadata",
+			nextStatusID: "review",
+			metadata:     map[string]string{},
+			wantID:       "",
+			wantErr:      nil, // generic error, not errInvalidTransition
+		},
+		{
+			name:         "invalid JSON in transitions",
+			nextStatusID: "review",
+			metadata:     map[string]string{"_available_transitions": "invalid"},
+			wantID:       "",
+			wantErr:      nil, // generic error, not errInvalidTransition
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, err := validateAndResolveTransition(tt.nextStatusID, tt.metadata)
+			if tt.wantErr != nil {
+				if err == nil {
+					t.Fatalf("expected error wrapping %v, got nil", tt.wantErr)
+				}
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("expected error wrapping %v, got %v", tt.wantErr, err)
+				}
+			} else if tt.wantID != "" {
+				// Expect success.
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if gotID != tt.wantID {
+					t.Errorf("got ID %q, want %q", gotID, tt.wantID)
+				}
+			} else {
+				// Expect some generic error (not errInvalidTransition).
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				if errors.Is(err, errInvalidTransition) {
+					t.Errorf("expected generic error, got errInvalidTransition: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildTransitionRetryPrompt(t *testing.T) {
+	t.Run("with valid transitions", func(t *testing.T) {
+		metadata := map[string]string{
+			"_available_transitions": `[{"id":"review","name":"Review"},{"id":"closed","name":"Closed"}]`,
+		}
+		prompt := buildTransitionRetryPrompt("invalid_status", metadata)
+
+		// Should mention the failed status.
+		if !strings.Contains(prompt, "invalid_status") {
+			t.Error("prompt should contain the failed status ID")
+		}
+		// Should list valid transitions.
+		if !strings.Contains(prompt, "review") {
+			t.Error("prompt should contain valid transition ID 'review'")
+		}
+		if !strings.Contains(prompt, "closed") {
+			t.Error("prompt should contain valid transition ID 'closed'")
+		}
+		// Should request NEXT_STATUS format.
+		if !strings.Contains(prompt, "NEXT_STATUS:") {
+			t.Error("prompt should contain NEXT_STATUS format instruction")
+		}
+	})
+
+	t.Run("with empty transitions metadata", func(t *testing.T) {
+		metadata := map[string]string{}
+		prompt := buildTransitionRetryPrompt("invalid_status", metadata)
+
+		// Should still mention the failed status.
+		if !strings.Contains(prompt, "invalid_status") {
+			t.Error("prompt should contain the failed status ID")
+		}
+		// Should request NEXT_STATUS format even without transition list.
+		if !strings.Contains(prompt, "NEXT_STATUS:") {
+			t.Error("prompt should contain NEXT_STATUS format instruction")
+		}
+	})
 }

--- a/backend/cmd/taskguild-agent/runner.go
+++ b/backend/cmd/taskguild-agent/runner.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -40,6 +41,10 @@ const (
 	// maxUserResponseRetries is the maximum number of auto-expire + retry
 	// cycles before the task is force-completed.
 	maxUserResponseRetries = 2
+
+	// maxStatusTransitionRetries is the maximum number of retry attempts
+	// when the agent outputs an invalid NEXT_STATUS value.
+	maxStatusTransitionRetries = 2
 )
 
 const (
@@ -129,6 +134,7 @@ func runTask(
 	consecutiveErrors := 0
 	backoff := initialBackoff
 	userResponseRetries := 0
+	statusTransitionRetries := 0
 
 	for turn := 0; ; turn++ {
 		opts := buildClaudeOptions(instructions, workDir, metadata, sessionID, worktreeName, client, ctx, taskID, agentManagerID, waiter, permCache, tl)
@@ -331,8 +337,6 @@ func runTask(
 		// Check completion: NEXT_STATUS present means task is done.
 		nextStatusID := parseNextStatus(summary)
 		if nextStatusID != "" {
-			displaySummary := stripNextStatus(summary)
-			logger.Info("completed with NEXT_STATUS", "next_status", nextStatusID, "turn", turn)
 			// Log the NEXT_STATUS directive to timeline.
 			tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_DIRECTIVE, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
 				fmt.Sprintf("Status transition: %s", nextStatusID),
@@ -341,6 +345,42 @@ func runTask(
 					"next_status":    nextStatusID,
 					"turn":           fmt.Sprintf("%d", turn),
 				})
+
+			// Validate the transition before reporting completion.
+			resolvedID, err := validateAndResolveTransition(nextStatusID, metadata)
+			if err != nil && errors.Is(err, errInvalidTransition) {
+				statusTransitionRetries++
+				logger.Warn("invalid status transition, retrying",
+					"next_status", nextStatusID,
+					"retry", statusTransitionRetries,
+					"max_retries", maxStatusTransitionRetries,
+					"error", err)
+				tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_WARN,
+					fmt.Sprintf("Invalid status transition to %q (retry %d/%d): %v", nextStatusID, statusTransitionRetries, maxStatusTransitionRetries, err), nil)
+
+				if statusTransitionRetries > maxStatusTransitionRetries {
+					logger.Warn("max status transition retries reached, completing without transition")
+					tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_WARN,
+						"Max status transition retries reached, completing without transition", nil)
+					displaySummary := stripNextStatus(summary)
+					reportTaskResult(ctx, client, taskID, displaySummary, "")
+					reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_IDLE, "task completed (invalid transition after retries)")
+					afterHooks()
+					return
+				}
+
+				// Retry with a corrective prompt.
+				reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_RUNNING, "retrying: invalid status transition")
+				prompt = buildTransitionRetryPrompt(nextStatusID, metadata)
+				continue
+			}
+
+			// Valid transition (or non-retryable error) — proceed with completion.
+			if resolvedID != "" {
+				nextStatusID = resolvedID
+			}
+			displaySummary := stripNextStatus(summary)
+			logger.Info("completed with NEXT_STATUS", "next_status", nextStatusID, "turn", turn)
 			tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
 				fmt.Sprintf("Task completed with status transition (turn %d)", turn),
 				map[string]string{"next_status": nextStatusID})


### PR DESCRIPTION
## Summary
- エージェントが無効な `NEXT_STATUS` を出力した場合に、正しい遷移先を伝えてリトライさせる（最大2回）
- ステータス名の大文字小文字を無視したマッチングにフォールバックするように改善
- リトライ上限に達した場合は、遷移なしでタスクを完了させる（従来と同じ動作）

## Test plan
- [x] `TestValidateAndResolveTransition` - ID完全一致、名前マッチ、無効値のテスト
- [x] `TestBuildTransitionRetryPrompt` - リトライプロンプトの内容検証
- [x] `go build` 成功
- [x] 既存テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)