### PR TITLE
fix: resolve OOM by adding in-memory index to YAML repositories

### DIFF
--- a/backend/cmd/taskguild-server/main.go
+++ b/backend/cmd/taskguild-server/main.go
@@ -10,9 +10,11 @@ var (
 	app = kingpin.New("taskguild-server", "TaskGuild server").
 		UsageWriter(os.Stderr)
 
-	runCmd      = app.Command("run", "Run the server")
-	sentinelCmd = app.Command("sentinel", "Supervisor that manages 'run' with auto-restart and binary watching")
-	migrateCmd  = app.Command("migrate", "Run data migrations")
+	runCmd     = app.Command("run", "Run the server")
+	runProf    = runCmd.Flag("prof", "Enable pprof server on :6060").Bool()
+	sentinelCmd  = app.Command("sentinel", "Supervisor that manages 'run' with auto-restart and binary watching")
+	sentinelProf = sentinelCmd.Flag("prof", "Enable pprof server in child 'run' process").Bool()
+	migrateCmd   = app.Command("migrate", "Run data migrations")
 )
 
 func main() {

--- a/backend/cmd/taskguild-server/run.go
+++ b/backend/cmd/taskguild-server/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	_ "net/http/pprof" // registers /debug/pprof/* handlers on DefaultServeMux
 	"os"
 	"os/signal"
 	"syscall"
@@ -221,6 +222,17 @@ func runServer() {
 		}
 		cancel()
 	}()
+
+	// Start pprof server on a separate port for profiling (only when --prof is set).
+	if *runProf {
+		go func() {
+			pprofAddr := ":6060"
+			slog.Info("starting pprof server", "addr", pprofAddr)
+			if err := http.ListenAndServe(pprofAddr, nil); err != nil {
+				slog.Error("pprof server error", "error", err)
+			}
+		}()
+	}
 
 	go orch.Start(ctx)
 	go pushDispatcher.Start(ctx)

--- a/backend/cmd/taskguild-server/sentinel.go
+++ b/backend/cmd/taskguild-server/sentinel.go
@@ -4,5 +4,9 @@ import "github.com/kazz187/taskguild/backend/pkg/sentinel"
 
 // runSentinel starts the sentinel supervisor for the server.
 func runSentinel() {
-	sentinel.Run()
+	var extraArgs []string
+	if *sentinelProf {
+		extraArgs = append(extraArgs, "--prof")
+	}
+	sentinel.Run(extraArgs...)
 }

--- a/backend/internal/interaction/repositoryimpl/yaml_repository.go
+++ b/backend/internal/interaction/repositoryimpl/yaml_repository.go
@@ -1,9 +1,13 @@
 package repositoryimpl
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"path/filepath"
 	"sort"
+	"strings"
+	"sync"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -15,20 +19,162 @@ import (
 
 const interactionsPrefix = "interactions"
 
+// YAMLRepository implements interaction.Repository using YAML files on Storage.
+//
+// An in-memory index is built lazily on first access and maintained
+// incrementally on Create/Update/Delete. This avoids reading and
+// YAML-parsing every file on each List or token-lookup call.
 type YAMLRepository struct {
 	storage storage.Storage
+
+	indexOnce  sync.Once
+	indexMu    sync.RWMutex
+	taskIndex  map[string][]string // taskID -> sorted []interactionID
+	tokenIndex map[string]string   // responseToken -> interactionID (pending only)
+	allIDs     []string            // all interaction IDs in sorted order
 }
 
 func NewYAMLRepository(s storage.Storage) *YAMLRepository {
 	return &YAMLRepository{storage: s}
 }
 
-func path(id string) string {
+func interactionPath(id string) string {
 	return fmt.Sprintf("%s/%s.yaml", interactionsPrefix, id)
 }
 
+func pathToID(p string) string {
+	return strings.TrimSuffix(filepath.Base(p), ".yaml")
+}
+
+// extractField does a fast text scan for a top-level YAML scalar field
+// (e.g. "task_id: VALUE") without full YAML parsing.
+func extractField(data []byte, field string) string {
+	prefix := []byte("\n" + field + ": ")
+	prefixStart := []byte(field + ": ")
+
+	var start int
+	if bytes.HasPrefix(data, prefixStart) {
+		start = len(prefixStart)
+	} else {
+		idx := bytes.Index(data, prefix)
+		if idx < 0 {
+			return ""
+		}
+		start = idx + len(prefix)
+	}
+
+	end := bytes.IndexByte(data[start:], '\n')
+	if end < 0 {
+		return strings.TrimSpace(string(data[start:]))
+	}
+	return strings.TrimSpace(string(data[start : start+end]))
+}
+
+// ensureIndex lazily builds the in-memory index on first access.
+func (r *YAMLRepository) ensureIndex(ctx context.Context) {
+	r.indexOnce.Do(func() {
+		r.indexMu.Lock()
+		defer r.indexMu.Unlock()
+		r.taskIndex = make(map[string][]string)
+		r.tokenIndex = make(map[string]string)
+
+		paths, err := r.storage.List(ctx, interactionsPrefix)
+		if err != nil {
+			return
+		}
+		sort.Strings(paths)
+
+		r.allIDs = make([]string, 0, len(paths))
+		for _, p := range paths {
+			data, err := r.storage.Read(ctx, p)
+			if err != nil {
+				continue
+			}
+			id := pathToID(p)
+			taskID := extractField(data, "task_id")
+			if id == "" || taskID == "" {
+				continue
+			}
+			r.taskIndex[taskID] = append(r.taskIndex[taskID], id)
+			r.allIDs = append(r.allIDs, id)
+
+			// Index response tokens for pending interactions.
+			token := extractField(data, "response_token")
+			statusStr := extractField(data, "status")
+			if token != "" && statusStr == "1" { // StatusPending = 1
+				r.tokenIndex[token] = id
+			}
+		}
+	})
+}
+
+func (r *YAMLRepository) addToIndex(i *interaction.Interaction) {
+	r.indexMu.Lock()
+	defer r.indexMu.Unlock()
+
+	r.taskIndex[i.TaskID] = append(r.taskIndex[i.TaskID], i.ID)
+	sort.Strings(r.taskIndex[i.TaskID])
+
+	idx := sort.SearchStrings(r.allIDs, i.ID)
+	r.allIDs = append(r.allIDs, "")
+	copy(r.allIDs[idx+1:], r.allIDs[idx:])
+	r.allIDs[idx] = i.ID
+
+	if i.ResponseToken != "" && i.Status == interaction.StatusPending {
+		r.tokenIndex[i.ResponseToken] = i.ID
+	}
+}
+
+func (r *YAMLRepository) removeFromIndex(id, taskID string) {
+	r.indexMu.Lock()
+	defer r.indexMu.Unlock()
+
+	if ids, ok := r.taskIndex[taskID]; ok {
+		for i, eid := range ids {
+			if eid == id {
+				r.taskIndex[taskID] = append(ids[:i], ids[i+1:]...)
+				break
+			}
+		}
+		if len(r.taskIndex[taskID]) == 0 {
+			delete(r.taskIndex, taskID)
+		}
+	}
+
+	for i, eid := range r.allIDs {
+		if eid == id {
+			r.allIDs = append(r.allIDs[:i], r.allIDs[i+1:]...)
+			break
+		}
+	}
+
+	// Remove any token index entry for this ID.
+	for token, tid := range r.tokenIndex {
+		if tid == id {
+			delete(r.tokenIndex, token)
+			break
+		}
+	}
+}
+
+func (r *YAMLRepository) updateTokenIndex(i *interaction.Interaction) {
+	r.indexMu.Lock()
+	defer r.indexMu.Unlock()
+
+	if i.ResponseToken == "" {
+		return
+	}
+	if i.Status == interaction.StatusPending {
+		r.tokenIndex[i.ResponseToken] = i.ID
+	} else {
+		delete(r.tokenIndex, i.ResponseToken)
+	}
+}
+
 func (r *YAMLRepository) Create(ctx context.Context, i *interaction.Interaction) error {
-	exists, err := r.storage.Exists(ctx, path(i.ID))
+	r.ensureIndex(ctx)
+
+	exists, err := r.storage.Exists(ctx, interactionPath(i.ID))
 	if err != nil {
 		return cerr.WrapStorageWriteError("interaction", err)
 	}
@@ -39,14 +185,15 @@ func (r *YAMLRepository) Create(ctx context.Context, i *interaction.Interaction)
 	if err != nil {
 		return cerr.NewError(cerr.Internal, "server error", fmt.Errorf("failed to marshal interaction: %w", err))
 	}
-	if err := r.storage.Write(ctx, path(i.ID), data); err != nil {
+	if err := r.storage.Write(ctx, interactionPath(i.ID), data); err != nil {
 		return cerr.WrapStorageWriteError("interaction", err)
 	}
+	r.addToIndex(i)
 	return nil
 }
 
 func (r *YAMLRepository) Get(ctx context.Context, id string) (*interaction.Interaction, error) {
-	data, err := r.storage.Read(ctx, path(id))
+	data, err := r.storage.Read(ctx, interactionPath(id))
 	if err != nil {
 		return nil, cerr.WrapStorageReadError("interaction", err)
 	}
@@ -58,25 +205,37 @@ func (r *YAMLRepository) Get(ctx context.Context, id string) (*interaction.Inter
 }
 
 func (r *YAMLRepository) List(ctx context.Context, taskID string, taskIDs []string, limit, offset int) ([]*interaction.Interaction, int, error) {
-	paths, err := r.storage.List(ctx, interactionsPrefix)
-	if err != nil {
-		return nil, 0, cerr.WrapStorageReadError("interactions", err)
-	}
+	r.ensureIndex(ctx)
 
-	sort.Strings(paths)
-
-	// Build a set for fast lookup when filtering by multiple task IDs.
-	var taskIDSet map[string]struct{}
-	if len(taskIDs) > 0 {
-		taskIDSet = make(map[string]struct{}, len(taskIDs))
-		for _, id := range taskIDs {
-			taskIDSet[id] = struct{}{}
+	r.indexMu.RLock()
+	var matchIDs []string
+	switch {
+	case taskID != "":
+		matchIDs = make([]string, len(r.taskIndex[taskID]))
+		copy(matchIDs, r.taskIndex[taskID])
+	case len(taskIDs) > 0:
+		for _, tid := range taskIDs {
+			matchIDs = append(matchIDs, r.taskIndex[tid]...)
 		}
+		sort.Strings(matchIDs)
+	default:
+		matchIDs = make([]string, len(r.allIDs))
+		copy(matchIDs, r.allIDs)
+	}
+	r.indexMu.RUnlock()
+
+	total := len(matchIDs)
+	if offset >= total {
+		return nil, total, nil
+	}
+	paginated := matchIDs[offset:]
+	if limit > 0 && len(paginated) > limit {
+		paginated = paginated[:limit]
 	}
 
-	var all []*interaction.Interaction
-	for _, p := range paths {
-		data, err := r.storage.Read(ctx, p)
+	result := make([]*interaction.Interaction, 0, len(paginated))
+	for _, id := range paginated {
+		data, err := r.storage.Read(ctx, interactionPath(id))
 		if err != nil {
 			continue
 		}
@@ -84,30 +243,15 @@ func (r *YAMLRepository) List(ctx context.Context, taskID string, taskIDs []stri
 		if err := yaml.Unmarshal(data, &i); err != nil {
 			continue
 		}
-		if taskID != "" && i.TaskID != taskID {
-			continue
-		}
-		if taskIDSet != nil {
-			if _, ok := taskIDSet[i.TaskID]; !ok {
-				continue
-			}
-		}
-		all = append(all, &i)
+		result = append(result, &i)
 	}
-
-	total := len(all)
-	if offset >= total {
-		return nil, total, nil
-	}
-	all = all[offset:]
-	if limit > 0 && len(all) > limit {
-		all = all[:limit]
-	}
-	return all, total, nil
+	return result, total, nil
 }
 
 func (r *YAMLRepository) Update(ctx context.Context, i *interaction.Interaction) error {
-	exists, err := r.storage.Exists(ctx, path(i.ID))
+	r.ensureIndex(ctx)
+
+	exists, err := r.storage.Exists(ctx, interactionPath(i.ID))
 	if err != nil {
 		return cerr.WrapStorageWriteError("interaction", err)
 	}
@@ -118,9 +262,10 @@ func (r *YAMLRepository) Update(ctx context.Context, i *interaction.Interaction)
 	if err != nil {
 		return cerr.NewError(cerr.Internal, "server error", fmt.Errorf("failed to marshal interaction: %w", err))
 	}
-	if err := r.storage.Write(ctx, path(i.ID), data); err != nil {
+	if err := r.storage.Write(ctx, interactionPath(i.ID), data); err != nil {
 		return cerr.WrapStorageWriteError("interaction", err)
 	}
+	r.updateTokenIndex(i)
 	return nil
 }
 
@@ -128,50 +273,39 @@ func (r *YAMLRepository) GetByResponseToken(ctx context.Context, token string) (
 	if token == "" {
 		return nil, cerr.NewError(cerr.InvalidArgument, "token is required", nil)
 	}
+	r.ensureIndex(ctx)
 
-	paths, err := r.storage.List(ctx, interactionsPrefix)
-	if err != nil {
-		return nil, cerr.WrapStorageReadError("interactions", err)
+	r.indexMu.RLock()
+	id, ok := r.tokenIndex[token]
+	r.indexMu.RUnlock()
+
+	if !ok {
+		return nil, cerr.NewError(cerr.NotFound, "interaction not found for token", nil)
 	}
-
-	// Iterate in reverse order (newest first) since recent interactions
-	// are more likely to have active tokens.
-	sort.Sort(sort.Reverse(sort.StringSlice(paths)))
-
-	for _, p := range paths {
-		data, err := r.storage.Read(ctx, p)
-		if err != nil {
-			continue
-		}
-		var i interaction.Interaction
-		if err := yaml.Unmarshal(data, &i); err != nil {
-			continue
-		}
-		if i.ResponseToken == token && i.Status == interaction.StatusPending {
-			return &i, nil
-		}
-	}
-
-	return nil, cerr.NewError(cerr.NotFound, "interaction not found for token", nil)
+	return r.Get(ctx, id)
 }
 
 func (r *YAMLRepository) DeleteByTaskID(ctx context.Context, taskID string) (int, error) {
-	all, _, err := r.List(ctx, taskID, nil, 0, 0)
-	if err != nil {
-		return 0, err
-	}
+	r.ensureIndex(ctx)
+
+	r.indexMu.RLock()
+	ids := make([]string, len(r.taskIndex[taskID]))
+	copy(ids, r.taskIndex[taskID])
+	r.indexMu.RUnlock()
+
 	count := 0
-	for _, i := range all {
-		if err := r.storage.Delete(ctx, path(i.ID)); err != nil {
+	for _, id := range ids {
+		if err := r.storage.Delete(ctx, interactionPath(id)); err != nil {
 			return count, cerr.WrapStorageDeleteError("interaction", err)
 		}
+		r.removeFromIndex(id, taskID)
 		count++
 	}
 	return count, nil
 }
 
 func (r *YAMLRepository) ExpirePendingByTask(ctx context.Context, taskID string) (int, error) {
-	// List all interactions and find PENDING ones for the given task.
+	// List all interactions for this task (uses index, reads only matching files).
 	all, _, err := r.List(ctx, taskID, nil, 0, 0)
 	if err != nil {
 		return 0, err

--- a/backend/internal/tasklog/repositoryimpl/yaml_repository.go
+++ b/backend/internal/tasklog/repositoryimpl/yaml_repository.go
@@ -1,9 +1,13 @@
 package repositoryimpl
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"path/filepath"
 	"sort"
+	"strings"
+	"sync"
 
 	"gopkg.in/yaml.v3"
 
@@ -14,20 +18,129 @@ import (
 
 const taskLogsPrefix = "task_logs"
 
+// YAMLRepository implements tasklog.Repository using YAML files on Storage.
+//
+// An in-memory index (taskID → sorted []logID) is built lazily on first
+// access and maintained incrementally on Create/Delete. This avoids the
+// need to read and YAML-parse every file on each List call.
 type YAMLRepository struct {
 	storage storage.Storage
+
+	indexOnce sync.Once
+	indexMu   sync.RWMutex
+	taskIndex map[string][]string // taskID -> sorted []logID
+	allIDs    []string            // all log IDs in sorted order
 }
 
 func NewYAMLRepository(s storage.Storage) *YAMLRepository {
 	return &YAMLRepository{storage: s}
 }
 
-func path(id string) string {
+func logPath(id string) string {
 	return fmt.Sprintf("%s/%s.yaml", taskLogsPrefix, id)
 }
 
+func pathToID(p string) string {
+	return strings.TrimSuffix(filepath.Base(p), ".yaml")
+}
+
+// extractField does a fast text scan for a top-level YAML scalar field
+// (e.g. "task_id: VALUE") without full YAML parsing.
+func extractField(data []byte, field string) string {
+	prefix := []byte("\n" + field + ": ")
+	// Also check if the field is at the very beginning of the data.
+	prefixStart := []byte(field + ": ")
+
+	var start int
+	if bytes.HasPrefix(data, prefixStart) {
+		start = len(prefixStart)
+	} else {
+		idx := bytes.Index(data, prefix)
+		if idx < 0 {
+			return ""
+		}
+		start = idx + len(prefix)
+	}
+
+	end := bytes.IndexByte(data[start:], '\n')
+	if end < 0 {
+		return strings.TrimSpace(string(data[start:]))
+	}
+	return strings.TrimSpace(string(data[start : start+end]))
+}
+
+// ensureIndex lazily builds the in-memory index on first access by
+// scanning all files once. Subsequent calls are no-ops.
+func (r *YAMLRepository) ensureIndex(ctx context.Context) {
+	r.indexOnce.Do(func() {
+		r.indexMu.Lock()
+		defer r.indexMu.Unlock()
+		r.taskIndex = make(map[string][]string)
+
+		paths, err := r.storage.List(ctx, taskLogsPrefix)
+		if err != nil {
+			return
+		}
+		sort.Strings(paths)
+
+		r.allIDs = make([]string, 0, len(paths))
+		for _, p := range paths {
+			data, err := r.storage.Read(ctx, p)
+			if err != nil {
+				continue
+			}
+			id := pathToID(p)
+			taskID := extractField(data, "task_id")
+			if id == "" || taskID == "" {
+				continue
+			}
+			r.taskIndex[taskID] = append(r.taskIndex[taskID], id)
+			r.allIDs = append(r.allIDs, id)
+		}
+	})
+}
+
+func (r *YAMLRepository) addToIndex(id, taskID string) {
+	r.indexMu.Lock()
+	defer r.indexMu.Unlock()
+
+	r.taskIndex[taskID] = append(r.taskIndex[taskID], id)
+	sort.Strings(r.taskIndex[taskID])
+
+	i := sort.SearchStrings(r.allIDs, id)
+	r.allIDs = append(r.allIDs, "")
+	copy(r.allIDs[i+1:], r.allIDs[i:])
+	r.allIDs[i] = id
+}
+
+func (r *YAMLRepository) removeFromIndex(id, taskID string) {
+	r.indexMu.Lock()
+	defer r.indexMu.Unlock()
+
+	if ids, ok := r.taskIndex[taskID]; ok {
+		for i, eid := range ids {
+			if eid == id {
+				r.taskIndex[taskID] = append(ids[:i], ids[i+1:]...)
+				break
+			}
+		}
+		if len(r.taskIndex[taskID]) == 0 {
+			delete(r.taskIndex, taskID)
+		}
+	}
+
+	for i, eid := range r.allIDs {
+		if eid == id {
+			r.allIDs = append(r.allIDs[:i], r.allIDs[i+1:]...)
+			break
+		}
+	}
+}
+
 func (r *YAMLRepository) Create(ctx context.Context, l *tasklog.TaskLog) error {
-	exists, err := r.storage.Exists(ctx, path(l.ID))
+	r.ensureIndex(ctx)
+
+	exists, err := r.storage.Exists(ctx, logPath(l.ID))
 	if err != nil {
 		return cerr.WrapStorageWriteError("task_log", err)
 	}
@@ -38,32 +151,45 @@ func (r *YAMLRepository) Create(ctx context.Context, l *tasklog.TaskLog) error {
 	if err != nil {
 		return cerr.NewError(cerr.Internal, "server error", fmt.Errorf("failed to marshal task log: %w", err))
 	}
-	if err := r.storage.Write(ctx, path(l.ID), data); err != nil {
+	if err := r.storage.Write(ctx, logPath(l.ID), data); err != nil {
 		return cerr.WrapStorageWriteError("task_log", err)
 	}
+	r.addToIndex(l.ID, l.TaskID)
 	return nil
 }
 
 func (r *YAMLRepository) List(ctx context.Context, taskID string, taskIDs []string, limit, offset int) ([]*tasklog.TaskLog, int, error) {
-	paths, err := r.storage.List(ctx, taskLogsPrefix)
-	if err != nil {
-		return nil, 0, cerr.WrapStorageReadError("task_logs", err)
-	}
+	r.ensureIndex(ctx)
 
-	sort.Strings(paths)
-
-	// Build a set for fast lookup when filtering by multiple task IDs.
-	var taskIDSet map[string]struct{}
-	if len(taskIDs) > 0 {
-		taskIDSet = make(map[string]struct{}, len(taskIDs))
-		for _, id := range taskIDs {
-			taskIDSet[id] = struct{}{}
+	r.indexMu.RLock()
+	var matchIDs []string
+	switch {
+	case taskID != "":
+		matchIDs = make([]string, len(r.taskIndex[taskID]))
+		copy(matchIDs, r.taskIndex[taskID])
+	case len(taskIDs) > 0:
+		for _, tid := range taskIDs {
+			matchIDs = append(matchIDs, r.taskIndex[tid]...)
 		}
+		sort.Strings(matchIDs)
+	default:
+		matchIDs = make([]string, len(r.allIDs))
+		copy(matchIDs, r.allIDs)
+	}
+	r.indexMu.RUnlock()
+
+	total := len(matchIDs)
+	if offset >= total {
+		return nil, total, nil
+	}
+	paginated := matchIDs[offset:]
+	if limit > 0 && len(paginated) > limit {
+		paginated = paginated[:limit]
 	}
 
-	var all []*tasklog.TaskLog
-	for _, p := range paths {
-		data, err := r.storage.Read(ctx, p)
+	result := make([]*tasklog.TaskLog, 0, len(paginated))
+	for _, id := range paginated {
+		data, err := r.storage.Read(ctx, logPath(id))
 		if err != nil {
 			continue
 		}
@@ -71,38 +197,25 @@ func (r *YAMLRepository) List(ctx context.Context, taskID string, taskIDs []stri
 		if err := yaml.Unmarshal(data, &l); err != nil {
 			continue
 		}
-		if taskID != "" && l.TaskID != taskID {
-			continue
-		}
-		if taskIDSet != nil {
-			if _, ok := taskIDSet[l.TaskID]; !ok {
-				continue
-			}
-		}
-		all = append(all, &l)
+		result = append(result, &l)
 	}
-
-	total := len(all)
-	if offset >= total {
-		return nil, total, nil
-	}
-	all = all[offset:]
-	if limit > 0 && len(all) > limit {
-		all = all[:limit]
-	}
-	return all, total, nil
+	return result, total, nil
 }
 
 func (r *YAMLRepository) DeleteByTaskID(ctx context.Context, taskID string) (int, error) {
-	all, _, err := r.List(ctx, taskID, nil, 0, 0)
-	if err != nil {
-		return 0, err
-	}
+	r.ensureIndex(ctx)
+
+	r.indexMu.RLock()
+	ids := make([]string, len(r.taskIndex[taskID]))
+	copy(ids, r.taskIndex[taskID])
+	r.indexMu.RUnlock()
+
 	count := 0
-	for _, l := range all {
-		if err := r.storage.Delete(ctx, path(l.ID)); err != nil {
+	for _, id := range ids {
+		if err := r.storage.Delete(ctx, logPath(id)); err != nil {
 			return count, cerr.WrapStorageDeleteError("task_log", err)
 		}
+		r.removeFromIndex(id, taskID)
 		count++
 	}
 	return count, nil

--- a/backend/pkg/sentinel/sentinel.go
+++ b/backend/pkg/sentinel/sentinel.go
@@ -44,6 +44,7 @@ const (
 // Sentinel manages the lifecycle of a child process with the "run" subcommand.
 type Sentinel struct {
 	binaryPath string
+	childArgs  []string // extra arguments appended after "run"
 	lastHash   [sha256.Size]byte
 	backoff    time.Duration
 	stopCh     chan struct{} // closed when sentinel should exit
@@ -52,8 +53,9 @@ type Sentinel struct {
 // Run starts the sentinel supervisor loop. It resolves the current executable
 // path, starts a child process with the "run" subcommand, watches the binary
 // for changes, and restarts the child on crash with exponential backoff.
+// Any extra arguments are appended to the child's "run" command (e.g. "--prof").
 // This function blocks until SIGINT/SIGTERM is received.
-func Run() {
+func Run(extraArgs ...string) {
 	// Prevent sentinel from being terminated by SIGUSR1. The sentinel sends
 	// SIGUSR1 to the child process for graceful hot-reload. Without this,
 	// if SIGUSR1 somehow reaches the sentinel (e.g. process group signal),
@@ -108,6 +110,7 @@ func Run() {
 
 	s := &Sentinel{
 		binaryPath: binaryPath,
+		childArgs:  extraArgs,
 		backoff:    InitialBackoff,
 		stopCh:     make(chan struct{}),
 	}
@@ -225,7 +228,8 @@ func (s *Sentinel) mainLoop(sigCh <-chan os.Signal, updateCh <-chan struct{}) {
 
 // startChild launches a new child process with the "run" subcommand.
 func (s *Sentinel) startChild() (*exec.Cmd, error) {
-	cmd := exec.Command(s.binaryPath, "run")
+	args := append([]string{"run"}, s.childArgs...)
+	cmd := exec.Command(s.binaryPath, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	// Child inherits environment (env vars like TASKGUILD_*).


### PR DESCRIPTION
## Summary
- **Root cause**: `tasklog` (8,005 files/45MB) and `interaction` (2,777 files/12MB) YAML repositories were reading and YAML-parsing ALL files on every `List` call, even when filtering by taskID with limit=50. This caused ~30MB+ heap allocation per call, leading to OOM kills (687MB RSS at time of kill).
- **Fix**: Add lazily-built in-memory index (`taskID → []entityID`) to both repositories. Index is built once on first access and maintained incrementally on Create/Update/Delete. `List` now reads only matching files (typically <50 instead of thousands).
- **Also**: Add `--prof` flag to `run` and `sentinel` commands for optional pprof server on `:6060` (disabled by default).

### Performance improvement (measured with pprof)
| Metric | Before | After |
|---|---|---|
| Heap (2min after start) | 30,408 KB (growing) | 9,991 KB (stable) |
| yaml.parser.scalar | 22,170 KB | 2,051 KB |
| tasklog.List allocation | 26,817 KB | 0 KB |

## Test plan
- [x] `go build ./...` passes
- [x] `go vet` passes
- [x] Server starts and serves requests normally
- [x] pprof confirms tasklog.List no longer appears in heap profile
- [x] `--prof` flag enables/disables pprof server correctly
- [ ] Verify frontend task log and interaction pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)