### PR TITLE
Embed interaction data in event payload to avoid redundant DB fetches

### DIFF
--- a/backend/internal/agentmanager/server.go
+++ b/backend/internal/agentmanager/server.go
@@ -631,15 +631,16 @@ func (s *Server) CreateInteraction(ctx context.Context, req *connect.Request[tas
 		return nil, err
 	}
 
+	interProto := interaction.ToProto(inter)
 	s.eventBus.PublishNew(
 		taskguildv1.EventType_EVENT_TYPE_INTERACTION_CREATED,
 		inter.ID,
-		"",
+		interaction.MarshalInteractionPayload(interProto),
 		map[string]string{"task_id": inter.TaskID, "agent_id": inter.AgentID},
 	)
 
 	return connect.NewResponse(&taskguildv1.CreateInteractionResponse{
-		Interaction: interactionToProto(inter),
+		Interaction: interProto,
 	}), nil
 }
 
@@ -649,7 +650,7 @@ func (s *Server) GetInteractionResponse(ctx context.Context, req *connect.Reques
 		return nil, err
 	}
 	return connect.NewResponse(&taskguildv1.GetInteractionResponseResponse{
-		Interaction: interactionToProto(inter),
+		Interaction: interaction.ToProto(inter),
 	}), nil
 }
 
@@ -1382,27 +1383,3 @@ func (s *Server) removeScriptDiff(projectID, scriptID, filename string) {
 	s.scriptDiffCache[projectID] = filtered
 }
 
-func interactionToProto(i *interaction.Interaction) *taskguildv1.Interaction {
-	pb := &taskguildv1.Interaction{
-		Id:          i.ID,
-		TaskId:      i.TaskID,
-		AgentId:     i.AgentID,
-		Type:        taskguildv1.InteractionType(i.Type),
-		Status:      taskguildv1.InteractionStatus(i.Status),
-		Title:       i.Title,
-		Description: i.Description,
-		Response:    i.Response,
-		CreatedAt:   timestamppb.New(i.CreatedAt),
-	}
-	for _, opt := range i.Options {
-		pb.Options = append(pb.Options, &taskguildv1.InteractionOption{
-			Label:       opt.Label,
-			Value:       opt.Value,
-			Description: opt.Description,
-		})
-	}
-	if i.RespondedAt != nil {
-		pb.RespondedAt = timestamppb.New(*i.RespondedAt)
-	}
-	return pb
-}

--- a/backend/internal/chatnotifier/notifier.go
+++ b/backend/internal/chatnotifier/notifier.go
@@ -99,10 +99,11 @@ func (n *Notifier) handleTaskStatusChanged(ctx context.Context, event *taskguild
 	}
 
 	// Publish event so that Chat and Global Chat receive the notification in real time.
+	interProto := interaction.ToProto(inter)
 	n.eventBus.PublishNew(
 		taskguildv1.EventType_EVENT_TYPE_INTERACTION_CREATED,
 		inter.ID,
-		"",
+		interaction.MarshalInteractionPayload(interProto),
 		map[string]string{"task_id": inter.TaskID, "project_id": t.ProjectID},
 	)
 

--- a/backend/internal/interaction/payload.go
+++ b/backend/internal/interaction/payload.go
@@ -1,0 +1,66 @@
+package interaction
+
+import (
+	"log/slog"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	taskguildv1 "github.com/kazz187/taskguild/backend/gen/proto/taskguild/v1"
+)
+
+// MarshalInteractionPayload serializes an Interaction proto to a JSON string
+// suitable for embedding in an Event's payload field.
+func MarshalInteractionPayload(pb *taskguildv1.Interaction) string {
+	b, err := protojson.Marshal(pb)
+	if err != nil {
+		slog.Warn("failed to marshal interaction payload", "id", pb.GetId(), "error", err)
+		return ""
+	}
+	return string(b)
+}
+
+// UnmarshalInteractionPayload deserializes an Interaction proto from a JSON
+// payload string. Returns nil if the payload is empty or cannot be parsed.
+func UnmarshalInteractionPayload(payload string) *taskguildv1.Interaction {
+	if payload == "" {
+		return nil
+	}
+	pb := &taskguildv1.Interaction{}
+	if err := protojson.Unmarshal([]byte(payload), pb); err != nil {
+		slog.Warn("failed to unmarshal interaction payload", "error", err)
+		return nil
+	}
+	return pb
+}
+
+// FromProto converts a protobuf Interaction back to the domain model.
+func FromProto(pb *taskguildv1.Interaction) *Interaction {
+	if pb == nil {
+		return nil
+	}
+	inter := &Interaction{
+		ID:          pb.Id,
+		TaskID:      pb.TaskId,
+		AgentID:     pb.AgentId,
+		Type:        InteractionType(pb.Type),
+		Status:      InteractionStatus(pb.Status),
+		Title:       pb.Title,
+		Description: pb.Description,
+		Response:    pb.Response,
+	}
+	if pb.CreatedAt != nil {
+		inter.CreatedAt = pb.CreatedAt.AsTime()
+	}
+	if pb.RespondedAt != nil {
+		t := pb.RespondedAt.AsTime()
+		inter.RespondedAt = &t
+	}
+	for _, opt := range pb.Options {
+		inter.Options = append(inter.Options, Option{
+			Label:       opt.Label,
+			Value:       opt.Value,
+			Description: opt.Description,
+		})
+	}
+	return inter
+}

--- a/backend/internal/interaction/server.go
+++ b/backend/internal/interaction/server.go
@@ -70,7 +70,7 @@ func (s *Server) ListInteractions(ctx context.Context, req *connect.Request[task
 
 	protos := make([]*taskguildv1.Interaction, len(interactions))
 	for i, inter := range interactions {
-		protos[i] = toProto(inter)
+		protos[i] = ToProto(inter)
 	}
 	return connect.NewResponse(&taskguildv1.ListInteractionsResponse{
 		Interactions: protos,
@@ -103,15 +103,16 @@ func (s *Server) RespondToInteraction(ctx context.Context, req *connect.Request[
 		return nil, err
 	}
 
+	interProto := ToProto(inter)
 	s.eventBus.PublishNew(
 		taskguildv1.EventType_EVENT_TYPE_INTERACTION_RESPONDED,
 		inter.ID,
-		"",
+		MarshalInteractionPayload(interProto),
 		map[string]string{"task_id": inter.TaskID, "agent_id": inter.AgentID},
 	)
 
 	return connect.NewResponse(&taskguildv1.RespondToInteractionResponse{
-		Interaction: toProto(inter),
+		Interaction: interProto,
 	}), nil
 }
 
@@ -143,15 +144,16 @@ func (s *Server) RespondToInteractionByToken(ctx context.Context, req *connect.R
 		return nil, err
 	}
 
+	interProto := ToProto(inter)
 	s.eventBus.PublishNew(
 		taskguildv1.EventType_EVENT_TYPE_INTERACTION_RESPONDED,
 		inter.ID,
-		"",
+		MarshalInteractionPayload(interProto),
 		map[string]string{"task_id": inter.TaskID, "agent_id": inter.AgentID},
 	)
 
 	return connect.NewResponse(&taskguildv1.RespondToInteractionByTokenResponse{
-		Interaction: toProto(inter),
+		Interaction: interProto,
 	}), nil
 }
 
@@ -173,15 +175,16 @@ func (s *Server) ExpireInteraction(ctx context.Context, req *connect.Request[tas
 		return nil, err
 	}
 
+	interProto := ToProto(inter)
 	s.eventBus.PublishNew(
 		taskguildv1.EventType_EVENT_TYPE_INTERACTION_RESPONDED,
 		inter.ID,
-		"",
+		MarshalInteractionPayload(interProto),
 		map[string]string{"task_id": inter.TaskID, "agent_id": inter.AgentID},
 	)
 
 	return connect.NewResponse(&taskguildv1.ExpireInteractionResponse{
-		Interaction: toProto(inter),
+		Interaction: interProto,
 	}), nil
 }
 
@@ -213,15 +216,16 @@ func (s *Server) SendMessage(ctx context.Context, req *connect.Request[taskguild
 		return nil, err
 	}
 
+	interProto := ToProto(inter)
 	s.eventBus.PublishNew(
 		taskguildv1.EventType_EVENT_TYPE_INTERACTION_CREATED,
 		inter.ID,
-		"",
+		MarshalInteractionPayload(interProto),
 		map[string]string{"task_id": inter.TaskID, "project_id": t.ProjectID},
 	)
 
 	return connect.NewResponse(&taskguildv1.SendMessageResponse{
-		Interaction: toProto(inter),
+		Interaction: interProto,
 	}), nil
 }
 
@@ -250,14 +254,19 @@ func (s *Server) SubscribeInteractions(ctx context.Context, req *connect.Request
 					continue
 				}
 			}
-			// Fetch latest interaction state.
-			inter, err := s.repo.Get(ctx, event.ResourceId)
-			if err != nil {
-				slog.Warn("failed to get interaction for stream", "id", event.ResourceId, "error", err)
-				continue
+			// Use interaction data from event payload if available;
+			// fall back to fetching from the repository.
+			interProto := UnmarshalInteractionPayload(event.Payload)
+			if interProto == nil {
+				inter, err := s.repo.Get(ctx, event.ResourceId)
+				if err != nil {
+					slog.Warn("failed to get interaction for stream", "id", event.ResourceId, "error", err)
+					continue
+				}
+				interProto = ToProto(inter)
 			}
 			if err := stream.Send(&taskguildv1.InteractionEvent{
-				Interaction: toProto(inter),
+				Interaction: interProto,
 			}); err != nil {
 				return err
 			}
@@ -265,7 +274,8 @@ func (s *Server) SubscribeInteractions(ctx context.Context, req *connect.Request
 	}
 }
 
-func toProto(i *Interaction) *taskguildv1.Interaction {
+// ToProto converts a domain Interaction to its protobuf representation.
+func ToProto(i *Interaction) *taskguildv1.Interaction {
 	pb := &taskguildv1.Interaction{
 		Id:          i.ID,
 		TaskId:      i.TaskID,

--- a/backend/internal/pushnotification/dispatcher.go
+++ b/backend/internal/pushnotification/dispatcher.go
@@ -52,6 +52,17 @@ func (d *Dispatcher) Start(ctx context.Context) {
 }
 
 func (d *Dispatcher) handleInteractionCreated(ctx context.Context, event *taskguildv1.Event) {
+	// Quick-filter using event payload to avoid DB fetch for
+	// interaction types that don't need push notifications.
+	if pb := interaction.UnmarshalInteractionPayload(event.Payload); pb != nil {
+		if pb.Type != taskguildv1.InteractionType_INTERACTION_TYPE_PERMISSION_REQUEST &&
+			pb.Type != taskguildv1.InteractionType_INTERACTION_TYPE_QUESTION {
+			return
+		}
+	}
+
+	// Fetch full interaction from DB because ResponseToken (not
+	// included in the proto) is required for push notification actions.
 	inter, err := d.interactionRepo.Get(ctx, event.ResourceId)
 	if err != nil {
 		slog.Error("push dispatcher: failed to get interaction", "id", event.ResourceId, "error", err)


### PR DESCRIPTION
## Summary
- Serialize the full `Interaction` proto into the `Event.payload` field when publishing `INTERACTION_CREATED` and `INTERACTION_RESPONDED` events
- `SubscribeInteractions` now reads interaction data from the event payload first, falling back to a DB fetch only when the payload is absent
- Push notification dispatcher uses the payload for quick type filtering before hitting the DB for the full record (with `ResponseToken`)
- Extract `toProto` / `interactionToProto` into an exported `interaction.ToProto` helper, and add `MarshalInteractionPayload` / `UnmarshalInteractionPayload` utilities in a new `payload.go` file

## Test plan
- [ ] Verify `SubscribeInteractions` stream delivers correct interaction data (including `Response` and `RespondedAt`) after responding
- [ ] Verify push notifications still fire for `PERMISSION_REQUEST` and `QUESTION` interaction types
- [ ] Verify non-push-eligible interaction types (e.g. `MESSAGE`) skip the DB fetch in the dispatcher
- [ ] Confirm backward compatibility: events with empty payload still work via DB fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)