### PR TITLE
Simplify frontend option logic by relying on backend-provided options

### DIFF
--- a/frontend/taskguild/src/components/organisms/RequestItem.tsx
+++ b/frontend/taskguild/src/components/organisms/RequestItem.tsx
@@ -224,33 +224,12 @@ export function RequestItem({
     )
   }, [])
 
-  // Build options list based on whether this is a Bash interaction
+  // Build options list — backend already provides the correct options per tool type.
+  // Only filter out legacy "always_allow" if present.
   const displayOptions = useMemo(() => {
     if (!isPending) return interaction.options
-
-    if (isBash) {
-      // Bash: Allow (y) / Always Allow Command (a) / Deny (n)
-      // Replace "always_allow" with "always_allow_command"
-      return interaction.options
-        .filter((opt) => opt.value !== 'always_allow')
-        .flatMap((opt) => {
-          if (opt.value === 'allow') {
-            return [
-              opt,
-              {
-                label: 'Always Allow Command',
-                value: 'always_allow_command',
-                description: 'Allow and save command patterns as rules',
-              },
-            ]
-          }
-          return [opt]
-        })
-    }
-
-    // Non-Bash: Allow (y) / Deny (n) — remove "Always Allow"
     return interaction.options.filter((opt) => opt.value !== 'always_allow')
-  }, [interaction.options, isBash, isPending])
+  }, [interaction.options, isPending])
 
   // Handle respond with special logic for always_allow_command
   const handleRespond = useCallback(


### PR DESCRIPTION
## Summary
- Remove Bash-specific conditional option-building logic from `RequestItem.tsx`
- The backend already provides the correct options per tool type (including `always_allow_command` for Bash), so the frontend no longer needs to duplicate this logic
- Only legacy `always_allow` filtering is retained as a safeguard

## Test plan
- [ ] Verify Bash tool permission prompt shows correct options (Allow / Always Allow Command / Deny)
- [ ] Verify non-Bash tool permission prompt shows correct options (Allow / Deny)
- [ ] Confirm no regression in permission handling flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)