### PR TITLE
Simplify command pattern suggestions and skip already-matched rules in always-allow

### DIFF
--- a/backend/cmd/taskguild-agent/single_command_permission_cache.go
+++ b/backend/cmd/taskguild-agent/single_command_permission_cache.go
@@ -201,48 +201,15 @@ func (c *singleCommandPermissionCache) CheckAllCommands(parsed *shellparse.Parse
 }
 
 // SuggestCommandPattern generates a suggested wildcard pattern for a command.
-// The pattern is broad enough to be useful but specific enough to be safe.
+// Returns the full command string as-is so users can see the exact command
+// and manually generalize it with wildcards (e.g. *) if desired.
 func SuggestCommandPattern(cmd shellparse.ParsedCommand) string {
-	exe := cmd.Executable
-	if exe == "" {
-		return cmd.Raw
-	}
-
-	// For commands with no arguments, match exactly.
-	if len(cmd.Args) == 0 {
-		return exe
-	}
-
-	// For common commands that take subcommands, include the subcommand.
-	switch exe {
-	case "git", "npm", "pnpm", "yarn", "bun", "make", "docker", "docker-compose", "kubectl":
-		if len(cmd.Args) >= 1 {
-			subCmd := cmd.Args[0]
-			if len(cmd.Args) > 1 {
-				return fmt.Sprintf("%s %s *", exe, subCmd)
-			}
-			return fmt.Sprintf("%s %s", exe, subCmd)
-		}
-		return fmt.Sprintf("%s *", exe)
-	default:
-		// Default: command name + wildcard
-		return fmt.Sprintf("%s *", exe)
-	}
+	return cmd.Raw
 }
 
 // SuggestRedirectPattern generates a suggested wildcard pattern for a redirect path.
+// Returns the exact path so users can see the full path and manually generalize
+// it with wildcards (e.g. *) if desired.
 func SuggestRedirectPattern(path string) string {
-	switch {
-	case path == "/dev/null":
-		return "/dev/null"
-	case strings.HasPrefix(path, "./"):
-		return "./*"
-	case strings.HasPrefix(path, "../"):
-		return "../*"
-	case strings.HasPrefix(path, "/tmp/") || strings.HasPrefix(path, "/tmp"):
-		return "/tmp/*"
-	default:
-		// Exact match by default
-		return path
-	}
+	return path
 }

--- a/backend/cmd/taskguild-agent/single_command_permission_cache_test.go
+++ b/backend/cmd/taskguild-agent/single_command_permission_cache_test.go
@@ -194,54 +194,34 @@ func TestSuggestCommandPattern(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "git status (single arg)",
-			cmd:      shellparse.ParsedCommand{Executable: "git", Args: []string{"status"}},
+			name:     "returns raw command as-is",
+			cmd:      shellparse.ParsedCommand{Raw: "git status", Executable: "git", Args: []string{"status"}},
 			expected: "git status",
 		},
 		{
-			name:     "git checkout with args",
-			cmd:      shellparse.ParsedCommand{Executable: "git", Args: []string{"checkout", "-b", "feature"}},
-			expected: "git checkout *",
+			name:     "returns full command with args",
+			cmd:      shellparse.ParsedCommand{Raw: "git checkout -b feature", Executable: "git", Args: []string{"checkout", "-b", "feature"}},
+			expected: "git checkout -b feature",
 		},
 		{
-			name:     "npm test (single arg)",
-			cmd:      shellparse.ParsedCommand{Executable: "npm", Args: []string{"test"}},
-			expected: "npm test",
-		},
-		{
-			name:     "npm test with args",
-			cmd:      shellparse.ParsedCommand{Executable: "npm", Args: []string{"test", "--coverage"}},
-			expected: "npm test *",
+			name:     "npm test with coverage",
+			cmd:      shellparse.ParsedCommand{Raw: "npm test --coverage", Executable: "npm", Args: []string{"test", "--coverage"}},
+			expected: "npm test --coverage",
 		},
 		{
 			name:     "no args",
-			cmd:      shellparse.ParsedCommand{Executable: "ls"},
+			cmd:      shellparse.ParsedCommand{Raw: "ls", Executable: "ls"},
 			expected: "ls",
 		},
 		{
 			name:     "unknown command with args",
-			cmd:      shellparse.ParsedCommand{Executable: "myapp", Args: []string{"serve", "--port", "8080"}},
-			expected: "myapp *",
+			cmd:      shellparse.ParsedCommand{Raw: "myapp serve --port 8080", Executable: "myapp", Args: []string{"serve", "--port", "8080"}},
+			expected: "myapp serve --port 8080",
 		},
 		{
-			name:     "command with flag-like first arg",
-			cmd:      shellparse.ParsedCommand{Executable: "ls", Args: []string{"-la"}},
-			expected: "ls *",
-		},
-		{
-			name:     "cd with path",
-			cmd:      shellparse.ParsedCommand{Executable: "cd", Args: []string{"/home"}},
-			expected: "cd *",
-		},
-		{
-			name:     "empty executable",
+			name:     "empty executable falls back to raw",
 			cmd:      shellparse.ParsedCommand{Raw: "some raw command"},
 			expected: "some raw command",
-		},
-		{
-			name:     "docker compose",
-			cmd:      shellparse.ParsedCommand{Executable: "docker", Args: []string{"compose", "up"}},
-			expected: "docker compose *",
 		},
 	}
 
@@ -261,9 +241,9 @@ func TestSuggestRedirectPattern(t *testing.T) {
 		expected string
 	}{
 		{"/dev/null", "/dev/null"},
-		{"./output.txt", "./*"},
-		{"../output.txt", "../*"},
-		{"/tmp/foo", "/tmp/*"},
+		{"./output.txt", "./output.txt"},
+		{"../output.txt", "../output.txt"},
+		{"/tmp/foo", "/tmp/foo"},
 		{"/etc/passwd", "/etc/passwd"},
 	}
 

--- a/frontend/taskguild/src/components/organisms/RequestItem.tsx
+++ b/frontend/taskguild/src/components/organisms/RequestItem.tsx
@@ -63,7 +63,7 @@ function buildPatternRows(meta: BashPermissionMetadata): PatternRow[] {
       label: cmd.command,
       matched: cmd.matched,
       pattern: cmd.matched ? (cmd.matched_pattern ?? cmd.command) : (cmd.suggested_pattern ?? cmd.command),
-      checked: true,
+      checked: !cmd.matched,
     })
   }
 
@@ -75,7 +75,7 @@ function buildPatternRows(meta: BashPermissionMetadata): PatternRow[] {
       label: `${redir.operator} ${redir.path}`,
       matched: redir.matched,
       pattern: redir.matched ? (redir.matched_pattern ?? redir.path) : (redir.suggested_pattern ?? redir.path),
-      checked: true,
+      checked: !redir.matched,
     })
   }
 

--- a/frontend/taskguild/src/hooks/useRequestKeyboard.ts
+++ b/frontend/taskguild/src/hooks/useRequestKeyboard.ts
@@ -68,17 +68,17 @@ function buildDefaultAlwaysAllowResponse(meta: BashPermissionMeta): string {
   const rules: Array<{ pattern: string; type: string; label: string }> = []
 
   for (const cmd of meta.parsed_commands) {
-    const pattern = cmd.matched
-      ? (cmd.matched_pattern ?? cmd.command)
-      : (cmd.suggested_pattern ?? cmd.command)
+    // Skip already-matched commands — they are already allowed by existing rules
+    if (cmd.matched) continue
+    const pattern = cmd.suggested_pattern ?? cmd.command
     rules.push({ pattern, type: 'command', label: cmd.command })
   }
 
   if (meta.redirects) {
     for (const redir of meta.redirects) {
-      const pattern = redir.matched
-        ? (redir.matched_pattern ?? redir.path)
-        : (redir.suggested_pattern ?? redir.path)
+      // Skip already-matched redirects — they are already allowed by existing rules
+      if (redir.matched) continue
+      const pattern = redir.suggested_pattern ?? redir.path
       rules.push({ pattern, type: 'redirect', label: `${redir.operator} ${redir.path}` })
     }
   }


### PR DESCRIPTION
## Summary
- Simplify `SuggestCommandPattern` and `SuggestRedirectPattern` to return the exact raw command/path instead of generating wildcard patterns, so users can see the full command and manually generalize with `*` if desired
- Skip already-matched commands and redirects in the always-allow UI (uncheck them by default) and in keyboard shortcut response building, since they are already covered by existing rules
- Update tests to reflect the simplified pattern suggestion behavior

## Test plan
- [ ] Verify that the always-allow dialog shows exact commands instead of wildcard patterns
- [ ] Verify that already-matched commands/redirects are unchecked by default in the UI
- [ ] Verify that pressing the always-allow keyboard shortcut only adds rules for unmatched commands
- [ ] Run backend tests: `go test ./backend/cmd/taskguild-agent/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)