### PR TITLE
Make single command permission creation idempotent with pattern+type dedup

### DIFF
--- a/backend/internal/agentmanager/server.go
+++ b/backend/internal/agentmanager/server.go
@@ -1629,6 +1629,9 @@ func (s *Server) ListSingleCommandPermissions(ctx context.Context, req *connect.
 }
 
 // AddSingleCommandPermission adds a new wildcard permission rule from an agent.
+// If a rule with the same pattern+type already exists in the project, the
+// existing rule is updated (label overwrite) and any extra duplicates are
+// removed. This makes the operation idempotent and cleans up legacy duplicates.
 func (s *Server) AddSingleCommandPermission(ctx context.Context, req *connect.Request[taskguildv1.AddSingleCommandPermissionRequest]) (*connect.Response[taskguildv1.AddSingleCommandPermissionResponse], error) {
 	projectName := req.Msg.ProjectName
 	if projectName == "" {
@@ -1641,17 +1644,39 @@ func (s *Server) AddSingleCommandPermission(ctx context.Context, req *connect.Re
 		return nil, fmt.Errorf("failed to resolve project: %w", err)
 	}
 
-	p := &scp.SingleCommandPermission{
-		ID:        ulid.Make().String(),
-		ProjectID: proj.ID,
-		Pattern:   req.Msg.Pattern,
-		Type:      req.Msg.Type,
-		Label:     req.Msg.Label,
-		CreatedAt: time.Now(),
+	// Check for existing duplicates (pattern + type within the same project).
+	existing, err := s.scpRepo.FindByPatternAndType(ctx, proj.ID, req.Msg.Pattern, req.Msg.Type)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check existing single command permissions: %w", err)
 	}
 
-	if err := s.scpRepo.Create(ctx, p); err != nil {
-		return nil, fmt.Errorf("failed to create single command permission: %w", err)
+	var p *scp.SingleCommandPermission
+
+	if len(existing) > 0 {
+		// Keep the oldest entry and update its label.
+		p = existing[0]
+		p.Label = req.Msg.Label
+		if err := s.scpRepo.Update(ctx, p); err != nil {
+			return nil, fmt.Errorf("failed to update single command permission: %w", err)
+		}
+
+		// Remove extra duplicates (index 1+).
+		for _, dup := range existing[1:] {
+			_ = s.scpRepo.Delete(ctx, dup.ID)
+		}
+	} else {
+		// No duplicate — create a new entry.
+		p = &scp.SingleCommandPermission{
+			ID:        ulid.Make().String(),
+			ProjectID: proj.ID,
+			Pattern:   req.Msg.Pattern,
+			Type:      req.Msg.Type,
+			Label:     req.Msg.Label,
+			CreatedAt: time.Now(),
+		}
+		if err := s.scpRepo.Create(ctx, p); err != nil {
+			return nil, fmt.Errorf("failed to create single command permission: %w", err)
+		}
 	}
 
 	return connect.NewResponse(&taskguildv1.AddSingleCommandPermissionResponse{

--- a/backend/internal/singlecommandpermission/repository.go
+++ b/backend/internal/singlecommandpermission/repository.go
@@ -14,6 +14,11 @@ type Repository interface {
 	// List returns all permission rules for a project.
 	List(ctx context.Context, projectID string) ([]*SingleCommandPermission, error)
 
+	// FindByPatternAndType returns all permission rules that match the given
+	// projectID, pattern, and type combination. Returns an empty slice if none
+	// found. Results are sorted by CreatedAt ascending (oldest first).
+	FindByPatternAndType(ctx context.Context, projectID, pattern, permType string) ([]*SingleCommandPermission, error)
+
 	// Update replaces an existing permission rule.
 	Update(ctx context.Context, p *SingleCommandPermission) error
 

--- a/backend/internal/singlecommandpermission/repositoryimpl/yaml_repository.go
+++ b/backend/internal/singlecommandpermission/repositoryimpl/yaml_repository.go
@@ -99,6 +99,41 @@ func (r *YAMLRepository) List(ctx context.Context, projectID string) ([]*singlec
 	return result, nil
 }
 
+// FindByPatternAndType returns all permission rules matching the given
+// projectID, pattern, and type. Results are sorted by CreatedAt ascending
+// (oldest first) so that callers can keep the oldest entry when deduplicating.
+func (r *YAMLRepository) FindByPatternAndType(ctx context.Context, projectID, pattern, permType string) ([]*singlecommandpermission.SingleCommandPermission, error) {
+	keys, err := r.storage.List(ctx, prefixPath())
+	if err != nil {
+		return nil, cerr.WrapStorageReadError("single_command_permission", err)
+	}
+
+	var result []*singlecommandpermission.SingleCommandPermission
+	for _, key := range keys {
+		if !strings.HasSuffix(key, ".yaml") {
+			continue
+		}
+		data, err := r.storage.Read(ctx, key)
+		if err != nil {
+			return nil, cerr.WrapStorageReadError("single_command_permission", err)
+		}
+		var p singlecommandpermission.SingleCommandPermission
+		if err := yaml.Unmarshal(data, &p); err != nil {
+			continue // skip malformed entries
+		}
+		if p.ProjectID == projectID && p.Pattern == pattern && p.Type == permType {
+			result = append(result, &p)
+		}
+	}
+
+	// Sort by creation time ascending (oldest first).
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].CreatedAt.Before(result[j].CreatedAt)
+	})
+
+	return result, nil
+}
+
 // Update replaces an existing permission rule.
 func (r *YAMLRepository) Update(ctx context.Context, p *singlecommandpermission.SingleCommandPermission) error {
 	exists, err := r.storage.Exists(ctx, path(p.ID))

--- a/backend/internal/singlecommandpermission/server.go
+++ b/backend/internal/singlecommandpermission/server.go
@@ -84,6 +84,9 @@ func (s *Server) ListSingleCommandPermissions(
 }
 
 // CreateSingleCommandPermission adds a new wildcard permission rule.
+// If a rule with the same pattern+type already exists in the project, the
+// existing rule is updated (label overwrite) and any extra duplicates are
+// removed. This makes the operation idempotent and cleans up legacy duplicates.
 func (s *Server) CreateSingleCommandPermission(
 	ctx context.Context,
 	req *connect.Request[taskguildv1.CreateSingleCommandPermissionRequest],
@@ -98,17 +101,39 @@ func (s *Server) CreateSingleCommandPermission(
 		return nil, cerr.NewError(cerr.InvalidArgument, fmt.Sprintf("type must be %q or %q", TypeCommand, TypeRedirect), nil)
 	}
 
-	p := &SingleCommandPermission{
-		ID:        ulid.Make().String(),
-		ProjectID: req.Msg.ProjectId,
-		Pattern:   req.Msg.Pattern,
-		Type:      req.Msg.Type,
-		Label:     req.Msg.Label,
-		CreatedAt: time.Now(),
+	// Check for existing duplicates (pattern + type within the same project).
+	existing, err := s.repo.FindByPatternAndType(ctx, req.Msg.ProjectId, req.Msg.Pattern, req.Msg.Type)
+	if err != nil {
+		return nil, err
 	}
 
-	if err := s.repo.Create(ctx, p); err != nil {
-		return nil, err
+	var p *SingleCommandPermission
+
+	if len(existing) > 0 {
+		// Keep the oldest entry and update its label.
+		p = existing[0]
+		p.Label = req.Msg.Label
+		if err := s.repo.Update(ctx, p); err != nil {
+			return nil, err
+		}
+
+		// Remove extra duplicates (index 1+).
+		for _, dup := range existing[1:] {
+			_ = s.repo.Delete(ctx, dup.ID)
+		}
+	} else {
+		// No duplicate — create a new entry.
+		p = &SingleCommandPermission{
+			ID:        ulid.Make().String(),
+			ProjectID: req.Msg.ProjectId,
+			Pattern:   req.Msg.Pattern,
+			Type:      req.Msg.Type,
+			Label:     req.Msg.Label,
+			CreatedAt: time.Now(),
+		}
+		if err := s.repo.Create(ctx, p); err != nil {
+			return nil, err
+		}
 	}
 
 	s.notifyChange(p.ProjectID)

--- a/frontend/taskguild/src/components/organisms/SingleCommandPermissionList.tsx
+++ b/frontend/taskguild/src/components/organisms/SingleCommandPermissionList.tsx
@@ -44,8 +44,8 @@ export function SingleCommandPermissionList({ projectId }: { projectId: string }
     return null
   }
 
-  const checkDuplicate = (pattern: string, excludeId?: string): boolean => {
-    return permissions.some(p => p.pattern === pattern && p.id !== excludeId)
+  const checkDuplicate = (pattern: string, type: PermissionType, excludeId?: string): boolean => {
+    return permissions.some(p => p.pattern === pattern && p.type === type && p.id !== excludeId)
   }
 
   const handleCreate = (e: React.FormEvent) => {
@@ -55,8 +55,8 @@ export function SingleCommandPermissionList({ projectId }: { projectId: string }
       setValidationError(error)
       return
     }
-    if (checkDuplicate(form.pattern)) {
-      setValidationError('A rule with this pattern already exists')
+    if (checkDuplicate(form.pattern, form.type)) {
+      setValidationError('A rule with this pattern and type already exists')
       return
     }
     setValidationError(null)
@@ -90,8 +90,8 @@ export function SingleCommandPermissionList({ projectId }: { projectId: string }
       setValidationError(error)
       return
     }
-    if (checkDuplicate(editForm.pattern, id)) {
-      setValidationError('A rule with this pattern already exists')
+    if (checkDuplicate(editForm.pattern, editForm.type, id)) {
+      setValidationError('A rule with this pattern and type already exists')
       return
     }
     setValidationError(null)


### PR DESCRIPTION
## Summary
- Make `AddSingleCommandPermission` / `CreateSingleCommandPermission` idempotent: when a rule with the same pattern+type already exists in a project, update the oldest entry's label instead of creating a duplicate
- Remove extra duplicate entries automatically to clean up legacy data
- Add `FindByPatternAndType` method to the repository interface and YAML implementation
- Fix frontend duplicate validation to check both pattern and type (not pattern alone)

## Test plan
- [ ] Create a new single command permission and verify it is created correctly
- [ ] Create the same pattern+type permission again and verify it updates the existing entry instead of creating a duplicate
- [ ] Verify that when duplicates exist, only the oldest entry is kept and extras are removed
- [ ] Test frontend form validation rejects same pattern+type but allows same pattern with different type
- [ ] Verify the agent-side `AddSingleCommandPermission` endpoint behaves the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)