### PR TITLE
Simplify Always Allow Command: exact patterns, skip matched rules, remove from push notifications

### DIFF
--- a/backend/internal/pushnotification/dispatcher.go
+++ b/backend/internal/pushnotification/dispatcher.go
@@ -114,11 +114,11 @@ func (d *Dispatcher) handleInteractionCreated(ctx context.Context, event *taskgu
 func (d *Dispatcher) buildActions(inter *interaction.Interaction) []NotificationAction {
 	switch inter.Type {
 	case interaction.TypePermissionRequest:
-		// Permission requests always have Allow / Always Allow / Deny.
-		// Chrome Android supports up to 3 action buttons.
+		// Permission requests: Allow / Deny.
+		// "Always Allow Command" requires pattern metadata that push notifications
+		// cannot carry, so we only offer the simple allow/deny actions here.
 		return []NotificationAction{
 			{Action: "allow", Title: "Allow"},
-			{Action: "always_allow", Title: "Always Allow"},
 			{Action: "deny", Title: "Deny"},
 		}
 


### PR DESCRIPTION
## Summary
- **Backend**: Simplify `SuggestCommandPattern` and `SuggestRedirectPattern` to return the exact command/path as-is, instead of generating wildcard patterns. Users can manually generalize with wildcards if desired.
- **Frontend**: Remove Bash-specific option logic from `RequestItem`; rely on backend-provided options. Filter out legacy `always_allow` option only.
- **Frontend**: Skip already-matched commands/redirects when building "Always Allow Command" rules, and default checkboxes to unchecked for already-matched patterns.
- **Push notifications**: Remove "Always Allow" action button since push notifications cannot carry the command pattern metadata required for it to work correctly.

## Test plan
- [ ] Verify "Always Allow Command" flow works correctly in the web UI with exact command patterns
- [ ] Confirm already-matched rules are skipped and not re-added
- [ ] Confirm push notifications show only Allow / Deny buttons
- [ ] Run backend tests (`go test ./backend/cmd/taskguild-agent/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)