### PR TITLE
fix: auto-reload on stale asset errors after deployment

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,18 @@ import { RouterProvider, createRouter } from '@tanstack/react-router'
 import { routeTree } from './routeTree.gen'
 import { ConfigProvider } from './components/organisms/ConfigProvider'
 
+// Handle stale asset errors after deployments by reloading the page once.
+// When Cloudflare Pages deploys new assets with different hashes, browsers
+// with cached index.html will fail to load the old chunks.
+window.addEventListener('vite:preloadError', (event) => {
+  event.preventDefault()
+  const reloadedKey = 'vite-preload-reloaded'
+  if (!sessionStorage.getItem(reloadedKey)) {
+    sessionStorage.setItem(reloadedKey, '1')
+    window.location.reload()
+  }
+})
+
 const router = createRouter({
   routeTree,
   defaultPreload: 'intent',


### PR DESCRIPTION
## Summary
- デプロイ後に古いアセットハッシュを読み込もうとして `Failed to fetch dynamically imported module` エラーが発生する問題を修正
- Vite の `vite:preloadError` イベントをリッスンし、自動的にページをリロードして新しいアセットを取得
- `sessionStorage` でリロードループを防止（1回のみリロード）

## Test plan
- [ ] デプロイ後、古いタブでページ遷移してもエラーが出ずリロードされることを確認
- [ ] リロードループが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)