### PR TITLE
Fix hook form fields to display in a single horizontal row

### DIFF
--- a/frontend/src/components/organisms/WorkflowForm.tsx
+++ b/frontend/src/components/organisms/WorkflowForm.tsx
@@ -680,7 +680,7 @@ export function WorkflowForm({
                       )}
                       <div className="space-y-2">
                         {s.hooks.map((h, hi) => (
-                          <div key={h.key} className="flex items-center gap-2 flex-wrap bg-slate-900/50 rounded p-2">
+                          <div key={h.key} className="flex items-center gap-2 bg-slate-900/50 rounded p-2">
                             <div className="flex flex-col -my-1">
                               <Button
                                 type="button"
@@ -744,7 +744,7 @@ export function WorkflowForm({
                                   })
                                 }}
                                 selectSize="xs"
-                                className="flex-1 min-w-[140px] rounded text-[11px]"
+                                className="flex-1 min-w-0 rounded text-[11px]"
                               >
                                 <option value="">Select script...</option>
                                 {scripts.map((sc) => (
@@ -765,7 +765,7 @@ export function WorkflowForm({
                                   })
                                 }}
                                 selectSize="xs"
-                                className="flex-1 min-w-[140px] rounded text-[11px]"
+                                className="flex-1 min-w-0 rounded text-[11px]"
                               >
                                 <option value="">Select skill...</option>
                                 {skills.map((sk) => (


### PR DESCRIPTION
## Summary
- Remove `flex-wrap` from hook form row to keep all fields in a single horizontal line
- Change `min-w-[140px]` to `min-w-0` on script/skill select dropdowns so they shrink to fit within the container instead of overflowing

## Test plan
- [ ] Open workflow edit form with hooks configured
- [ ] Verify hook form fields (reorder buttons, event select, type select, script/skill select, delete button) display in a single row without wrapping
- [ ] Verify select dropdowns do not overflow the container on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)