### PR TITLE
Add structured logging to script execution streaming pipeline

### DIFF
--- a/cmd/taskguild-agent/execute_script.go
+++ b/cmd/taskguild-agent/execute_script.go
@@ -62,7 +62,7 @@ func handleExecuteScript(ctx context.Context, client taskguildv1connect.AgentMan
 	slog.Info("executing script", "script_id", scriptID, "request_id", requestID, "filename", filename)
 
 	reportResult := func(success bool, exitCode int32, logEntries []*v1.ScriptLogEntry, errMsg string, stoppedByUser bool) {
-		_, err := client.ReportScriptExecutionResult(ctx, connect.NewRequest(&v1.ReportScriptExecutionResultRequest{
+		_, err := client.ReportScriptExecutionResult(context.Background(), connect.NewRequest(&v1.ReportScriptExecutionResultRequest{
 			RequestId:     requestID,
 			ProjectName:   cfg.ProjectName,
 			ScriptId:      scriptID,
@@ -154,6 +154,8 @@ func handleExecuteScript(ctx context.Context, client taskguildv1connect.AgentMan
 		reportResult(false, -1, nil, fmt.Sprintf("failed to start script: %v", err), false)
 		return
 	}
+
+	slog.Info("script process started", "request_id", requestID, "pid", execCmd.Process.Pid, "filename", filename)
 
 	// Stream output in real-time.
 	var fullLog logEntryBuffer
@@ -282,8 +284,10 @@ func streamOutput(
 		case <-doneCh:
 			// Pipes closed — flush any remaining data.
 			flushLogEntries(ctx, client, cfg, requestID, &chunk)
+			slog.Info("script output streaming finished", "request_id", requestID)
 			return
 		case <-ctx.Done():
+			slog.Warn("script output streaming cancelled by context", "request_id", requestID, "error", ctx.Err())
 			return
 		}
 	}
@@ -310,5 +314,7 @@ func flushLogEntries(
 	}))
 	if err != nil {
 		slog.Error("failed to send output chunk", "request_id", requestID, "error", err)
+	} else {
+		slog.Debug("sent output chunk", "request_id", requestID, "entry_count", len(entries))
 	}
 }

--- a/frontend/src/components/organisms/ScriptList.tsx
+++ b/frontend/src/components/organisms/ScriptList.tsx
@@ -344,12 +344,14 @@ export function ScriptList({ projectId }: { projectId: string }) {
 
     try {
       const req = create(StreamScriptExecutionRequestSchema, { requestId })
+      console.log('[ScriptStream] connecting', { scriptId, requestId })
       for await (const event of client.streamScriptExecution(req, {
         signal: controller.signal,
       })) {
         if (event.event.case === 'output') {
           const chunk = event.event.value
           const newEntries = protoLogToLocal(chunk.entries)
+          console.debug('[ScriptStream] received output chunk', { scriptId, entries: newEntries.length })
           // Append to mutable buffer (no React state update per chunk).
           const buf = logBuffersRef.current.get(scriptId)
           if (buf) {

--- a/internal/agentmanager/server.go
+++ b/internal/agentmanager/server.go
@@ -1341,6 +1341,8 @@ func (s *Server) ReportScriptOutputChunk(ctx context.Context, req *connect.Reque
 		return nil, cerr.NewError(cerr.InvalidArgument, "project_name is required", nil).ConnectError()
 	}
 
+	slog.Debug("received script output chunk", "request_id", req.Msg.RequestId, "entry_count", len(req.Msg.Entries))
+
 	if s.scriptBroker != nil {
 		s.scriptBroker.PushOutput(req.Msg.RequestId, req.Msg.Entries)
 	}

--- a/internal/script/broker.go
+++ b/internal/script/broker.go
@@ -149,11 +149,12 @@ func (b *ScriptExecutionBroker) PushOutput(requestID string, entries []*taskguil
 		return
 	}
 	es.buffer = append(es.buffer, event)
-	for _, ch := range es.subscribers {
+	for i, ch := range es.subscribers {
 		select {
 		case ch <- event:
 		default:
 			// Drop if subscriber is full; they can catch up via buffer.
+			slog.Warn("PushOutput: subscriber channel full, dropping event", "request_id", requestID, "subscriber_index", i)
 		}
 	}
 }
@@ -238,6 +239,8 @@ func (b *ScriptExecutionBroker) Subscribe(requestID string) (<-chan *taskguildv1
 	// started its read loop).
 	chanSize := len(es.buffer) + 128
 	ch := make(chan *taskguildv1.ScriptExecutionEvent, chanSize)
+
+	slog.Info("script execution stream subscriber connected", "request_id", requestID, "buffered_events", len(es.buffer), "completed", es.completed)
 
 	// Replay buffered events (guaranteed not to block).
 	for _, evt := range es.buffer {

--- a/internal/script/server.go
+++ b/internal/script/server.go
@@ -3,6 +3,7 @@ package script
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -281,8 +282,11 @@ func (s *Server) ListActiveExecutions(ctx context.Context, req *connect.Request[
 
 // StreamScriptExecution streams real-time output from a script execution.
 func (s *Server) StreamScriptExecution(ctx context.Context, req *connect.Request[taskguildv1.StreamScriptExecutionRequest], stream *connect.ServerStream[taskguildv1.ScriptExecutionEvent]) error {
+	slog.Info("frontend subscribed to script execution stream", "request_id", req.Msg.RequestId)
+
 	ch, unsubscribe := s.broker.Subscribe(req.Msg.RequestId)
 	if ch == nil {
+		slog.Warn("script execution stream: unknown request_id", "request_id", req.Msg.RequestId)
 		return connect.NewError(connect.CodeNotFound, fmt.Errorf("unknown execution request_id: %s", req.Msg.RequestId))
 	}
 	defer unsubscribe()
@@ -290,13 +294,16 @@ func (s *Server) StreamScriptExecution(ctx context.Context, req *connect.Request
 	for {
 		select {
 		case <-ctx.Done():
+			slog.Info("script execution stream ended: client disconnected", "request_id", req.Msg.RequestId)
 			return nil
 		case event, ok := <-ch:
 			if !ok {
 				// Channel closed — execution completed and all events sent.
+				slog.Info("script execution stream ended: execution completed", "request_id", req.Msg.RequestId)
 				return nil
 			}
 			if err := stream.Send(event); err != nil {
+				slog.Warn("script execution stream: send error", "request_id", req.Msg.RequestId, "error", err)
 				return err
 			}
 		}


### PR DESCRIPTION
## Summary
- Add structured logging (info/debug/warn) across the entire script execution streaming pipeline: agent executor, broker, gRPC server, and frontend
- Trace script output flow from agent → `ReportScriptOutputChunk` → broker → `StreamScriptExecution` → frontend for easier debugging of streaming issues
- Fix `ReportScriptExecutionResult` to use `context.Background()` instead of the parent context, ensuring results are reported even when the execution context is cancelled
- Log subscriber channel full events in broker to detect backpressure/drop scenarios

## Test plan
- [ ] Execute a script and verify structured logs appear at each stage in server logs
- [ ] Cancel a running script and confirm the result is still reported (context.Background fix)
- [ ] Check browser console for `[ScriptStream]` debug logs during script execution
- [ ] Verify no regression in script execution streaming behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)