### PR TITLE
fix: cancel running scripts on SIGUSR1 to prevent hot reload from blocking

### DIFF
--- a/cmd/taskguild-agent/run.go
+++ b/cmd/taskguild-agent/run.go
@@ -151,10 +151,19 @@ func runAgent() {
 	signal.Notify(usr1Ch, syscall.SIGUSR1)
 	go func() {
 		<-usr1Ch
-		slog.Info("received SIGUSR1 (hot reload), waiting for running scripts to complete")
+		slog.Info("received SIGUSR1 (hot reload), cancelling running scripts")
 		scriptTracker.mu.Lock()
 		scriptTracker.reject = true
 		scriptTracker.mu.Unlock()
+
+		// Cancel all running script executions so they terminate promptly.
+		runningScripts.mu.Lock()
+		for reqID, cancelFn := range runningScripts.cancels {
+			slog.Info("cancelling script for hot reload", "request_id", reqID)
+			cancelFn()
+		}
+		runningScripts.mu.Unlock()
+
 		scriptTracker.wg.Wait()
 		slog.Info("all scripts completed, shutting down for hot reload restart")
 		cancel()


### PR DESCRIPTION
## Summary
- Cancel all running script executions when SIGUSR1 (hot reload) signal is received, instead of just waiting for them to complete
- Previously, the hot reload process would block indefinitely if long-running scripts were active; now it actively cancels them via their context cancel functions before waiting

## Test plan
- [ ] Verify hot reload (SIGUSR1) completes promptly when scripts are running
- [ ] Verify scripts are properly cancelled and cleaned up on hot reload
- [ ] Verify normal script execution is unaffected when no SIGUSR1 is received

🤖 Generated with [Claude Code](https://claude.com/claude-code)