### PR TITLE
fix: enable DOTALL mode in wildcard regex to match multiline commands

### DIFF
--- a/cmd/taskguild-agent/single_command_permission_cache.go
+++ b/cmd/taskguild-agent/single_command_permission_cache.go
@@ -22,7 +22,7 @@ func wildcardToRegex(pattern string) string {
 	for i, p := range parts {
 		parts[i] = regexp.QuoteMeta(p)
 	}
-	return "^" + strings.Join(parts, ".*") + "$"
+	return "(?s)^" + strings.Join(parts, ".*") + "$"
 }
 
 // compileWildcard converts a wildcard pattern string to a compiled *regexp.Regexp.

--- a/cmd/taskguild-agent/single_command_permission_cache_test.go
+++ b/cmd/taskguild-agent/single_command_permission_cache_test.go
@@ -29,6 +29,9 @@ func TestWildcardToRegex(t *testing.T) {
 		// Wildcard only
 		{"*", "anything at all", true},
 		{"*", "", true},
+		// Multiline commands (heredoc-style)
+		{"git commit -m *", "git commit -m \"$(cat <<'EOF'\nfix: some message\n\nCo-Authored-By: Claude <noreply@anthropic.com>\nEOF\n)\"", true},
+		{"git *", "git commit -m \"$(cat <<'EOF'\nfix: message\nEOF\n)\"", true},
 		// Special regex characters in pattern are escaped
 		{"npm test (coverage)", "npm test (coverage)", true},
 		{"file.txt", "fileTtxt", false}, // dot is literal, not regex dot


### PR DESCRIPTION
## Summary
- Enable `(?s)` (DOTALL) flag in wildcard-to-regex conversion so that `.*` matches newline characters
- Fix permission cache matching for multiline commands such as heredoc-style `git commit -m` with `Co-Authored-By` trailers
- Add test cases for multiline command matching

## Test plan
- [ ] Verify existing wildcard pattern tests still pass
- [ ] Verify new multiline heredoc-style command tests pass (`go test ./cmd/taskguild-agent/ -run TestWildcardToRegex`)
- [ ] Confirm permission allow rules like `git commit -m *` correctly match commands containing newlines

🤖 Generated with [Claude Code](https://claude.com/claude-code)