### PR TITLE
debug: add stream trace logging for script execution pipeline

### DIFF
--- a/cmd/taskguild-agent/execute_script.go
+++ b/cmd/taskguild-agent/execute_script.go
@@ -62,6 +62,7 @@ func handleExecuteScript(ctx context.Context, client taskguildv1connect.AgentMan
 	slog.Info("executing script", "script_id", scriptID, "request_id", requestID, "filename", filename)
 
 	reportResult := func(success bool, exitCode int32, logEntries []*v1.ScriptLogEntry, errMsg string, stoppedByUser bool) {
+		slog.Info("[STREAM-TRACE] agent: reporting execution result to backend", "request_id", requestID, "success", success, "exit_code", exitCode, "log_entry_count", len(logEntries), "error_message", errMsg)
 		_, err := client.ReportScriptExecutionResult(context.Background(), connect.NewRequest(&v1.ReportScriptExecutionResultRequest{
 			RequestId:     requestID,
 			ProjectName:   cfg.ProjectName,
@@ -282,22 +283,36 @@ func streamOutput(
 		defer wg.Done()
 		scanner := bufio.NewScanner(stdoutPipe)
 		scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+		lineCount := 0
 		for scanner.Scan() {
 			line := scanner.Text() + "\n"
+			lineCount++
+			slog.Info("[STREAM-TRACE] agent: read stdout line", "request_id", requestID, "line_num", lineCount, "len", len(line))
 			chunk.append(v1.ScriptLogStream_SCRIPT_LOG_STREAM_STDOUT, line)
 			fullLog.append(v1.ScriptLogStream_SCRIPT_LOG_STREAM_STDOUT, line)
 		}
+		if err := scanner.Err(); err != nil {
+			slog.Warn("[STREAM-TRACE] agent: stdout scanner error", "request_id", requestID, "error", err)
+		}
+		slog.Info("[STREAM-TRACE] agent: stdout pipe closed", "request_id", requestID, "total_lines", lineCount)
 	}()
 
 	go func() {
 		defer wg.Done()
 		scanner := bufio.NewScanner(stderrPipe)
 		scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+		lineCount := 0
 		for scanner.Scan() {
 			line := scanner.Text() + "\n"
+			lineCount++
+			slog.Info("[STREAM-TRACE] agent: read stderr line", "request_id", requestID, "line_num", lineCount, "len", len(line))
 			chunk.append(v1.ScriptLogStream_SCRIPT_LOG_STREAM_STDERR, line)
 			fullLog.append(v1.ScriptLogStream_SCRIPT_LOG_STREAM_STDERR, line)
 		}
+		if err := scanner.Err(); err != nil {
+			slog.Warn("[STREAM-TRACE] agent: stderr scanner error", "request_id", requestID, "error", err)
+		}
+		slog.Info("[STREAM-TRACE] agent: stderr pipe closed", "request_id", requestID, "total_lines", lineCount)
 	}()
 
 	// Flush buffered output every 200ms until both pipes close.
@@ -346,8 +361,8 @@ func flushLogEntries(
 		Entries:     entries,
 	}))
 	if err != nil {
-		slog.Error("failed to send output chunk", "request_id", requestID, "error", err)
+		slog.Error("[STREAM-TRACE] agent: failed to send output chunk to backend", "request_id", requestID, "error", err)
 	} else {
-		slog.Debug("sent output chunk", "request_id", requestID, "entry_count", len(entries))
+		slog.Info("[STREAM-TRACE] agent: sent output chunk to backend", "request_id", requestID, "entry_count", len(entries))
 	}
 }

--- a/internal/agentmanager/server.go
+++ b/internal/agentmanager/server.go
@@ -1299,6 +1299,7 @@ func (s *Server) ReportScriptExecutionResult(ctx context.Context, req *connect.R
 
 	// Complete execution in the broker — this sends the completion event
 	// to all streaming subscribers and closes their channels.
+	slog.Info("[STREAM-TRACE] backend(agentmanager): received execution result from agent", "request_id", req.Msg.RequestId, "success", req.Msg.Success, "exit_code", req.Msg.ExitCode, "log_entry_count", len(req.Msg.LogEntries))
 	if s.scriptBroker != nil {
 		s.scriptBroker.CompleteExecution(
 			req.Msg.RequestId,
@@ -1341,10 +1342,12 @@ func (s *Server) ReportScriptOutputChunk(ctx context.Context, req *connect.Reque
 		return nil, cerr.NewError(cerr.InvalidArgument, "project_name is required", nil).ConnectError()
 	}
 
-	slog.Debug("received script output chunk", "request_id", req.Msg.RequestId, "entry_count", len(req.Msg.Entries))
+	slog.Info("[STREAM-TRACE] backend(agentmanager): received output chunk from agent", "request_id", req.Msg.RequestId, "entry_count", len(req.Msg.Entries))
 
 	if s.scriptBroker != nil {
 		s.scriptBroker.PushOutput(req.Msg.RequestId, req.Msg.Entries)
+	} else {
+		slog.Warn("[STREAM-TRACE] backend(agentmanager): scriptBroker is nil, cannot push output", "request_id", req.Msg.RequestId)
 	}
 
 	return connect.NewResponse(&taskguildv1.ReportScriptOutputChunkResponse{}), nil

--- a/internal/script/broker.go
+++ b/internal/script/broker.go
@@ -146,15 +146,18 @@ func (b *ScriptExecutionBroker) PushOutput(requestID string, entries []*taskguil
 	es.mu.Lock()
 	defer es.mu.Unlock()
 	if es.completed {
+		slog.Warn("[STREAM-TRACE] broker: PushOutput called on completed execution, ignoring", "request_id", requestID)
 		return
 	}
 	es.buffer = append(es.buffer, event)
+	slog.Info("[STREAM-TRACE] broker: PushOutput buffered event", "request_id", requestID, "entry_count", len(entries), "buffer_size", len(es.buffer), "subscriber_count", len(es.subscribers))
 	for i, ch := range es.subscribers {
 		select {
 		case ch <- event:
+			slog.Info("[STREAM-TRACE] broker: PushOutput sent to subscriber", "request_id", requestID, "subscriber_index", i)
 		default:
 			// Drop if subscriber is full; they can catch up via buffer.
-			slog.Warn("PushOutput: subscriber channel full, dropping event", "request_id", requestID, "subscriber_index", i)
+			slog.Warn("[STREAM-TRACE] broker: subscriber channel full, dropping event", "request_id", requestID, "subscriber_index", i)
 		}
 	}
 }
@@ -170,7 +173,7 @@ func (b *ScriptExecutionBroker) CompleteExecution(requestID string, success bool
 			"request_id", requestID, "log_entry_count", len(logEntries))
 		return
 	}
-	slog.Debug("CompleteExecution: completing execution",
+	slog.Info("[STREAM-TRACE] broker: CompleteExecution called",
 		"request_id", requestID, "success", success, "log_entry_count", len(logEntries))
 
 	event := &taskguildv1.ScriptExecutionEvent{
@@ -196,10 +199,13 @@ func (b *ScriptExecutionBroker) CompleteExecution(requestID string, success bool
 	es.subscribers = nil
 	es.mu.Unlock()
 
-	for _, ch := range subs {
+	slog.Info("[STREAM-TRACE] broker: CompleteExecution sending to subscribers", "request_id", requestID, "subscriber_count", len(subs))
+	for i, ch := range subs {
 		select {
 		case ch <- event:
+			slog.Info("[STREAM-TRACE] broker: CompleteExecution sent to subscriber", "request_id", requestID, "subscriber_index", i)
 		default:
+			slog.Warn("[STREAM-TRACE] broker: CompleteExecution subscriber full, dropping", "request_id", requestID, "subscriber_index", i)
 		}
 		close(ch)
 	}

--- a/internal/script/server.go
+++ b/internal/script/server.go
@@ -299,13 +299,20 @@ func (s *Server) StreamScriptExecution(ctx context.Context, req *connect.Request
 		case event, ok := <-ch:
 			if !ok {
 				// Channel closed — execution completed and all events sent.
-				slog.Info("script execution stream ended: execution completed", "request_id", req.Msg.RequestId)
+				slog.Info("[STREAM-TRACE] server->frontend: stream ended (channel closed)", "request_id", req.Msg.RequestId)
 				return nil
 			}
+			switch e := event.Event.(type) {
+			case *taskguildv1.ScriptExecutionEvent_Output:
+				slog.Info("[STREAM-TRACE] server->frontend: sending output event", "request_id", req.Msg.RequestId, "entry_count", len(e.Output.Entries))
+			case *taskguildv1.ScriptExecutionEvent_Complete:
+				slog.Info("[STREAM-TRACE] server->frontend: sending complete event", "request_id", req.Msg.RequestId, "success", e.Complete.Success, "exit_code", e.Complete.ExitCode)
+			}
 			if err := stream.Send(event); err != nil {
-				slog.Warn("script execution stream: send error", "request_id", req.Msg.RequestId, "error", err)
+				slog.Warn("[STREAM-TRACE] server->frontend: send error", "request_id", req.Msg.RequestId, "error", err)
 				return err
 			}
+			slog.Info("[STREAM-TRACE] server->frontend: event sent successfully", "request_id", req.Msg.RequestId)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- スクリプト実行結果のストリーミングパイプライン全体に `[STREAM-TRACE]` プレフィックス付きのINFOログを追加
- Agent（stdout/stderr読み取り、チャンク送信）→ Backend AgentManager（チャンク受信）→ Broker（バッファリング、subscriber配信）→ Server→Frontend（SSE送信）の各ステージをトレース可能に
- `grep STREAM-TRACE` でどのステージまで到達しているか即座に特定可能

## Test plan
- [ ] スクリプトをRunして `[STREAM-TRACE]` ログが各ステージで出力されることを確認
- [ ] ログからストリームが途絶えているポイントを特定

🤖 Generated with [Claude Code](https://claude.com/claude-code)