### PR TITLE
Fix hook row select widths and refactor large files

### DIFF
--- a/frontend/src/components/organisms/WorkflowForm.tsx
+++ b/frontend/src/components/organisms/WorkflowForm.tsx
@@ -709,7 +709,7 @@ export function WorkflowForm({
                                 updateHook(s.key, h.key, { trigger: Number(e.target.value) as HookTrigger })
                               }
                               selectSize="xs"
-                              className="w-auto rounded text-[11px]"
+                              className="flex-[2] min-w-0 rounded text-[11px]"
                             >
                               <option value={HookTrigger.BEFORE_TASK_EXECUTION}>Before Task</option>
                               <option value={HookTrigger.AFTER_TASK_EXECUTION}>After Task</option>
@@ -727,7 +727,7 @@ export function WorkflowForm({
                                 })
                               }}
                               selectSize="xs"
-                              className="w-auto rounded text-[11px]"
+                              className="flex-[1] min-w-0 rounded text-[11px]"
                             >
                               <option value={HookActionType.SKILL}>Skill</option>
                               <option value={HookActionType.SCRIPT}>Script</option>
@@ -744,7 +744,7 @@ export function WorkflowForm({
                                   })
                                 }}
                                 selectSize="xs"
-                                className="flex-1 min-w-0 rounded text-[11px]"
+                                className="flex-[3] min-w-0 rounded text-[11px]"
                               >
                                 <option value="">Select script...</option>
                                 {scripts.map((sc) => (
@@ -765,7 +765,7 @@ export function WorkflowForm({
                                   })
                                 }}
                                 selectSize="xs"
-                                className="flex-1 min-w-0 rounded text-[11px]"
+                                className="flex-[3] min-w-0 rounded text-[11px]"
                               >
                                 <option value="">Select skill...</option>
                                 {skills.map((sk) => (


### PR DESCRIPTION
## Summary
- **Fix hook row selects**: Use proportional flex widths for hook row select elements in WorkflowForm to improve layout
- **Refactor large files**: Split `server.go` (2076 lines → 11 focused files) and `ScriptList.tsx` (1047 lines → 4 files) for better maintainability
  - `server.go` → `agent_conflict.go`, `agent_sync.go`, `git_handler.go`, `interaction_handler.go`, `permission_handler.go`, `script_conflict.go`, `script_handler.go`, `task_handler.go`, `task_log_handler.go`, `worktree_handler.go`
  - `ScriptList.tsx` → `ScriptListUtils.ts`, `useScriptExecution.ts` + `LogOutput.tsx` enhancements
- **Debug logging**: Add `[STREAM-TRACE]` logging across script execution streaming pipeline for troubleshooting

## Test plan
- [ ] Verify hook row selects display with correct proportional widths
- [ ] Verify all agent manager endpoints still function correctly after server.go split
- [ ] Verify script list UI works correctly after component extraction
- [ ] Confirm stream trace logs appear during script execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)