### PR TITLE
test: add agent-side and server-side script execution tests

### DIFF
--- a/cmd/taskguild-agent/execute_script_test.go
+++ b/cmd/taskguild-agent/execute_script_test.go
@@ -1,0 +1,622 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	v1 "github.com/kazz187/taskguild/gen/proto/taskguild/v1"
+	"github.com/kazz187/taskguild/gen/proto/taskguild/v1/taskguildv1connect"
+)
+
+// --- mock client ---
+
+type scriptMockClient struct {
+	taskguildv1connect.UnimplementedAgentManagerServiceHandler
+
+	mu     sync.Mutex
+	chunks []*v1.ReportScriptOutputChunkRequest
+	result *v1.ReportScriptExecutionResultRequest
+}
+
+func (m *scriptMockClient) Subscribe(_ context.Context, _ *connect.Request[v1.AgentManagerSubscribeRequest]) (*connect.ServerStreamForClient[v1.AgentCommand], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+
+func (m *scriptMockClient) ReportScriptOutputChunk(_ context.Context, req *connect.Request[v1.ReportScriptOutputChunkRequest]) (*connect.Response[v1.ReportScriptOutputChunkResponse], error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.chunks = append(m.chunks, req.Msg)
+	return connect.NewResponse(&v1.ReportScriptOutputChunkResponse{}), nil
+}
+
+func (m *scriptMockClient) ReportScriptExecutionResult(_ context.Context, req *connect.Request[v1.ReportScriptExecutionResultRequest]) (*connect.Response[v1.ReportScriptExecutionResultResponse], error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.result = req.Msg
+	return connect.NewResponse(&v1.ReportScriptExecutionResultResponse{}), nil
+}
+
+func (m *scriptMockClient) getChunks() []*v1.ReportScriptOutputChunkRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]*v1.ReportScriptOutputChunkRequest, len(m.chunks))
+	copy(result, m.chunks)
+	return result
+}
+
+func (m *scriptMockClient) getResult() *v1.ReportScriptExecutionResultRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.result
+}
+
+func (m *scriptMockClient) allChunkEntries() []*v1.ScriptLogEntry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var entries []*v1.ScriptLogEntry
+	for _, c := range m.chunks {
+		entries = append(entries, c.Entries...)
+	}
+	return entries
+}
+
+// --- chunkBuffer ---
+
+func TestChunkBuffer_AppendAndDrain(t *testing.T) {
+	var cb chunkBuffer
+	cb.append(v1.ScriptLogStream_SCRIPT_LOG_STREAM_STDOUT, "line1\n")
+	cb.append(v1.ScriptLogStream_SCRIPT_LOG_STREAM_STDERR, "err1\n")
+
+	entries := cb.drain()
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].Text != "line1\n" || entries[0].Stream != v1.ScriptLogStream_SCRIPT_LOG_STREAM_STDOUT {
+		t.Errorf("entry 0: unexpected %v", entries[0])
+	}
+	if entries[1].Text != "err1\n" || entries[1].Stream != v1.ScriptLogStream_SCRIPT_LOG_STREAM_STDERR {
+		t.Errorf("entry 1: unexpected %v", entries[1])
+	}
+
+	// Drain again should be empty
+	entries = cb.drain()
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries after second drain, got %d", len(entries))
+	}
+}
+
+func TestChunkBuffer_DrainEmpty(t *testing.T) {
+	var cb chunkBuffer
+	entries := cb.drain()
+	if entries != nil {
+		t.Errorf("expected nil from draining empty buffer, got %v", entries)
+	}
+}
+
+// --- logEntryBuffer ---
+
+func TestLogEntryBuffer_AppendAndEntries(t *testing.T) {
+	var lb logEntryBuffer
+	lb.append(v1.ScriptLogStream_SCRIPT_LOG_STREAM_STDOUT, "a\n")
+	lb.append(v1.ScriptLogStream_SCRIPT_LOG_STREAM_STDERR, "b\n")
+
+	entries := lb.entries()
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+
+	// entries() returns a new slice (shallow copy of pointers)
+	if len(lb.entries()) != 2 {
+		t.Error("calling entries() again should still return 2 entries")
+	}
+}
+
+// --- flushLogEntries ---
+
+func TestFlushLogEntries_SendsChunk(t *testing.T) {
+	mock := &scriptMockClient{}
+	cfg := &config{ProjectName: "test-proj"}
+	var cb chunkBuffer
+	cb.append(v1.ScriptLogStream_SCRIPT_LOG_STREAM_STDOUT, "hello\n")
+
+	flushLogEntries(context.Background(), mock, cfg, "req-1", &cb)
+
+	chunks := mock.getChunks()
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if chunks[0].RequestId != "req-1" {
+		t.Errorf("expected requestID %q, got %q", "req-1", chunks[0].RequestId)
+	}
+	if chunks[0].ProjectName != "test-proj" {
+		t.Errorf("expected projectName %q, got %q", "test-proj", chunks[0].ProjectName)
+	}
+	if len(chunks[0].Entries) != 1 || chunks[0].Entries[0].Text != "hello\n" {
+		t.Errorf("unexpected entries: %v", chunks[0].Entries)
+	}
+}
+
+func TestFlushLogEntries_EmptyBuffer_NoRPC(t *testing.T) {
+	mock := &scriptMockClient{}
+	cfg := &config{ProjectName: "test-proj"}
+	var cb chunkBuffer
+
+	flushLogEntries(context.Background(), mock, cfg, "req-1", &cb)
+
+	if len(mock.getChunks()) != 0 {
+		t.Error("expected no RPC call for empty buffer")
+	}
+}
+
+// --- streamOutput ---
+
+func TestStreamOutput_StdoutAndStderr(t *testing.T) {
+	mock := &scriptMockClient{}
+	cfg := &config{ProjectName: "test-proj"}
+	var fullLog logEntryBuffer
+
+	// Create pipes that simulate script output
+	stdoutR, stdoutW, _ := os.Pipe()
+	stderrR, stderrW, _ := os.Pipe()
+
+	// Write output and close immediately
+	stdoutW.WriteString("stdout line1\nstdout line2\n")
+	stdoutW.Close()
+	stderrW.WriteString("stderr line1\n")
+	stderrW.Close()
+
+	streamOutput(context.Background(), mock, cfg, "req-1", stdoutR, stderrR, &fullLog)
+
+	// Verify full log captured all lines
+	entries := fullLog.entries()
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 log entries, got %d", len(entries))
+	}
+
+	// Collect all text
+	var stdoutTexts, stderrTexts []string
+	for _, e := range entries {
+		if e.Stream == v1.ScriptLogStream_SCRIPT_LOG_STREAM_STDOUT {
+			stdoutTexts = append(stdoutTexts, e.Text)
+		} else {
+			stderrTexts = append(stderrTexts, e.Text)
+		}
+	}
+	if len(stdoutTexts) != 2 {
+		t.Errorf("expected 2 stdout entries, got %d", len(stdoutTexts))
+	}
+	if len(stderrTexts) != 1 {
+		t.Errorf("expected 1 stderr entry, got %d", len(stderrTexts))
+	}
+
+	// Verify chunks were sent to server
+	chunkEntries := mock.allChunkEntries()
+	if len(chunkEntries) != 3 {
+		t.Errorf("expected 3 entries sent via RPC, got %d", len(chunkEntries))
+	}
+}
+
+func TestStreamOutput_EmptyPipes(t *testing.T) {
+	mock := &scriptMockClient{}
+	cfg := &config{ProjectName: "test-proj"}
+	var fullLog logEntryBuffer
+
+	stdoutR, stdoutW, _ := os.Pipe()
+	stderrR, stderrW, _ := os.Pipe()
+	stdoutW.Close()
+	stderrW.Close()
+
+	streamOutput(context.Background(), mock, cfg, "req-1", stdoutR, stderrR, &fullLog)
+
+	entries := fullLog.entries()
+	if len(entries) != 0 {
+		t.Errorf("expected 0 log entries for empty pipes, got %d", len(entries))
+	}
+}
+
+func TestStreamOutput_LargeOutput(t *testing.T) {
+	mock := &scriptMockClient{}
+	cfg := &config{ProjectName: "test-proj"}
+	var fullLog logEntryBuffer
+
+	stdoutR, stdoutW, _ := os.Pipe()
+	stderrR, stderrW, _ := os.Pipe()
+
+	// Write many lines
+	go func() {
+		for i := 0; i < 100; i++ {
+			stdoutW.WriteString("line of output\n")
+		}
+		stdoutW.Close()
+	}()
+	stderrW.Close()
+
+	streamOutput(context.Background(), mock, cfg, "req-1", stdoutR, stderrR, &fullLog)
+
+	entries := fullLog.entries()
+	if len(entries) != 100 {
+		t.Fatalf("expected 100 log entries, got %d", len(entries))
+	}
+
+	// All entries should have been sent via chunks
+	chunkEntries := mock.allChunkEntries()
+	if len(chunkEntries) != 100 {
+		t.Errorf("expected 100 entries sent via RPC, got %d", len(chunkEntries))
+	}
+}
+
+func TestStreamOutput_ContextCancelled(t *testing.T) {
+	mock := &scriptMockClient{}
+	cfg := &config{ProjectName: "test-proj"}
+	var fullLog logEntryBuffer
+
+	stdoutR, stdoutW, _ := os.Pipe()
+	stderrR, stderrW, _ := os.Pipe()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		streamOutput(ctx, mock, cfg, "req-1", stdoutR, stderrR, &fullLog)
+		close(done)
+	}()
+
+	// Cancel context while pipes are still open
+	cancel()
+
+	select {
+	case <-done:
+		// OK, streamOutput returned
+	case <-time.After(2 * time.Second):
+		t.Fatal("streamOutput did not return after context cancellation")
+	}
+
+	// Clean up pipes
+	stdoutW.Close()
+	stderrW.Close()
+	stdoutR.Close()
+	stderrR.Close()
+}
+
+// --- handleExecuteScript (end-to-end) ---
+
+func TestHandleExecuteScript_Success(t *testing.T) {
+	mock := &scriptMockClient{}
+	workDir := t.TempDir()
+	cfg := &config{
+		ProjectName: "test-proj",
+		WorkDir:     workDir,
+	}
+
+	cmd := &v1.ExecuteScriptCommand{
+		RequestId: "req-test-1",
+		ScriptId:  "sc-1",
+		Filename:  "hello.sh",
+		Content:   "#!/bin/sh\necho hello\necho world",
+	}
+
+	handleExecuteScript(context.Background(), mock, cfg, cmd)
+
+	// Verify result was reported
+	result := mock.getResult()
+	if result == nil {
+		t.Fatal("expected result to be reported")
+	}
+	if result.RequestId != "req-test-1" {
+		t.Errorf("expected requestID %q, got %q", "req-test-1", result.RequestId)
+	}
+	if result.ProjectName != "test-proj" {
+		t.Errorf("expected projectName %q, got %q", "test-proj", result.ProjectName)
+	}
+	if result.ScriptId != "sc-1" {
+		t.Errorf("expected scriptID %q, got %q", "sc-1", result.ScriptId)
+	}
+	if !result.Success {
+		t.Errorf("expected success=true, got false. error: %s", result.ErrorMessage)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("expected exitCode=0, got %d", result.ExitCode)
+	}
+
+	// Verify output was streamed
+	chunkEntries := mock.allChunkEntries()
+	var allText string
+	for _, e := range chunkEntries {
+		allText += e.Text
+	}
+	if !strings.Contains(allText, "hello") || !strings.Contains(allText, "world") {
+		t.Errorf("expected stdout to contain 'hello' and 'world', got: %q", allText)
+	}
+
+	// Verify full log in result
+	var resultText string
+	for _, e := range result.LogEntries {
+		resultText += e.Text
+	}
+	if !strings.Contains(resultText, "hello") || !strings.Contains(resultText, "world") {
+		t.Errorf("expected result log to contain 'hello' and 'world', got: %q", resultText)
+	}
+
+	// Verify temp file was cleaned up
+	tmpDir := workDir + "/.claude/scripts/.tmp"
+	entries, err := os.ReadDir(tmpDir)
+	if err == nil && len(entries) > 0 {
+		t.Errorf("expected temp file to be cleaned up, but found %d files", len(entries))
+	}
+}
+
+func TestHandleExecuteScript_ScriptFails(t *testing.T) {
+	mock := &scriptMockClient{}
+	workDir := t.TempDir()
+	cfg := &config{
+		ProjectName: "test-proj",
+		WorkDir:     workDir,
+	}
+
+	cmd := &v1.ExecuteScriptCommand{
+		RequestId: "req-fail",
+		ScriptId:  "sc-2",
+		Filename:  "fail.sh",
+		Content:   "#!/bin/sh\necho failing >&2\nexit 42",
+	}
+
+	handleExecuteScript(context.Background(), mock, cfg, cmd)
+
+	result := mock.getResult()
+	if result == nil {
+		t.Fatal("expected result to be reported")
+	}
+	if result.Success {
+		t.Error("expected success=false")
+	}
+	if result.ExitCode != 42 {
+		t.Errorf("expected exitCode=42, got %d", result.ExitCode)
+	}
+	if result.StoppedByUser {
+		t.Error("expected stoppedByUser=false")
+	}
+
+	// Verify stderr was captured
+	var stderrText string
+	for _, e := range mock.allChunkEntries() {
+		if e.Stream == v1.ScriptLogStream_SCRIPT_LOG_STREAM_STDERR {
+			stderrText += e.Text
+		}
+	}
+	if !strings.Contains(stderrText, "failing") {
+		t.Errorf("expected stderr to contain 'failing', got: %q", stderrText)
+	}
+}
+
+func TestHandleExecuteScript_StdoutAndStderrInterleaved(t *testing.T) {
+	mock := &scriptMockClient{}
+	workDir := t.TempDir()
+	cfg := &config{
+		ProjectName: "test-proj",
+		WorkDir:     workDir,
+	}
+
+	cmd := &v1.ExecuteScriptCommand{
+		RequestId: "req-interleave",
+		ScriptId:  "sc-3",
+		Filename:  "mixed.sh",
+		Content:   "#!/bin/sh\necho out1\necho err1 >&2\necho out2\necho err2 >&2",
+	}
+
+	handleExecuteScript(context.Background(), mock, cfg, cmd)
+
+	result := mock.getResult()
+	if result == nil {
+		t.Fatal("expected result to be reported")
+	}
+	if !result.Success {
+		t.Errorf("expected success=true, error: %s", result.ErrorMessage)
+	}
+
+	// Verify both streams captured
+	var stdoutCount, stderrCount int
+	for _, e := range result.LogEntries {
+		switch e.Stream {
+		case v1.ScriptLogStream_SCRIPT_LOG_STREAM_STDOUT:
+			stdoutCount++
+		case v1.ScriptLogStream_SCRIPT_LOG_STREAM_STDERR:
+			stderrCount++
+		}
+	}
+	if stdoutCount != 2 {
+		t.Errorf("expected 2 stdout entries in result, got %d", stdoutCount)
+	}
+	if stderrCount != 2 {
+		t.Errorf("expected 2 stderr entries in result, got %d", stderrCount)
+	}
+}
+
+func TestHandleExecuteScript_Stopped(t *testing.T) {
+	mock := &scriptMockClient{}
+	workDir := t.TempDir()
+	cfg := &config{
+		ProjectName: "test-proj",
+		WorkDir:     workDir,
+	}
+
+	cmd := &v1.ExecuteScriptCommand{
+		RequestId: "req-stop",
+		ScriptId:  "sc-4",
+		Filename:  "long.sh",
+		Content:   "#!/bin/sh\nsleep 60",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		handleExecuteScript(ctx, mock, cfg, cmd)
+		close(done)
+	}()
+
+	// Wait a moment for the script to start, then cancel
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// OK
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleExecuteScript did not return after context cancellation")
+	}
+
+	result := mock.getResult()
+	if result == nil {
+		t.Fatal("expected result to be reported")
+	}
+	if result.Success {
+		t.Error("expected success=false for stopped script")
+	}
+	if result.StoppedByUser != true {
+		t.Error("expected stoppedByUser=true")
+	}
+}
+
+func TestHandleExecuteScript_RunningScriptsTracked(t *testing.T) {
+	mock := &scriptMockClient{}
+	workDir := t.TempDir()
+	cfg := &config{
+		ProjectName: "test-proj",
+		WorkDir:     workDir,
+	}
+
+	cmd := &v1.ExecuteScriptCommand{
+		RequestId: "req-track",
+		ScriptId:  "sc-5",
+		Filename:  "slow.sh",
+		Content:   "#!/bin/sh\nsleep 60",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		// Signal when goroutine has entered handleExecuteScript
+		close(started)
+		handleExecuteScript(ctx, mock, cfg, cmd)
+		close(done)
+	}()
+	<-started
+	// Give it a moment to register in runningScripts
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify the script is registered in runningScripts
+	runningScripts.mu.Lock()
+	_, tracked := runningScripts.cancels["req-track"]
+	runningScripts.mu.Unlock()
+	if !tracked {
+		t.Error("expected script to be tracked in runningScripts")
+	}
+
+	// Stop via handleStopScript
+	handleStopScript(&v1.StopScriptCommand{RequestId: "req-track"})
+
+	select {
+	case <-done:
+		// OK
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleExecuteScript did not return after stop command")
+	}
+
+	// Verify cleanup
+	runningScripts.mu.Lock()
+	_, stillTracked := runningScripts.cancels["req-track"]
+	runningScripts.mu.Unlock()
+	if stillTracked {
+		t.Error("expected script to be removed from runningScripts after completion")
+	}
+}
+
+func TestHandleExecuteScript_RejectDuringHotReload(t *testing.T) {
+	mock := &scriptMockClient{}
+	workDir := t.TempDir()
+	cfg := &config{
+		ProjectName: "test-proj",
+		WorkDir:     workDir,
+	}
+
+	// Set reject mode
+	scriptTracker.mu.Lock()
+	scriptTracker.reject = true
+	scriptTracker.mu.Unlock()
+	defer func() {
+		scriptTracker.mu.Lock()
+		scriptTracker.reject = false
+		scriptTracker.mu.Unlock()
+	}()
+
+	cmd := &v1.ExecuteScriptCommand{
+		RequestId: "req-reject",
+		ScriptId:  "sc-6",
+		Filename:  "rejected.sh",
+		Content:   "#!/bin/sh\necho should not run",
+	}
+
+	handleExecuteScript(context.Background(), mock, cfg, cmd)
+
+	result := mock.getResult()
+	if result == nil {
+		t.Fatal("expected result to be reported")
+	}
+	if result.Success {
+		t.Error("expected success=false for rejected script")
+	}
+	if !strings.Contains(result.ErrorMessage, "hot reload") {
+		t.Errorf("expected error about hot reload, got: %q", result.ErrorMessage)
+	}
+
+	// No chunks should have been sent (script never ran)
+	if len(mock.getChunks()) != 0 {
+		t.Error("expected no output chunks for rejected script")
+	}
+}
+
+// --- streamOutput with slow producer (verifies periodic flushing) ---
+
+func TestStreamOutput_PeriodicFlush(t *testing.T) {
+	mock := &scriptMockClient{}
+	cfg := &config{ProjectName: "test-proj"}
+	var fullLog logEntryBuffer
+
+	stdoutR, stdoutW, _ := os.Pipe()
+	stderrR, stderrW, _ := os.Pipe()
+	stderrW.Close()
+
+	done := make(chan struct{})
+	go func() {
+		streamOutput(context.Background(), mock, cfg, "req-1", stdoutR, stderrR, &fullLog)
+		close(done)
+	}()
+
+	// Write a line, wait for flush interval, then write another
+	io.WriteString(stdoutW, "first\n")
+	time.Sleep(300 * time.Millisecond) // > outputFlushInterval (200ms)
+	io.WriteString(stdoutW, "second\n")
+	time.Sleep(300 * time.Millisecond)
+	stdoutW.Close()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("streamOutput did not return")
+	}
+
+	// Should have been sent in at least 2 separate chunks
+	chunks := mock.getChunks()
+	if len(chunks) < 2 {
+		t.Errorf("expected at least 2 separate chunk flushes, got %d", len(chunks))
+	}
+}

--- a/internal/script/server_test.go
+++ b/internal/script/server_test.go
@@ -1,0 +1,577 @@
+package script
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+
+	taskguildv1 "github.com/kazz187/taskguild/gen/proto/taskguild/v1"
+)
+
+// --- fakes ---
+
+type fakeRepository struct {
+	mu      sync.Mutex
+	scripts map[string]*Script
+}
+
+func newFakeRepository() *fakeRepository {
+	return &fakeRepository{scripts: make(map[string]*Script)}
+}
+
+func (r *fakeRepository) Create(_ context.Context, s *Script) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.scripts[s.ID] = s
+	return nil
+}
+
+func (r *fakeRepository) Get(_ context.Context, id string) (*Script, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	s, ok := r.scripts[id]
+	if !ok {
+		return nil, fmt.Errorf("script not found: %s", id)
+	}
+	return s, nil
+}
+
+func (r *fakeRepository) List(_ context.Context, projectID string, limit, offset int) ([]*Script, int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var result []*Script
+	for _, s := range r.scripts {
+		if s.ProjectID == projectID {
+			result = append(result, s)
+		}
+	}
+	return result, len(result), nil
+}
+
+func (r *fakeRepository) FindByName(_ context.Context, projectID, name string) (*Script, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, s := range r.scripts {
+		if s.ProjectID == projectID && s.Name == name {
+			return s, nil
+		}
+	}
+	return nil, fmt.Errorf("script not found")
+}
+
+func (r *fakeRepository) Update(_ context.Context, s *Script) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.scripts[s.ID] = s
+	return nil
+}
+
+func (r *fakeRepository) Delete(_ context.Context, id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.scripts, id)
+	return nil
+}
+
+type fakeExecutionRequester struct {
+	mu           sync.Mutex
+	execRequests []execRequest
+	stopRequests []stopRequest
+	execErr      error
+	stopErr      error
+}
+
+type execRequest struct {
+	RequestID string
+	ProjectID string
+	Script    *Script
+}
+
+type stopRequest struct {
+	ProjectID string
+	RequestID string
+}
+
+func (f *fakeExecutionRequester) RequestScriptExecution(requestID string, projectID string, sc *Script) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.execRequests = append(f.execRequests, execRequest{
+		RequestID: requestID,
+		ProjectID: projectID,
+		Script:    sc,
+	})
+	return f.execErr
+}
+
+func (f *fakeExecutionRequester) RequestScriptStop(projectID string, requestID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stopRequests = append(f.stopRequests, stopRequest{
+		ProjectID: projectID,
+		RequestID: requestID,
+	})
+	return f.stopErr
+}
+
+// helpers
+
+func seedScript(repo *fakeRepository, id, projectID, name string) *Script {
+	sc := &Script{
+		ID:        id,
+		ProjectID: projectID,
+		Name:      name,
+		Filename:  name + ".sh",
+		Content:   "#!/bin/sh\necho hello",
+	}
+	repo.scripts[id] = sc
+	return sc
+}
+
+func newTestServer() (*Server, *fakeRepository, *fakeExecutionRequester, *ScriptExecutionBroker) {
+	repo := newFakeRepository()
+	execReq := &fakeExecutionRequester{}
+	broker := NewScriptExecutionBroker()
+	srv := NewServer(repo, execReq, broker)
+	return srv, repo, execReq, broker
+}
+
+// --- ExecuteScript ---
+
+func TestExecuteScript_Success(t *testing.T) {
+	srv, repo, execReq, broker := newTestServer()
+	seedScript(repo, "sc-1", "proj-1", "deploy")
+
+	resp, err := srv.ExecuteScript(context.Background(), connect.NewRequest(&taskguildv1.ExecuteScriptRequest{
+		ScriptId: "sc-1",
+	}))
+	if err != nil {
+		t.Fatalf("ExecuteScript failed: %v", err)
+	}
+
+	requestID := resp.Msg.RequestId
+	if requestID == "" {
+		t.Fatal("expected non-empty requestID")
+	}
+
+	// Verify broker has registered the execution
+	ch, unsub := broker.Subscribe(requestID)
+	defer unsub()
+	if ch == nil {
+		t.Fatal("expected execution to be registered in broker")
+	}
+
+	// Verify execution request was sent to agent
+	execReq.mu.Lock()
+	defer execReq.mu.Unlock()
+	if len(execReq.execRequests) != 1 {
+		t.Fatalf("expected 1 exec request, got %d", len(execReq.execRequests))
+	}
+	if execReq.execRequests[0].RequestID != requestID {
+		t.Errorf("exec request has wrong requestID: %q", execReq.execRequests[0].RequestID)
+	}
+	if execReq.execRequests[0].ProjectID != "proj-1" {
+		t.Errorf("exec request has wrong projectID: %q", execReq.execRequests[0].ProjectID)
+	}
+}
+
+func TestExecuteScript_ScriptNotFound(t *testing.T) {
+	srv, _, _, _ := newTestServer()
+
+	_, err := srv.ExecuteScript(context.Background(), connect.NewRequest(&taskguildv1.ExecuteScriptRequest{
+		ScriptId: "nonexistent",
+	}))
+	if err == nil {
+		t.Fatal("expected error for missing script")
+	}
+}
+
+func TestExecuteScript_ExecRequestFails_BrokerCleaned(t *testing.T) {
+	srv, repo, execReq, broker := newTestServer()
+	seedScript(repo, "sc-1", "proj-1", "deploy")
+
+	execReq.execErr = errors.New("agent not connected")
+
+	_, err := srv.ExecuteScript(context.Background(), connect.NewRequest(&taskguildv1.ExecuteScriptRequest{
+		ScriptId: "sc-1",
+	}))
+	if err == nil {
+		t.Fatal("expected error when execReq fails")
+	}
+
+	// Broker should have been cleaned up — no active executions
+	if broker.ActiveCount() != 0 {
+		t.Fatalf("expected 0 active executions after failure, got %d", broker.ActiveCount())
+	}
+}
+
+func TestExecuteScript_RejectedWhileDraining(t *testing.T) {
+	srv, repo, _, broker := newTestServer()
+	seedScript(repo, "sc-1", "proj-1", "deploy")
+
+	broker.SetDraining(true)
+
+	_, err := srv.ExecuteScript(context.Background(), connect.NewRequest(&taskguildv1.ExecuteScriptRequest{
+		ScriptId: "sc-1",
+	}))
+	if err == nil {
+		t.Fatal("expected error when draining")
+	}
+}
+
+// --- StopScriptExecution ---
+
+func TestStopScriptExecution_Success(t *testing.T) {
+	srv, _, execReq, broker := newTestServer()
+	broker.RegisterExecution("req-1", "sc-1", "proj-1")
+
+	_, err := srv.StopScriptExecution(context.Background(), connect.NewRequest(&taskguildv1.StopScriptExecutionRequest{
+		RequestId: "req-1",
+	}))
+	if err != nil {
+		t.Fatalf("StopScriptExecution failed: %v", err)
+	}
+
+	execReq.mu.Lock()
+	defer execReq.mu.Unlock()
+	if len(execReq.stopRequests) != 1 {
+		t.Fatalf("expected 1 stop request, got %d", len(execReq.stopRequests))
+	}
+	if execReq.stopRequests[0].ProjectID != "proj-1" {
+		t.Errorf("stop request has wrong projectID: %q", execReq.stopRequests[0].ProjectID)
+	}
+	if execReq.stopRequests[0].RequestID != "req-1" {
+		t.Errorf("stop request has wrong requestID: %q", execReq.stopRequests[0].RequestID)
+	}
+}
+
+func TestStopScriptExecution_EmptyRequestID(t *testing.T) {
+	srv, _, _, _ := newTestServer()
+
+	_, err := srv.StopScriptExecution(context.Background(), connect.NewRequest(&taskguildv1.StopScriptExecutionRequest{
+		RequestId: "",
+	}))
+	if err == nil {
+		t.Fatal("expected error for empty request_id")
+	}
+}
+
+func TestStopScriptExecution_UnknownRequestID(t *testing.T) {
+	srv, _, _, _ := newTestServer()
+
+	_, err := srv.StopScriptExecution(context.Background(), connect.NewRequest(&taskguildv1.StopScriptExecutionRequest{
+		RequestId: "unknown",
+	}))
+	if err == nil {
+		t.Fatal("expected error for unknown request_id")
+	}
+}
+
+// --- ListActiveExecutions ---
+
+func TestListActiveExecutions(t *testing.T) {
+	srv, _, _, broker := newTestServer()
+	broker.RegisterExecution("req-1", "sc-1", "proj-1")
+	broker.RegisterExecution("req-2", "sc-2", "proj-1")
+	broker.RegisterExecution("req-3", "sc-3", "proj-2")
+	broker.CompleteExecution("req-2", true, 0, nil, "", false)
+
+	resp, err := srv.ListActiveExecutions(context.Background(), connect.NewRequest(&taskguildv1.ListActiveExecutionsRequest{
+		ProjectId: "proj-1",
+	}))
+	if err != nil {
+		t.Fatalf("ListActiveExecutions failed: %v", err)
+	}
+	if len(resp.Msg.Executions) != 2 {
+		t.Fatalf("expected 2 executions for proj-1, got %d", len(resp.Msg.Executions))
+	}
+}
+
+// --- End-to-end: ExecuteScript → agent reports via broker → subscriber receives ---
+
+func TestEndToEnd_ExecuteAndReceiveViaSubscriber(t *testing.T) {
+	srv, repo, _, broker := newTestServer()
+	seedScript(repo, "sc-1", "proj-1", "deploy")
+
+	// 1. Frontend triggers execution
+	execResp, err := srv.ExecuteScript(context.Background(), connect.NewRequest(&taskguildv1.ExecuteScriptRequest{
+		ScriptId: "sc-1",
+	}))
+	if err != nil {
+		t.Fatalf("ExecuteScript failed: %v", err)
+	}
+	requestID := execResp.Msg.RequestId
+
+	// 2. Frontend subscribes to the stream (via broker directly, since
+	//    connect.ServerStream requires HTTP infrastructure to construct)
+	ch, unsub := broker.Subscribe(requestID)
+	defer unsub()
+	if ch == nil {
+		t.Fatal("expected non-nil channel for new execution")
+	}
+
+	// 3. Simulate agent sending output chunks (ReportScriptOutputChunk → broker.PushOutput)
+	broker.PushOutput(requestID, []*taskguildv1.ScriptLogEntry{
+		{Stream: taskguildv1.ScriptLogStream_SCRIPT_LOG_STREAM_STDOUT, Text: "deploying...\n"},
+	})
+	broker.PushOutput(requestID, []*taskguildv1.ScriptLogEntry{
+		{Stream: taskguildv1.ScriptLogStream_SCRIPT_LOG_STREAM_STDERR, Text: "warning: disk low\n"},
+	})
+	broker.PushOutput(requestID, []*taskguildv1.ScriptLogEntry{
+		{Stream: taskguildv1.ScriptLogStream_SCRIPT_LOG_STREAM_STDOUT, Text: "done!\n"},
+	})
+
+	// 4. Simulate agent reporting completion (ReportScriptExecutionResult → broker.CompleteExecution)
+	fullLog := []*taskguildv1.ScriptLogEntry{
+		{Stream: taskguildv1.ScriptLogStream_SCRIPT_LOG_STREAM_STDOUT, Text: "deploying...\n"},
+		{Stream: taskguildv1.ScriptLogStream_SCRIPT_LOG_STREAM_STDERR, Text: "warning: disk low\n"},
+		{Stream: taskguildv1.ScriptLogStream_SCRIPT_LOG_STREAM_STDOUT, Text: "done!\n"},
+	}
+	broker.CompleteExecution(requestID, true, 0, fullLog, "", false)
+
+	// 5. Collect all events from the subscriber channel
+	var events []*taskguildv1.ScriptExecutionEvent
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case evt, ok := <-ch:
+			if !ok {
+				goto done
+			}
+			events = append(events, evt)
+		case <-timeout:
+			t.Fatal("timed out waiting for events")
+		}
+	}
+done:
+
+	// 6. Verify: 3 output events + 1 completion event = 4 total
+	if len(events) != 4 {
+		t.Fatalf("expected 4 events (3 output + 1 complete), got %d", len(events))
+	}
+
+	// Verify output events
+	expectedTexts := []string{"deploying...\n", "warning: disk low\n", "done!\n"}
+	expectedStreams := []taskguildv1.ScriptLogStream{
+		taskguildv1.ScriptLogStream_SCRIPT_LOG_STREAM_STDOUT,
+		taskguildv1.ScriptLogStream_SCRIPT_LOG_STREAM_STDERR,
+		taskguildv1.ScriptLogStream_SCRIPT_LOG_STREAM_STDOUT,
+	}
+	for i := 0; i < 3; i++ {
+		out, ok := events[i].Event.(*taskguildv1.ScriptExecutionEvent_Output)
+		if !ok {
+			t.Fatalf("event %d: expected output event", i)
+		}
+		if len(out.Output.Entries) != 1 {
+			t.Fatalf("event %d: expected 1 entry, got %d", i, len(out.Output.Entries))
+		}
+		if out.Output.Entries[0].Text != expectedTexts[i] {
+			t.Errorf("event %d: expected text %q, got %q", i, expectedTexts[i], out.Output.Entries[0].Text)
+		}
+		if out.Output.Entries[0].Stream != expectedStreams[i] {
+			t.Errorf("event %d: expected stream %v, got %v", i, expectedStreams[i], out.Output.Entries[0].Stream)
+		}
+	}
+
+	// Verify completion event
+	comp, ok := events[3].Event.(*taskguildv1.ScriptExecutionEvent_Complete)
+	if !ok {
+		t.Fatal("event 3: expected complete event")
+	}
+	if !comp.Complete.Success {
+		t.Error("expected success=true")
+	}
+	if comp.Complete.ExitCode != 0 {
+		t.Errorf("expected exitCode=0, got %d", comp.Complete.ExitCode)
+	}
+	if len(comp.Complete.LogEntries) != 3 {
+		t.Errorf("expected 3 log entries in completion, got %d", len(comp.Complete.LogEntries))
+	}
+
+	// 7. Verify execution shows as completed in list
+	listResp, err := srv.ListActiveExecutions(context.Background(), connect.NewRequest(&taskguildv1.ListActiveExecutionsRequest{
+		ProjectId: "proj-1",
+	}))
+	if err != nil {
+		t.Fatalf("ListActiveExecutions failed: %v", err)
+	}
+	if len(listResp.Msg.Executions) != 1 {
+		t.Fatalf("expected 1 execution in list, got %d", len(listResp.Msg.Executions))
+	}
+	if !listResp.Msg.Executions[0].Completed {
+		t.Error("expected execution to be marked completed")
+	}
+}
+
+func TestEndToEnd_ExecuteFailure(t *testing.T) {
+	srv, repo, _, broker := newTestServer()
+	seedScript(repo, "sc-1", "proj-1", "deploy")
+
+	// Execute
+	execResp, err := srv.ExecuteScript(context.Background(), connect.NewRequest(&taskguildv1.ExecuteScriptRequest{
+		ScriptId: "sc-1",
+	}))
+	if err != nil {
+		t.Fatalf("ExecuteScript failed: %v", err)
+	}
+	requestID := execResp.Msg.RequestId
+
+	// Subscribe
+	ch, unsub := broker.Subscribe(requestID)
+	defer unsub()
+
+	// Agent sends some output then fails
+	broker.PushOutput(requestID, []*taskguildv1.ScriptLogEntry{
+		{Stream: taskguildv1.ScriptLogStream_SCRIPT_LOG_STREAM_STDERR, Text: "error: permission denied\n"},
+	})
+	broker.CompleteExecution(requestID, false, 126, nil, "permission denied", false)
+
+	// Collect events
+	var events []*taskguildv1.ScriptExecutionEvent
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case evt, ok := <-ch:
+			if !ok {
+				goto done
+			}
+			events = append(events, evt)
+		case <-timeout:
+			t.Fatal("timed out waiting for events")
+		}
+	}
+done:
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+
+	comp, ok := events[1].Event.(*taskguildv1.ScriptExecutionEvent_Complete)
+	if !ok {
+		t.Fatal("event 1: expected complete event")
+	}
+	if comp.Complete.Success {
+		t.Error("expected success=false")
+	}
+	if comp.Complete.ExitCode != 126 {
+		t.Errorf("expected exitCode=126, got %d", comp.Complete.ExitCode)
+	}
+	if comp.Complete.ErrorMessage != "permission denied" {
+		t.Errorf("expected errorMessage=%q, got %q", "permission denied", comp.Complete.ErrorMessage)
+	}
+}
+
+func TestEndToEnd_StoppedByUser(t *testing.T) {
+	srv, repo, _, broker := newTestServer()
+	seedScript(repo, "sc-1", "proj-1", "deploy")
+
+	// Execute
+	execResp, err := srv.ExecuteScript(context.Background(), connect.NewRequest(&taskguildv1.ExecuteScriptRequest{
+		ScriptId: "sc-1",
+	}))
+	if err != nil {
+		t.Fatalf("ExecuteScript failed: %v", err)
+	}
+	requestID := execResp.Msg.RequestId
+
+	// Subscribe
+	ch, unsub := broker.Subscribe(requestID)
+	defer unsub()
+
+	// Agent reports user-stopped execution
+	broker.CompleteExecution(requestID, false, -1, nil, "Stopped by user", true)
+
+	// Collect events
+	var events []*taskguildv1.ScriptExecutionEvent
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case evt, ok := <-ch:
+			if !ok {
+				goto done
+			}
+			events = append(events, evt)
+		case <-timeout:
+			t.Fatal("timed out waiting for events")
+		}
+	}
+done:
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	comp, ok := events[0].Event.(*taskguildv1.ScriptExecutionEvent_Complete)
+	if !ok {
+		t.Fatal("event 0: expected complete event")
+	}
+	if comp.Complete.Success {
+		t.Error("expected success=false")
+	}
+	if !comp.Complete.StoppedByUser {
+		t.Error("expected stoppedByUser=true")
+	}
+}
+
+func TestEndToEnd_LateJoinerGetsFullReplay(t *testing.T) {
+	srv, repo, _, broker := newTestServer()
+	seedScript(repo, "sc-1", "proj-1", "deploy")
+
+	// Execute
+	execResp, err := srv.ExecuteScript(context.Background(), connect.NewRequest(&taskguildv1.ExecuteScriptRequest{
+		ScriptId: "sc-1",
+	}))
+	if err != nil {
+		t.Fatalf("ExecuteScript failed: %v", err)
+	}
+	requestID := execResp.Msg.RequestId
+
+	// Agent sends output and completes BEFORE anyone subscribes
+	broker.PushOutput(requestID, []*taskguildv1.ScriptLogEntry{
+		{Stream: taskguildv1.ScriptLogStream_SCRIPT_LOG_STREAM_STDOUT, Text: "line1\n"},
+	})
+	broker.PushOutput(requestID, []*taskguildv1.ScriptLogEntry{
+		{Stream: taskguildv1.ScriptLogStream_SCRIPT_LOG_STREAM_STDOUT, Text: "line2\n"},
+	})
+	broker.CompleteExecution(requestID, true, 0, nil, "", false)
+
+	// Late joiner subscribes after completion (e.g. page reload)
+	ch, _ := broker.Subscribe(requestID)
+	if ch == nil {
+		t.Fatal("expected non-nil channel for completed execution")
+	}
+
+	var events []*taskguildv1.ScriptExecutionEvent
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case evt, ok := <-ch:
+			if !ok {
+				goto done
+			}
+			events = append(events, evt)
+		case <-timeout:
+			t.Fatal("timed out waiting for events")
+		}
+	}
+done:
+
+	// Should get all 3 events: 2 output + 1 complete
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events for late joiner, got %d", len(events))
+	}
+
+	if _, ok := events[0].Event.(*taskguildv1.ScriptExecutionEvent_Output); !ok {
+		t.Error("event 0: expected output")
+	}
+	if _, ok := events[1].Event.(*taskguildv1.ScriptExecutionEvent_Output); !ok {
+		t.Error("event 1: expected output")
+	}
+	if _, ok := events[2].Event.(*taskguildv1.ScriptExecutionEvent_Complete); !ok {
+		t.Error("event 2: expected complete")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `cmd/taskguild-agent/execute_script_test.go` (15 tests): agent-side script execution, pipe streaming, periodic flush, stop/cancel, hot-reload rejection
- Add `internal/script/server_test.go` (12 tests): server-side ExecuteScript API, StopScriptExecution, ListActiveExecutions, end-to-end flows with broker

## Test plan
- [x] All 27 new tests pass
- [x] Existing broker_test.go (21 tests) still passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)