### PR TITLE
feat: inject workflow context into agent system prompt

### DIFF
--- a/cmd/taskguild-agent/prompt.go
+++ b/cmd/taskguild-agent/prompt.go
@@ -118,3 +118,69 @@ func buildUserPrompt(metadata map[string]string, workDir string) string {
 
 	return sb.String()
 }
+
+// buildWorkflowContext builds a concise workflow context block for the system prompt.
+// Returns "" if no workflow context is available.
+func buildWorkflowContext(metadata map[string]string) string {
+	if metadata["_workflow_id"] == "" {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## TaskGuild Workflow Context\n")
+	sb.WriteString("You are an agent in a TaskGuild workflow. Complete your work for the current status, then transition the task forward.\n")
+
+	// List all workflow statuses, marking the current one.
+	if statusesJSON := metadata["_workflow_statuses"]; statusesJSON != "" {
+		type statusEntry struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		}
+		var statuses []statusEntry
+		if err := json.Unmarshal([]byte(statusesJSON), &statuses); err == nil && len(statuses) > 0 {
+			currentID := metadata["_current_status_id"]
+			sb.WriteString("\n### Workflow Statuses\n")
+			for _, s := range statuses {
+				sb.WriteString(fmt.Sprintf("- %s: %s", s.ID, s.Name))
+				if s.ID == currentID {
+					sb.WriteString("  <-- current")
+				}
+				sb.WriteString("\n")
+			}
+		}
+	}
+
+	// List available transitions.
+	if transitionsJSON := metadata["_available_transitions"]; transitionsJSON != "" {
+		type transitionEntry struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		}
+		var transitions []transitionEntry
+		if err := json.Unmarshal([]byte(transitionsJSON), &transitions); err == nil && len(transitions) > 0 {
+			sb.WriteString("\n### Available Transitions\n")
+			for _, t := range transitions {
+				sb.WriteString(fmt.Sprintf("- %s: %s\n", t.ID, t.Name))
+			}
+		}
+	}
+
+	// List hooks only if configured.
+	if hooksJSON := metadata["_hooks"]; hooksJSON != "" {
+		type hookEntry struct {
+			Name       string `json:"name"`
+			ActionType string `json:"action_type"`
+			Trigger    string `json:"trigger"`
+		}
+		var hooks []hookEntry
+		if err := json.Unmarshal([]byte(hooksJSON), &hooks); err == nil && len(hooks) > 0 {
+			sb.WriteString("\n### Hooks\n")
+			sb.WriteString("Hooks run automatically for this status:\n")
+			for _, h := range hooks {
+				sb.WriteString(fmt.Sprintf("- %q (%s) — %s\n", h.Name, h.ActionType, h.Trigger))
+			}
+		}
+	}
+
+	return sb.String()
+}

--- a/cmd/taskguild-agent/prompt_test.go
+++ b/cmd/taskguild-agent/prompt_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildWorkflowContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]string
+		contains []string
+		excludes []string
+		empty    bool
+	}{
+		{
+			name:     "empty metadata",
+			metadata: map[string]string{},
+			empty:    true,
+		},
+		{
+			name:     "no workflow ID",
+			metadata: map[string]string{"_task_title": "Test"},
+			empty:    true,
+		},
+		{
+			name: "full metadata with hooks",
+			metadata: map[string]string{
+				"_workflow_id":           "wf1",
+				"_current_status_id":    "s2",
+				"_current_status_name":  "In Progress",
+				"_workflow_statuses":    `[{"id":"s1","name":"Backlog"},{"id":"s2","name":"In Progress"},{"id":"s3","name":"Review"},{"id":"s4","name":"Done"}]`,
+				"_available_transitions": `[{"id":"s3","name":"Review"}]`,
+				"_hooks":                `[{"name":"Run linter","action_type":"skill","trigger":"before_task_execution"},{"name":"Deploy check","action_type":"script","trigger":"after_task_execution"}]`,
+			},
+			contains: []string{
+				"## TaskGuild Workflow Context",
+				"### Workflow Statuses",
+				"- s1: Backlog\n",
+				"- s2: In Progress  <-- current\n",
+				"- s3: Review\n",
+				"- s4: Done\n",
+				"### Available Transitions",
+				"- s3: Review\n",
+				"### Hooks",
+				`"Run linter" (skill)`,
+				"before_task_execution",
+				`"Deploy check" (script)`,
+				"after_task_execution",
+			},
+		},
+		{
+			name: "full metadata without hooks",
+			metadata: map[string]string{
+				"_workflow_id":           "wf1",
+				"_current_status_id":    "s1",
+				"_current_status_name":  "Backlog",
+				"_workflow_statuses":    `[{"id":"s1","name":"Backlog"},{"id":"s2","name":"In Progress"}]`,
+				"_available_transitions": `[{"id":"s2","name":"In Progress"}]`,
+			},
+			contains: []string{
+				"### Workflow Statuses",
+				"- s1: Backlog  <-- current\n",
+				"- s2: In Progress\n",
+				"### Available Transitions",
+			},
+			excludes: []string{
+				"### Hooks",
+			},
+		},
+		{
+			name: "malformed JSON graceful handling",
+			metadata: map[string]string{
+				"_workflow_id":           "wf1",
+				"_workflow_statuses":    `invalid json`,
+				"_available_transitions": `also invalid`,
+				"_hooks":                `not json`,
+			},
+			contains: []string{
+				"## TaskGuild Workflow Context",
+			},
+			excludes: []string{
+				"### Workflow Statuses",
+				"### Available Transitions",
+				"### Hooks",
+			},
+		},
+		{
+			name: "empty hooks array omits section",
+			metadata: map[string]string{
+				"_workflow_id":        "wf1",
+				"_workflow_statuses": `[{"id":"s1","name":"Draft"}]`,
+				"_hooks":             `[]`,
+			},
+			excludes: []string{
+				"### Hooks",
+			},
+		},
+		{
+			name: "current status marker on correct status",
+			metadata: map[string]string{
+				"_workflow_id":        "wf1",
+				"_current_status_id": "s3",
+				"_workflow_statuses": `[{"id":"s1","name":"A"},{"id":"s2","name":"B"},{"id":"s3","name":"C"}]`,
+			},
+			contains: []string{
+				"- s1: A\n",
+				"- s2: B\n",
+				"- s3: C  <-- current\n",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildWorkflowContext(tt.metadata)
+
+			if tt.empty {
+				if result != "" {
+					t.Errorf("expected empty string, got:\n%s", result)
+				}
+				return
+			}
+
+			for _, s := range tt.contains {
+				if !strings.Contains(result, s) {
+					t.Errorf("expected result to contain %q, got:\n%s", s, result)
+				}
+			}
+
+			for _, s := range tt.excludes {
+				if strings.Contains(result, s) {
+					t.Errorf("expected result NOT to contain %q, got:\n%s", s, result)
+				}
+			}
+		})
+	}
+}

--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -487,6 +487,15 @@ func buildClaudeOptions(
 		}
 	}
 
+	// Append workflow context to instructions for the system prompt.
+	if wfCtx := buildWorkflowContext(metadata); wfCtx != "" {
+		if instructions != "" {
+			instructions = instructions + "\n\n" + wfCtx
+		} else {
+			instructions = wfCtx
+		}
+	}
+
 	opts := &claudeagent.ClaudeAgentOptions{
 		Cwd:            cwd,
 		PermissionMode: permMode,


### PR DESCRIPTION
## Summary
- Add `buildWorkflowContext` function to format workflow statuses, available transitions, and hooks into a concise context block
- Append workflow context to agent system prompt instructions in `runner.go`, giving the agent awareness of its position in the workflow pipeline
- Add comprehensive tests for `buildWorkflowContext` covering edge cases (empty metadata, malformed JSON, empty arrays, current status marking)

## Test plan
- [ ] `go test ./cmd/taskguild-agent/...` passes with new prompt_test.go
- [ ] Agent receives workflow context in system prompt when workflow metadata is present
- [ ] Agent system prompt is unchanged when no workflow metadata is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)