### PR TITLE
fix: distinguish user-initiated script stops from hot-reload cancellations

### DIFF
--- a/cmd/taskguild-agent/execute_script.go
+++ b/cmd/taskguild-agent/execute_script.go
@@ -26,12 +26,14 @@ const (
 // runningScripts tracks cancel functions for running script executions
 // so they can be stopped via StopScriptCommand.
 var runningScripts struct {
-	mu      sync.Mutex
-	cancels map[string]context.CancelFunc // requestID → cancel
+	mu          sync.Mutex
+	cancels     map[string]context.CancelFunc // requestID → cancel
+	userStopped map[string]bool               // requestID → true if stopped by user (not hot-reload)
 }
 
 func init() {
 	runningScripts.cancels = make(map[string]context.CancelFunc)
+	runningScripts.userStopped = make(map[string]bool)
 }
 
 // handleStopScript cancels a running script execution by its requestID.
@@ -41,6 +43,9 @@ func handleStopScript(cmd *v1.StopScriptCommand) {
 
 	runningScripts.mu.Lock()
 	cancel, ok := runningScripts.cancels[requestID]
+	if ok {
+		runningScripts.userStopped[requestID] = true
+	}
 	runningScripts.mu.Unlock()
 
 	if ok {
@@ -109,6 +114,7 @@ func handleExecuteScript(ctx context.Context, client taskguildv1connect.AgentMan
 	defer func() {
 		runningScripts.mu.Lock()
 		delete(runningScripts.cancels, requestID)
+		delete(runningScripts.userStopped, requestID)
 		runningScripts.mu.Unlock()
 	}()
 
@@ -191,8 +197,13 @@ func handleExecuteScript(ctx context.Context, client taskguildv1connect.AgentMan
 	// streamOutput returns).
 	cmdErr := <-waitCh
 
-	// Check if this was a user-initiated stop.
-	stoppedByUser := execCtx.Err() == context.Canceled
+	// Check if this was a user-initiated stop (via StopScriptCommand).
+	// Do not rely on execCtx.Err() == context.Canceled because the context
+	// can also be canceled by SIGUSR1 (hot-reload) or SIGINT/SIGTERM,
+	// which are not user-initiated stops.
+	runningScripts.mu.Lock()
+	stoppedByUser := runningScripts.userStopped[requestID]
+	runningScripts.mu.Unlock()
 
 	logEntries := fullLog.entries()
 

--- a/cmd/taskguild-agent/execute_script_test.go
+++ b/cmd/taskguild-agent/execute_script_test.go
@@ -501,7 +501,7 @@ func TestHandleExecuteScript_StdoutAndStderrInterleaved(t *testing.T) {
 	}
 }
 
-func TestHandleExecuteScript_Stopped(t *testing.T) {
+func TestHandleExecuteScript_ParentContextCancelled(t *testing.T) {
 	mock := &scriptMockClient{}
 	workDir := t.TempDir()
 	cfg := &config{
@@ -512,7 +512,7 @@ func TestHandleExecuteScript_Stopped(t *testing.T) {
 	writeTestScript(t, workDir, "long.sh", "#!/bin/sh\nsleep 60")
 
 	cmd := &v1.ExecuteScriptCommand{
-		RequestId: "req-stop",
+		RequestId: "req-parent-cancel",
 		ScriptId:  "sc-4",
 		Filename:  "long.sh",
 	}
@@ -525,7 +525,8 @@ func TestHandleExecuteScript_Stopped(t *testing.T) {
 		close(done)
 	}()
 
-	// Wait a moment for the script to start, then cancel
+	// Wait a moment for the script to start, then cancel the parent context
+	// (simulating SIGINT/SIGTERM or hot-reload — NOT a user-initiated stop).
 	time.Sleep(200 * time.Millisecond)
 	cancel()
 
@@ -541,10 +542,111 @@ func TestHandleExecuteScript_Stopped(t *testing.T) {
 		t.Fatal("expected result to be reported")
 	}
 	if result.Success {
+		t.Error("expected success=false for cancelled script")
+	}
+	if result.StoppedByUser {
+		t.Error("expected stoppedByUser=false for parent context cancellation (not user-initiated)")
+	}
+}
+
+func TestHandleExecuteScript_StoppedByUser(t *testing.T) {
+	mock := &scriptMockClient{}
+	workDir := t.TempDir()
+	cfg := &config{
+		ProjectName: "test-proj",
+		WorkDir:     workDir,
+	}
+
+	writeTestScript(t, workDir, "long.sh", "#!/bin/sh\nsleep 60")
+
+	cmd := &v1.ExecuteScriptCommand{
+		RequestId: "req-user-stop",
+		ScriptId:  "sc-4b",
+		Filename:  "long.sh",
+	}
+
+	done := make(chan struct{})
+	go func() {
+		handleExecuteScript(context.Background(), mock, cfg, cmd)
+		close(done)
+	}()
+
+	// Wait for the script to register in runningScripts
+	time.Sleep(200 * time.Millisecond)
+
+	// Stop via handleStopScript (user-initiated stop)
+	handleStopScript(&v1.StopScriptCommand{RequestId: "req-user-stop"})
+
+	select {
+	case <-done:
+		// OK
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleExecuteScript did not return after user stop")
+	}
+
+	result := mock.getResult()
+	if result == nil {
+		t.Fatal("expected result to be reported")
+	}
+	if result.Success {
 		t.Error("expected success=false for stopped script")
 	}
-	if result.StoppedByUser != true {
-		t.Error("expected stoppedByUser=true")
+	if !result.StoppedByUser {
+		t.Error("expected stoppedByUser=true for user-initiated stop")
+	}
+}
+
+func TestHandleExecuteScript_HotReloadDoesNotSetStoppedByUser(t *testing.T) {
+	mock := &scriptMockClient{}
+	workDir := t.TempDir()
+	cfg := &config{
+		ProjectName: "test-proj",
+		WorkDir:     workDir,
+	}
+
+	writeTestScript(t, workDir, "long.sh", "#!/bin/sh\nsleep 60")
+
+	cmd := &v1.ExecuteScriptCommand{
+		RequestId: "req-hotreload",
+		ScriptId:  "sc-4c",
+		Filename:  "long.sh",
+	}
+
+	done := make(chan struct{})
+	go func() {
+		handleExecuteScript(context.Background(), mock, cfg, cmd)
+		close(done)
+	}()
+
+	// Wait for the script to register in runningScripts
+	time.Sleep(200 * time.Millisecond)
+
+	// Cancel via runningScripts.cancels directly (mimicking SIGUSR1 handler
+	// which iterates cancels without setting userStopped)
+	runningScripts.mu.Lock()
+	cancelFn, ok := runningScripts.cancels["req-hotreload"]
+	runningScripts.mu.Unlock()
+	if !ok {
+		t.Fatal("expected script to be tracked in runningScripts")
+	}
+	cancelFn()
+
+	select {
+	case <-done:
+		// OK
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleExecuteScript did not return after hot-reload cancellation")
+	}
+
+	result := mock.getResult()
+	if result == nil {
+		t.Fatal("expected result to be reported")
+	}
+	if result.Success {
+		t.Error("expected success=false for cancelled script")
+	}
+	if result.StoppedByUser {
+		t.Error("expected stoppedByUser=false for hot-reload cancellation")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace `execCtx.Err() == context.Canceled` check with an explicit `userStopped` flag to correctly distinguish user-initiated script stops from hot-reload (SIGUSR1) and signal-based cancellations
- Previously, SIGUSR1 sent by the sentinel during `deploy.sh` binary rebuilds would falsely report "Stopped by user"
- The `userStopped` flag is now only set by `handleStopScript()`, the actual user stop path
- Added comprehensive tests covering user stop, hot-reload, and signal scenarios

## Test plan
- [ ] Verify that manually stopping a script via the UI correctly reports "Stopped by user"
- [ ] Verify that hot-reload (SIGUSR1) during script execution does NOT report "Stopped by user"
- [ ] Verify that SIGINT/SIGTERM does NOT falsely trigger "Stopped by user"
- [ ] Run `go test ./cmd/taskguild-agent/...` to confirm all new and existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)