### PR TITLE
feat: save ExitPlanMode result as task plan_result metadata

### DIFF
--- a/cmd/taskguild-agent/directive.go
+++ b/cmd/taskguild-agent/directive.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -450,5 +451,23 @@ func saveTaskDescription(ctx context.Context, taskClient taskguildv1connect.Task
 		logger.Error("failed to save task description", "error", err)
 	} else {
 		logger.Info("task description updated", "description_length", len(description))
+	}
+}
+
+func savePlanResult(ctx context.Context, taskClient taskguildv1connect.TaskServiceClient, taskID, planFilePath string) {
+	logger := clog.LoggerFromContext(ctx)
+	content, err := os.ReadFile(planFilePath)
+	if err != nil {
+		logger.Error("failed to read plan file", "path", planFilePath, "error", err)
+		return
+	}
+	_, err = taskClient.UpdateTask(ctx, connect.NewRequest(&v1.UpdateTaskRequest{
+		Id:       taskID,
+		Metadata: map[string]string{"plan_result": string(content)},
+	}))
+	if err != nil {
+		logger.Error("failed to save plan_result", "error", err)
+	} else {
+		logger.Info("plan_result saved", "path", planFilePath, "content_length", len(content))
 	}
 }

--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -136,7 +136,7 @@ func runTask(
 	statusTransitionRetries := 0
 
 	for turn := 0; ; turn++ {
-		opts := buildClaudeOptions(instructions, workDir, metadata, sessionID, worktreeName, client, ctx, taskID, agentManagerID, waiter, permCache, scpCache, tl)
+		opts := buildClaudeOptions(instructions, workDir, metadata, sessionID, worktreeName, client, taskClient, ctx, taskID, agentManagerID, waiter, permCache, scpCache, tl)
 		// Override StderrCallback to also send to task logger.
 		opts.StderrCallback = func(line string) {
 			logger.Debug("claude-stderr", "line", line)
@@ -459,6 +459,7 @@ func buildClaudeOptions(
 	sessionID string,
 	worktreeName string,
 	client taskguildv1connect.AgentManagerServiceClient,
+	taskClient taskguildv1connect.TaskServiceClient,
 	ctx context.Context,
 	taskID string,
 	agentManagerID string,
@@ -505,7 +506,7 @@ func buildClaudeOptions(
 		StderrCallback: func(line string) {
 			logger.Debug("claude-stderr", "line", line)
 		},
-		Hooks: buildToolUseHooks(tl, taskID),
+		Hooks: buildToolUseHooks(tl, taskID, taskClient),
 	}
 
 	// Use --agent flag when a named agent is assigned; otherwise fall back to --system-prompt.

--- a/cmd/taskguild-agent/toolhooks.go
+++ b/cmd/taskguild-agent/toolhooks.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -8,11 +9,17 @@ import (
 
 	claudeagent "github.com/kazz187/claude-agent-sdk-go"
 	v1 "github.com/kazz187/taskguild/gen/proto/taskguild/v1"
+	"github.com/kazz187/taskguild/gen/proto/taskguild/v1/taskguildv1connect"
 )
 
 // buildToolUseHooks creates PostToolUse and PostToolUseFail hook matchers
 // that log tool invocations (with input and output) to the task timeline.
-func buildToolUseHooks(tl *taskLogger, taskID string) map[claudeagent.HookEvent][]*claudeagent.HookMatcher {
+// When a taskClient is provided, it also tracks plan file writes and saves
+// the plan content to task metadata when ExitPlanMode is called.
+func buildToolUseHooks(tl *taskLogger, taskID string, taskClient taskguildv1connect.TaskServiceClient) map[claudeagent.HookEvent][]*claudeagent.HookMatcher {
+	// Track the most recently written plan file path across hook invocations.
+	var planFilePath string
+
 	return map[claudeagent.HookEvent][]*claudeagent.HookMatcher{
 		claudeagent.HookEventPostToolUse: {
 			{
@@ -20,6 +27,21 @@ func buildToolUseHooks(tl *taskLogger, taskID string) map[claudeagent.HookEvent]
 				Hooks: []claudeagent.HookCallback{
 					func(input claudeagent.HookInput, toolUseID string, ctx claudeagent.HookContext) (claudeagent.HookOutput, error) {
 						logToolUse(tl, taskID, input, false)
+
+						// Track plan file writes.
+						if input.ToolName == "Write" || input.ToolName == "Edit" {
+							if fp, ok := input.ToolInput["file_path"].(string); ok {
+								if strings.Contains(fp, ".claude/plans/") {
+									planFilePath = fp
+								}
+							}
+						}
+
+						// Save plan result when ExitPlanMode is called.
+						if input.ToolName == "ExitPlanMode" && planFilePath != "" && taskClient != nil {
+							savePlanResult(context.Background(), taskClient, taskID, planFilePath)
+						}
+
 						return claudeagent.HookOutput{}, nil
 					},
 				},

--- a/frontend/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/frontend/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -249,7 +249,8 @@ function TaskDetailPage() {
 
   const metadata = task.metadata ?? {}
   const resultSummary = metadata['result_summary'] ?? ''
-  const metadataEntries = Object.entries(metadata).filter(([key, v]) => v && key !== 'result_summary' && key !== 'result_status' && key !== 'result_error')
+  const planResult = metadata['plan_result'] ?? ''
+  const metadataEntries = Object.entries(metadata).filter(([key, v]) => v && key !== 'result_summary' && key !== 'result_status' && key !== 'result_error' && key !== 'plan_result')
 
   return (
     <div className="flex flex-col h-full">
@@ -366,6 +367,14 @@ function TaskDetailPage() {
             <div className="bg-slate-900 border border-slate-800 rounded-lg p-3 md:p-4">
               <p className="text-xs text-gray-500 uppercase tracking-wide mb-2">Description</p>
               <p className="text-sm text-gray-300 whitespace-pre-wrap">{task.description}</p>
+            </div>
+          )}
+
+          {/* Plan Result */}
+          {planResult && (
+            <div className="bg-slate-900 border border-slate-800 rounded-lg p-3 md:p-4">
+              <p className="text-xs text-gray-500 uppercase tracking-wide mb-2">Plan Result</p>
+              <MarkdownDescription content={planResult} className="text-sm text-gray-300" />
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- Save ExitPlanMode tool results as `plan_result` metadata on tasks
- Add directive support and tool hooks for capturing plan results
- Display plan results in the task detail UI

## Test plan
- [ ] Verify ExitPlanMode results are saved as task metadata
- [ ] Confirm plan results are displayed in the task detail view

🤖 Generated with [Claude Code](https://claude.com/claude-code)