### PR TITLE
fix: auto-transition on missing NEXT_STATUS, unify status naming, realtime logging

### DIFF
--- a/cmd/taskguild-agent/cmdlog.go
+++ b/cmd/taskguild-agent/cmdlog.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	claudeagent "github.com/kazz187/claude-agent-sdk-go"
@@ -18,8 +19,8 @@ import (
 // userInputMsg mirrors the SDK's internal userInputMessage for sending
 // the initial prompt via the control protocol.
 type userInputMsg struct {
-	Type    string          `json:"type"`
-	Message userInputBody   `json:"message"`
+	Type      string        `json:"type"`
+	Message   userInputBody `json:"message"`
 	SessionID string        `json:"sessionId"`
 }
 
@@ -28,12 +29,20 @@ type userInputBody struct {
 	Content string `json:"content"`
 }
 
-// logCommandArgs writes the CLI command arguments to a timestamped log file
-// under {workDir}/.claude/cmd-logs/{taskID}/.
-// Errors are non-fatal and logged as warnings.
-func logCommandArgs(workDir, taskID, label string, args []string) {
+// turnLog writes log entries to a single file per turn in real-time.
+// Each method appends to the file immediately so that partial logs
+// are available even if the process is interrupted.
+type turnLog struct {
+	mu   sync.Mutex
+	file *os.File
+	idx  int // message counter
+}
+
+// newTurnLog creates a new turn log file and writes the header.
+// If workDir is empty, logging is disabled (all methods become no-ops).
+func newTurnLog(workDir, taskID, label string) *turnLog {
 	if workDir == "" {
-		return
+		return &turnLog{}
 	}
 
 	dir := taskID
@@ -44,57 +53,83 @@ func logCommandArgs(workDir, taskID, label string, args []string) {
 	logDir := filepath.Join(workDir, ".claude", "cmd-logs", dir)
 	if err := os.MkdirAll(logDir, 0o755); err != nil {
 		slog.Warn("failed to create cmd-log directory", "dir", logDir, "error", err)
-		return
+		return &turnLog{}
 	}
 
 	ts := time.Now().UTC().Format(time.RFC3339Nano)
 	filename := fmt.Sprintf("%s_%s.log", ts, label)
 	logPath := filepath.Join(logDir, filename)
 
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("# Command: %s\n", ts))
-	sb.WriteString(fmt.Sprintf("# Task: %s\n", taskID))
-	sb.WriteString(fmt.Sprintf("# Label: %s\n\n", label))
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		slog.Warn("failed to open turn-log file", "path", logPath, "error", err)
+		return &turnLog{}
+	}
 
+	tl := &turnLog{file: f}
+	tl.write(fmt.Sprintf("# Turn log: %s\n# Task: %s\n# Label: %s\n", ts, taskID, label))
+	return tl
+}
+
+// Close closes the underlying file.
+func (tl *turnLog) Close() {
+	tl.mu.Lock()
+	defer tl.mu.Unlock()
+	if tl.file != nil {
+		tl.file.Close()
+		tl.file = nil
+	}
+}
+
+// write appends text to the file. Caller must not hold tl.mu.
+func (tl *turnLog) write(s string) {
+	if tl.file == nil {
+		return
+	}
+	if _, err := tl.file.WriteString(s); err != nil {
+		slog.Warn("failed to write to turn-log", "error", err)
+	}
+}
+
+// writeLocked appends text while holding the lock.
+func (tl *turnLog) writeLocked(s string) {
+	tl.mu.Lock()
+	defer tl.mu.Unlock()
+	tl.write(s)
+}
+
+func separator() string {
+	return "\n" + strings.Repeat("=", 60) + "\n"
+}
+
+func ts() string {
+	return time.Now().UTC().Format(time.RFC3339Nano)
+}
+
+// LogCommandArgs writes command arguments immediately.
+func (tl *turnLog) LogCommandArgs(args []string) {
+	if tl.file == nil || len(args) == 0 {
+		return
+	}
+	var sb strings.Builder
+	sb.WriteString(separator())
+	sb.WriteString(fmt.Sprintf("[%s] ## Command Args\n\n", ts()))
 	for _, arg := range args {
 		sb.WriteString(arg)
 		sb.WriteString("\n")
 	}
-
 	sb.WriteString(fmt.Sprintf("\n# Full command:\n%s\n", strings.Join(args, " ")))
-
-	if err := os.WriteFile(logPath, []byte(sb.String()), 0o644); err != nil {
-		slog.Warn("failed to write cmd-log", "path", logPath, "error", err)
-	}
+	tl.writeLocked(sb.String())
 }
 
-// logStdinMessage writes the stdin JSON control protocol message to a
-// timestamped log file under {workDir}/.claude/cmd-logs/{taskID}/.
-// Errors are non-fatal and logged as warnings.
-func logStdinMessage(workDir, taskID, label string, jsonData []byte) {
-	if workDir == "" {
+// LogStdinMessage writes the stdin JSON message immediately.
+func (tl *turnLog) LogStdinMessage(jsonData []byte) {
+	if tl.file == nil {
 		return
 	}
-
-	dir := taskID
-	if dir == "" {
-		dir = "_system"
-	}
-
-	logDir := filepath.Join(workDir, ".claude", "cmd-logs", dir)
-	if err := os.MkdirAll(logDir, 0o755); err != nil {
-		slog.Warn("failed to create cmd-log directory", "dir", logDir, "error", err)
-		return
-	}
-
-	ts := time.Now().UTC().Format(time.RFC3339Nano)
-	filename := fmt.Sprintf("%s_%s_stdin.log", ts, label)
-	logPath := filepath.Join(logDir, filename)
-
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("# Stdin message: %s\n", ts))
-	sb.WriteString(fmt.Sprintf("# Task: %s\n", taskID))
-	sb.WriteString(fmt.Sprintf("# Label: %s\n\n", label))
+	sb.WriteString(separator())
+	sb.WriteString(fmt.Sprintf("[%s] ## Stdin Message\n\n", ts()))
 
 	var prettyJSON bytes.Buffer
 	if err := json.Indent(&prettyJSON, jsonData, "", "  "); err == nil {
@@ -103,16 +138,65 @@ func logStdinMessage(workDir, taskID, label string, jsonData []byte) {
 		sb.Write(jsonData)
 	}
 	sb.WriteString("\n")
+	tl.writeLocked(sb.String())
+}
 
-	if err := os.WriteFile(logPath, []byte(sb.String()), 0o644); err != nil {
-		slog.Warn("failed to write stdin-log", "path", logPath, "error", err)
+// LogMessage writes a single received message immediately with a timestamp.
+func (tl *turnLog) LogMessage(msg claudeagent.Message) {
+	if tl.file == nil {
+		return
 	}
+	tl.mu.Lock()
+	idx := tl.idx
+	tl.idx++
+	tl.mu.Unlock()
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		tl.writeLocked(fmt.Sprintf("\n[%s] ## Message[%d] (marshal error: %v)\n", ts(), idx, err))
+		return
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("\n[%s] ## Message[%d]\n", ts(), idx))
+	var prettyJSON bytes.Buffer
+	if err := json.Indent(&prettyJSON, data, "", "  "); err == nil {
+		sb.WriteString(prettyJSON.String())
+	} else {
+		sb.Write(data)
+	}
+	sb.WriteString("\n")
+	tl.writeLocked(sb.String())
+}
+
+// LogResult writes the final result summary immediately.
+func (tl *turnLog) LogResult(result *claudeagent.ResultMessage, queryErr error) {
+	if tl.file == nil {
+		return
+	}
+	var sb strings.Builder
+	sb.WriteString(separator())
+	sb.WriteString(fmt.Sprintf("[%s] ## Final Result\n\n", ts()))
+
+	if queryErr != nil {
+		sb.WriteString(fmt.Sprintf("### Error\n%v\n\n", queryErr))
+	}
+
+	if result == nil {
+		sb.WriteString("Result: nil\n")
+	} else {
+		sb.WriteString(fmt.Sprintf("Session ID: %s\n", result.SessionID))
+		sb.WriteString(fmt.Sprintf("Is Error: %v\n", result.IsError))
+		sb.WriteString(fmt.Sprintf("Result Text (%d chars):\n", len(result.Result)))
+		sb.WriteString(result.Result)
+		sb.WriteString("\n")
+	}
+	tl.writeLocked(sb.String())
 }
 
 // runQuerySyncWithLog executes a synchronous SDK query and logs the CLI
-// command arguments to an individual file. It mirrors the behavior of
-// claudeagent.RunQuerySync but uses lower-level SDK APIs to access the
-// transport's CommandArgs().
+// command arguments, stdin message, each received message, and the final
+// result to a single file per turn in real-time.
 func runQuerySyncWithLog(
 	ctx context.Context,
 	prompt string,
@@ -123,6 +207,9 @@ func runQuerySyncWithLog(
 	if options != nil {
 		opts = *options
 	}
+
+	tl := newTurnLog(workDir, taskID, label)
+	defer tl.Close()
 
 	// Configure permission prompt tool name (matching RunQuery behavior).
 	if opts.CanUseTool != nil {
@@ -139,9 +226,9 @@ func runQuerySyncWithLog(
 	}
 	defer transport.Close()
 
-	// Log command args to file.
+	// Log command args.
 	if args := transport.CommandArgs(); args != nil {
-		logCommandArgs(workDir, taskID, label, args)
+		tl.LogCommandArgs(args)
 	}
 
 	// Calculate initialize timeout (matching RunQuery behavior).
@@ -185,7 +272,7 @@ func runQuerySyncWithLog(
 	if err := transport.Write(ctx, string(data)+"\n"); err != nil {
 		return nil, err
 	}
-	logStdinMessage(workDir, taskID, label, data)
+	tl.LogStdinMessage(data)
 
 	// Handle stdin closure.
 	hasHooks := len(opts.Hooks) > 0
@@ -210,17 +297,21 @@ func runQuerySyncWithLog(
 	for {
 		select {
 		case <-ctx.Done():
+			tl.LogResult(result.Result, ctx.Err())
 			return result, ctx.Err()
 		case err, ok := <-queryErrChan:
 			if ok && err != nil {
 				// Exit code 0 is normal termination.
 				if pe, ok := err.(*claudeagent.ProcessError); ok && pe.ExitCode == 0 {
+					tl.LogResult(result.Result, nil)
 					return result, nil
 				}
+				tl.LogResult(result.Result, err)
 				return result, err
 			}
 		case rawMsg, ok := <-rawMsgChan:
 			if !ok {
+				tl.LogResult(result.Result, nil)
 				return result, nil
 			}
 
@@ -230,6 +321,7 @@ func runQuerySyncWithLog(
 				if _, isParseErr := err.(*claudeagent.MessageParseError); isParseErr {
 					continue
 				}
+				tl.LogResult(result.Result, err)
 				return result, err
 			}
 			if parsed == nil {
@@ -237,6 +329,7 @@ func runQuerySyncWithLog(
 			}
 
 			result.Messages = append(result.Messages, parsed)
+			tl.LogMessage(parsed)
 
 			if rm, ok := parsed.(*claudeagent.ResultMessage); ok {
 				result.Result = rm
@@ -245,6 +338,7 @@ func runQuerySyncWithLog(
 					transport.EndInput()
 					stdinClosed = true
 				}
+				tl.LogResult(result.Result, nil)
 				return result, nil
 			}
 		}

--- a/cmd/taskguild-agent/directive.go
+++ b/cmd/taskguild-agent/directive.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
+
 	v1 "github.com/kazz187/taskguild/gen/proto/taskguild/v1"
 	"github.com/kazz187/taskguild/gen/proto/taskguild/v1/taskguildv1connect"
 	"github.com/kazz187/taskguild/pkg/clog"
@@ -19,11 +20,11 @@ var errInvalidTransition = errors.New("invalid status transition")
 
 // createTaskDirective holds parsed CREATE_TASK directive fields.
 type createTaskDirective struct {
-	Title          string
-	Description    string
-	StatusID       string // could be status name, resolved from _workflow_statuses
-	UseWorktree    *bool
-	Worktree       string
+	Title       string
+	Description string
+	StatusID    string // could be status name, resolved from _workflow_statuses
+	UseWorktree *bool
+	Worktree    string
 }
 
 // parseCreateTasks extracts all CREATE_TASK_START...CREATE_TASK_END blocks from the result text.
@@ -152,12 +153,12 @@ func createTaskFromDirective(
 	}
 
 	req := &v1.CreateTaskRequest{
-		ProjectId:      projectID,
-		WorkflowId:     workflowID,
-		Title:          directive.Title,
-		Description:    directive.Description,
-		UseWorktree:    useWorktree,
-		Metadata:       taskMeta,
+		ProjectId:   projectID,
+		WorkflowId:  workflowID,
+		Title:       directive.Title,
+		Description: directive.Description,
+		UseWorktree: useWorktree,
+		Metadata:    taskMeta,
 	}
 	if statusID != "" {
 		req.StatusId = &statusID
@@ -334,11 +335,11 @@ func validateAndResolveTransition(nextStatusID string, metadata map[string]strin
 	return "", fmt.Errorf("%w: %q (available: %s)", errInvalidTransition, nextStatusID, formatTransitionList(transitions))
 }
 
-// formatTransitionList formats a list of transitions as "ID (Name), ..." for error messages.
+// formatTransitionList formats a list of transitions as "Name, ..." for error messages.
 func formatTransitionList(transitions []transitionEntry) string {
 	parts := make([]string, len(transitions))
 	for i, t := range transitions {
-		parts[i] = fmt.Sprintf("%s (%s)", t.ID, t.Name)
+		parts[i] = t.Name
 	}
 	return strings.Join(parts, ", ")
 }
@@ -353,13 +354,13 @@ func buildTransitionRetryPrompt(failedStatusID string, metadata map[string]strin
 	if err == nil && len(transitions) > 0 {
 		sb.WriteString("Valid transitions are:\n")
 		for _, t := range transitions {
-			sb.WriteString(fmt.Sprintf("- %s: %s\n", t.ID, t.Name))
+			sb.WriteString(fmt.Sprintf("- %s\n", t.Name))
 		}
 	}
 
 	sb.WriteString("\nPlease output the correct status on the LAST LINE of your response in the format:\n")
-	sb.WriteString("NEXT_STATUS: <status_id>\n\n")
-	sb.WriteString("Use ONLY one of the status IDs listed above.")
+	sb.WriteString("NEXT_STATUS: <status>\n\n")
+	sb.WriteString("Use ONLY one of the statuses listed above.")
 	return sb.String()
 }
 

--- a/cmd/taskguild-agent/prompt.go
+++ b/cmd/taskguild-agent/prompt.go
@@ -41,9 +41,9 @@ func buildUserPrompt(metadata map[string]string, workDir string) string {
 			}
 			sb.WriteString("Available next statuses:\n")
 			for _, t := range transitions {
-				sb.WriteString(fmt.Sprintf("- %s: %s\n", t.ID, t.Name))
+				sb.WriteString(fmt.Sprintf("- %s\n", t.Name))
 			}
-			sb.WriteString("\nAfter completing the task, output your chosen next status on the last line:\nNEXT_STATUS: <status_id>\n")
+			sb.WriteString("\nAfter completing the task, output your chosen next status on the last line:\nNEXT_STATUS: <status>\n")
 		}
 	}
 
@@ -62,7 +62,7 @@ func buildUserPrompt(metadata map[string]string, workDir string) string {
 	sb.WriteString("```\n")
 	sb.WriteString("CREATE_TASK_START\n")
 	sb.WriteString("title: Task title (required)\n")
-	sb.WriteString("status: Status ID or status name (optional)\n")
+	sb.WriteString("status: Status name (optional)\n")
 	sb.WriteString("use_worktree: true or false (optional, inherits current task setting)\n")
 	sb.WriteString("worktree: existing-worktree-name (optional)\n")
 	sb.WriteString("\n")
@@ -82,7 +82,7 @@ func buildUserPrompt(metadata map[string]string, workDir string) string {
 		if err := json.Unmarshal([]byte(statusesJSON), &statuses); err == nil && len(statuses) > 0 {
 			sb.WriteString("\nAvailable statuses for new tasks:\n")
 			for _, s := range statuses {
-				sb.WriteString(fmt.Sprintf("- %s: %s\n", s.ID, s.Name))
+				sb.WriteString(fmt.Sprintf("- %s\n", s.Name))
 			}
 		}
 	}
@@ -141,7 +141,7 @@ func buildWorkflowContext(metadata map[string]string) string {
 			currentID := metadata["_current_status_id"]
 			sb.WriteString("\n### Workflow Statuses\n")
 			for _, s := range statuses {
-				sb.WriteString(fmt.Sprintf("- %s: %s", s.ID, s.Name))
+				sb.WriteString(fmt.Sprintf("- %s", s.Name))
 				if s.ID == currentID {
 					sb.WriteString("  <-- current")
 				}
@@ -160,7 +160,7 @@ func buildWorkflowContext(metadata map[string]string) string {
 		if err := json.Unmarshal([]byte(transitionsJSON), &transitions); err == nil && len(transitions) > 0 {
 			sb.WriteString("\n### Available Transitions\n")
 			for _, t := range transitions {
-				sb.WriteString(fmt.Sprintf("- %s: %s\n", t.ID, t.Name))
+				sb.WriteString(fmt.Sprintf("- %s\n", t.Name))
 			}
 		}
 	}

--- a/cmd/taskguild-agent/prompt_test.go
+++ b/cmd/taskguild-agent/prompt_test.go
@@ -27,21 +27,21 @@ func TestBuildWorkflowContext(t *testing.T) {
 			name: "full metadata with hooks",
 			metadata: map[string]string{
 				"_workflow_id":           "wf1",
-				"_current_status_id":    "s2",
-				"_current_status_name":  "In Progress",
-				"_workflow_statuses":    `[{"id":"s1","name":"Backlog"},{"id":"s2","name":"In Progress"},{"id":"s3","name":"Review"},{"id":"s4","name":"Done"}]`,
+				"_current_status_id":     "s2",
+				"_current_status_name":   "In Progress",
+				"_workflow_statuses":     `[{"id":"s1","name":"Backlog"},{"id":"s2","name":"In Progress"},{"id":"s3","name":"Review"},{"id":"s4","name":"Done"}]`,
 				"_available_transitions": `[{"id":"s3","name":"Review"}]`,
-				"_hooks":                `[{"name":"Run linter","action_type":"skill","trigger":"before_task_execution"},{"name":"Deploy check","action_type":"script","trigger":"after_task_execution"}]`,
+				"_hooks":                 `[{"name":"Run linter","action_type":"skill","trigger":"before_task_execution"},{"name":"Deploy check","action_type":"script","trigger":"after_task_execution"}]`,
 			},
 			contains: []string{
 				"## TaskGuild Workflow Context",
 				"### Workflow Statuses",
-				"- s1: Backlog\n",
-				"- s2: In Progress  <-- current\n",
-				"- s3: Review\n",
-				"- s4: Done\n",
+				"- Backlog\n",
+				"- In Progress  <-- current\n",
+				"- Review\n",
+				"- Done\n",
 				"### Available Transitions",
-				"- s3: Review\n",
+				"- Review\n",
 				"### Hooks",
 				`"Run linter" (skill)`,
 				"before_task_execution",
@@ -53,15 +53,15 @@ func TestBuildWorkflowContext(t *testing.T) {
 			name: "full metadata without hooks",
 			metadata: map[string]string{
 				"_workflow_id":           "wf1",
-				"_current_status_id":    "s1",
-				"_current_status_name":  "Backlog",
-				"_workflow_statuses":    `[{"id":"s1","name":"Backlog"},{"id":"s2","name":"In Progress"}]`,
+				"_current_status_id":     "s1",
+				"_current_status_name":   "Backlog",
+				"_workflow_statuses":     `[{"id":"s1","name":"Backlog"},{"id":"s2","name":"In Progress"}]`,
 				"_available_transitions": `[{"id":"s2","name":"In Progress"}]`,
 			},
 			contains: []string{
 				"### Workflow Statuses",
-				"- s1: Backlog  <-- current\n",
-				"- s2: In Progress\n",
+				"- Backlog  <-- current\n",
+				"- In Progress\n",
 				"### Available Transitions",
 			},
 			excludes: []string{
@@ -72,9 +72,9 @@ func TestBuildWorkflowContext(t *testing.T) {
 			name: "malformed JSON graceful handling",
 			metadata: map[string]string{
 				"_workflow_id":           "wf1",
-				"_workflow_statuses":    `invalid json`,
+				"_workflow_statuses":     `invalid json`,
 				"_available_transitions": `also invalid`,
-				"_hooks":                `not json`,
+				"_hooks":                 `not json`,
 			},
 			contains: []string{
 				"## TaskGuild Workflow Context",
@@ -88,7 +88,7 @@ func TestBuildWorkflowContext(t *testing.T) {
 		{
 			name: "empty hooks array omits section",
 			metadata: map[string]string{
-				"_workflow_id":        "wf1",
+				"_workflow_id":       "wf1",
 				"_workflow_statuses": `[{"id":"s1","name":"Draft"}]`,
 				"_hooks":             `[]`,
 			},
@@ -99,14 +99,14 @@ func TestBuildWorkflowContext(t *testing.T) {
 		{
 			name: "current status marker on correct status",
 			metadata: map[string]string{
-				"_workflow_id":        "wf1",
+				"_workflow_id":       "wf1",
 				"_current_status_id": "s3",
 				"_workflow_statuses": `[{"id":"s1","name":"A"},{"id":"s2","name":"B"},{"id":"s3","name":"C"}]`,
 			},
 			contains: []string{
-				"- s1: A\n",
-				"- s2: B\n",
-				"- s3: C  <-- current\n",
+				"- A\n",
+				"- B\n",
+				"- C  <-- current\n",
 			},
 		},
 	}

--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -13,6 +13,7 @@ import (
 
 	"connectrpc.com/connect"
 	claudeagent "github.com/kazz187/claude-agent-sdk-go"
+
 	v1 "github.com/kazz187/taskguild/gen/proto/taskguild/v1"
 	"github.com/kazz187/taskguild/gen/proto/taskguild/v1/taskguildv1connect"
 	"github.com/kazz187/taskguild/pkg/clog"
@@ -412,6 +413,27 @@ func runTask(
 			return
 		}
 
+		// No NEXT_STATUS output but transitions exist — try auto-transition
+		// if exactly one transition is available.
+		if transitions, err := parseAvailableTransitions(metadata); err == nil && len(transitions) == 1 {
+			autoID := transitions[0].ID
+			autoName := transitions[0].Name
+			logger.Info("no NEXT_STATUS output, auto-transitioning (single transition available)",
+				"next_status_id", autoID, "next_status_name", autoName, "turn", turn)
+			tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
+				fmt.Sprintf("No NEXT_STATUS output; auto-transitioning to %s (%s)", autoID, autoName), nil)
+			reportTaskResult(ctx, client, taskID, summary, "")
+			reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_IDLE, "task completed (auto-transition)")
+			afterHooks()
+			maybeRunAgentMDHarness(ctx, metadata, taskID, summary, workDir, tl, client)
+			if err := handleStatusTransition(ctx, taskClient, taskID, autoID, metadata, tl); err != nil {
+				logger.Error("auto status transition failed", "error", err)
+				tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_WARN,
+					fmt.Sprintf("Auto status transition to %q failed: %v", autoID, err), nil)
+			}
+			return
+		}
+
 		// Claude hasn't completed — wait for user input.
 		logger.Info("waiting for user input", "turn", turn)
 		reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_RUNNING, "waiting for user input")
@@ -425,6 +447,14 @@ func runTask(
 					"Max user response retries reached, force-completing task", nil)
 				reportTaskResult(ctx, client, taskID, summary, "")
 				reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_IDLE, "task force-completed (no NEXT_STATUS after retries)")
+				// Attempt auto-transition on force-complete so the task
+				// does not remain stuck at the current status.
+				afterHooks()
+				if err := handleStatusTransition(ctx, taskClient, taskID, "", metadata, tl); err != nil {
+					logger.Warn("auto-transition on force-complete failed", "error", err)
+					tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_WARN,
+						fmt.Sprintf("Auto-transition on force-complete failed: %v", err), nil)
+				}
 				return
 			}
 			logger.Warn("user response timeout, prompting for NEXT_STATUS", "retry", userResponseRetries, "max_retries", maxUserResponseRetries)
@@ -433,7 +463,7 @@ func runTask(
 			reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_RUNNING, "retrying: requesting NEXT_STATUS")
 			prompt = "You appear to have completed your work but did not output a NEXT_STATUS directive. " +
 				"Please review the available status transitions and output your chosen next status on the LAST LINE of your response in the format:\n" +
-				"NEXT_STATUS: <status_id>\n\n" +
+				"NEXT_STATUS: <status>\n\n" +
 				"If you still need user input, clearly state what you need."
 			continue
 		}
@@ -441,6 +471,11 @@ func runTask(
 			logger.Error("user response error, completing task", "error", err)
 			reportTaskResult(ctx, client, taskID, summary, "")
 			reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_IDLE, "task completed (no user response)")
+			// Attempt auto-transition so the task does not remain stuck.
+			afterHooks()
+			if transErr := handleStatusTransition(ctx, taskClient, taskID, "", metadata, tl); transErr != nil {
+				logger.Warn("auto-transition on user response error failed", "error", transErr)
+			}
 			return
 		}
 


### PR DESCRIPTION
## Summary
- **Auto-transition**: NEXT_STATUSを出力せずに完了した場合、遷移先が1つなら自動遷移（タスクstuck防止）
- **Force-complete/エラー時にも自動遷移を試行**: タイムアウトやユーザー応答エラーでも同様
- **status_id → status**: エージェント向けプロンプトで `- ID: Name` ペア表示を `- Name` リスト表示に統一、プレースホルダを `<status>` に変更
- **リアルタイムターンログ**: 1ターン=1ファイルに統合し、メッセージ受信時に即座にファイルへ書き出し（途中停止でもログが残る）

## Test plan
- [x] `go build ./cmd/taskguild-agent/` 成功
- [x] `go test ./cmd/taskguild-agent/ -run TestBuildWorkflowContext` 全パス
- [ ] NEXT_STATUSなしで完了するタスクが自動遷移されることを確認
- [ ] `.claude/cmd-logs/` に1ターン1ファイルでリアルタイムログが出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)