### PR TITLE
fix: non-blocking semaphore to prevent subscribe loop deadlock

### DIFF
--- a/cmd/taskguild-agent/directive.go
+++ b/cmd/taskguild-agent/directive.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -454,20 +453,15 @@ func saveTaskDescription(ctx context.Context, taskClient taskguildv1connect.Task
 	}
 }
 
-func savePlanResult(ctx context.Context, taskClient taskguildv1connect.TaskServiceClient, taskID, planFilePath string) {
+func savePlanResult(ctx context.Context, taskClient taskguildv1connect.TaskServiceClient, taskID, content string) {
 	logger := clog.LoggerFromContext(ctx)
-	content, err := os.ReadFile(planFilePath)
-	if err != nil {
-		logger.Error("failed to read plan file", "path", planFilePath, "error", err)
-		return
-	}
-	_, err = taskClient.UpdateTask(ctx, connect.NewRequest(&v1.UpdateTaskRequest{
+	_, err := taskClient.UpdateTask(ctx, connect.NewRequest(&v1.UpdateTaskRequest{
 		Id:       taskID,
-		Metadata: map[string]string{"plan_result": string(content)},
+		Metadata: map[string]string{"plan_result": content},
 	}))
 	if err != nil {
 		logger.Error("failed to save plan_result", "error", err)
 	} else {
-		logger.Info("plan_result saved", "path", planFilePath, "content_length", len(content))
+		logger.Info("plan_result saved", "content_length", len(content))
 	}
 }

--- a/cmd/taskguild-agent/run.go
+++ b/cmd/taskguild-agent/run.go
@@ -333,16 +333,29 @@ func runSubscribeLoop(
 				mu.Unlock()
 			}
 
+			// Try to acquire semaphore slot BEFORE claiming to avoid
+			// blocking the subscribe loop when at max capacity.
+			// If all slots are full, skip this task so another agent
+			// (or a later retry) can pick it up.
+			select {
+			case sem <- struct{}{}:
+			default:
+				slog.Info("at max capacity, skipping task", "task_id", taskID)
+				continue
+			}
+
 			// Try to claim the task
 			claimResp, err := client.ClaimTask(ctx, connect.NewRequest(&v1.ClaimTaskRequest{
 				TaskId:         taskID,
 				AgentManagerId: cfg.AgentManagerID,
 			}))
 			if err != nil {
+				<-sem // release slot on claim failure
 				slog.Error("failed to claim task", "task_id", taskID, "error", err)
 				continue
 			}
 			if !claimResp.Msg.GetSuccess() {
+				<-sem // release slot on claim failure
 				slog.Info("task already claimed by another agent", "task_id", taskID)
 				continue
 			}
@@ -350,13 +363,6 @@ func runSubscribeLoop(
 			slog.Info("claimed task", "task_id", taskID)
 			instructions := claimResp.Msg.GetInstructions()
 			metadata := claimResp.Msg.GetMetadata()
-
-			// Acquire semaphore slot
-			select {
-			case sem <- struct{}{}:
-			case <-ctx.Done():
-				return ctx.Err()
-			}
 
 			taskCtx, taskCancel := context.WithCancel(ctx)
 			mu.Lock()
@@ -373,8 +379,15 @@ func runSubscribeLoop(
 					mu.Unlock()
 					taskCancel()
 				}()
+				defer func() {
+					if r := recover(); r != nil {
+						slog.Error("runTask panicked", "task_id", tID, "panic", fmt.Sprintf("%v", r))
+					}
+				}()
 
+				slog.Info("launching runTask goroutine", "task_id", tID)
 				runTask(taskCtx, client, taskClient, interClient, cfg.AgentManagerID, tID, instructions, metadata, cfg.WorkDir, permCache, scpCache)
+				slog.Info("runTask goroutine finished", "task_id", tID)
 			}(taskID)
 
 		case *v1.AgentCommand_ListWorktrees:
@@ -487,10 +500,12 @@ func runSubscribeLoop(
 			instructions := assignCmd.GetInstructions()
 			metadata := assignCmd.GetMetadata()
 
+			// Non-blocking semaphore check to avoid blocking the subscribe loop.
 			select {
 			case sem <- struct{}{}:
-			case <-ctx.Done():
-				return ctx.Err()
+			default:
+				slog.Warn("at max capacity, cannot run assigned task", "task_id", taskID)
+				continue
 			}
 
 			taskCtx, taskCancel := context.WithCancel(ctx)
@@ -508,8 +523,15 @@ func runSubscribeLoop(
 					mu.Unlock()
 					taskCancel()
 				}()
+				defer func() {
+					if r := recover(); r != nil {
+						slog.Error("runTask panicked", "task_id", tID, "panic", fmt.Sprintf("%v", r))
+					}
+				}()
 
+				slog.Info("launching runTask goroutine (assigned)", "task_id", tID)
 				runTask(taskCtx, client, taskClient, interClient, cfg.AgentManagerID, tID, instructions, metadata, cfg.WorkDir, permCache, scpCache)
+				slog.Info("runTask goroutine finished (assigned)", "task_id", tID)
 			}(taskID)
 
 		case *v1.AgentCommand_InteractionResponse:

--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -70,6 +70,7 @@ func runTask(
 	logger := slog.Default().With("task_id", taskID)
 	ctx = clog.ContextWithLogger(ctx, logger)
 
+	logger.Info("runTask started", "agent_name", metadata["_agent_name"], "use_worktree", metadata["_use_worktree"])
 	reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_RUNNING, "starting task")
 
 	// Initialize task logger for structured log streaming.
@@ -80,7 +81,9 @@ func runTask(
 	// Resolve worktree name: reuse persisted name or generate a new one.
 	worktreeName := metadata["worktree"]
 	if worktreeName == "" && metadata["_use_worktree"] == "true" {
+		logger.Info("generating worktree name")
 		worktreeName = generateWorktreeName(ctx, taskID, metadata["_task_title"], workDir)
+		logger.Info("worktree name generated", "worktree_name", worktreeName)
 		saveWorktreeName(ctx, taskClient, taskID, worktreeName)
 		metadata["worktree"] = worktreeName // keep local metadata in sync for buildUserPrompt
 	}
@@ -88,6 +91,7 @@ func runTask(
 	// Ensure the worktree directory exists before launching Claude so that
 	// Cwd is set to the worktree from the very first turn.
 	if metadata["_use_worktree"] == "true" && worktreeName != "" {
+		logger.Info("ensuring worktree directory", "worktree_name", worktreeName)
 		if _, err := ensureWorktree(ctx, workDir, worktreeName, taskID); err != nil {
 			logger.Warn("failed to ensure worktree", "error", err)
 		}
@@ -117,7 +121,9 @@ func runTask(
 	defer afterHooks()
 
 	// Execute before_task_execution hooks.
+	logger.Info("executing before_task_execution hooks")
 	executeHooks(ctx, taskID, "before_task_execution", metadata, workDir, taskClient, tl)
+	logger.Info("before_task_execution hooks completed")
 
 	// Start interaction stream listener for this task.
 	waiter := newInteractionWaiter()
@@ -126,6 +132,7 @@ func runTask(
 	sessionID := metadata["session_id"]
 	prompt := buildUserPrompt(metadata, workDir)
 	hasTransitions := metadata["_available_transitions"] != ""
+	logger.Info("task setup complete, entering turn loop", "has_session", sessionID != "", "has_transitions", hasTransitions)
 
 	const maxResumeRetries = 2 // after this many consecutive resume failures, start fresh
 
@@ -146,6 +153,7 @@ func runTask(
 		tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_TURN_START, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
 			fmt.Sprintf("Turn %d started", turn),
 			map[string]string{"turn": fmt.Sprintf("%d", turn)})
+		logger.Info("starting Claude CLI", "turn", turn, "session_id", sessionID)
 		logger.Debug("Claude SDK input", "turn", turn)
 		if turn == 0 {
 			logger.Debug("system prompt", "prompt", instructions)
@@ -159,7 +167,7 @@ func runTask(
 
 		result, err := runQuerySyncWithLog(ctx, prompt, opts, workDir, taskID, fmt.Sprintf("task_turn%d", turn))
 
-		logger.Debug("Claude SDK output", "turn", turn)
+		logger.Info("Claude CLI finished", "turn", turn, "has_error", err != nil)
 		if err != nil {
 			logger.Error("Claude SDK error", "turn", turn, "error", err)
 		} else if result.Result != nil {

--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -271,6 +271,7 @@ func runTask(
 		// Success — reset error tracking.
 		consecutiveErrors = 0
 		backoff = initialBackoff
+		logger.Info("processing successful result", "turn", turn, "result_len", len(result.Result.Result))
 
 		// Extract and persist task description updates from agent output.
 		if result.Result != nil {
@@ -343,6 +344,7 @@ func runTask(
 
 		// Check completion: NEXT_STATUS present means task is done.
 		nextStatusID := parseNextStatus(summary)
+		logger.Info("parsed directives", "turn", turn, "next_status", nextStatusID, "summary_len", len(summary))
 		if nextStatusID != "" {
 			// Log the NEXT_STATUS directive to timeline.
 			tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_DIRECTIVE, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
@@ -392,18 +394,25 @@ func runTask(
 			tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
 				fmt.Sprintf("Task completed with status transition (turn %d)", turn),
 				map[string]string{"next_status": nextStatusID})
+			logger.Info("reporting task result")
 			reportTaskResult(ctx, client, taskID, displaySummary, "")
+			logger.Info("reporting agent status IDLE")
 			reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_IDLE, "task completed")
 			// Run after hooks before transitioning status so that hooks
 			// still observe the current status and the transition happens
 			// only after all hooks complete.
+			logger.Info("running after hooks")
 			afterHooks()
+			logger.Info("after hooks completed")
 			// Launch AGENT.md harness in background goroutine if enabled.
 			maybeRunAgentMDHarness(ctx, metadata, taskID, displaySummary, workDir, tl, client)
+			logger.Info("calling handleStatusTransition", "next_status", nextStatusID)
 			if err := handleStatusTransition(ctx, taskClient, taskID, nextStatusID, metadata, tl); err != nil {
 				logger.Error("status transition failed", "error", err)
 				tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_WARN,
 					fmt.Sprintf("Status transition to %q failed: %v", nextStatusID, err), nil)
+			} else {
+				logger.Info("status transition succeeded", "next_status", nextStatusID)
 			}
 			return
 		}

--- a/cmd/taskguild-agent/toolhooks.go
+++ b/cmd/taskguild-agent/toolhooks.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 
 	claudeagent "github.com/kazz187/claude-agent-sdk-go"
@@ -38,8 +39,24 @@ func buildToolUseHooks(tl *taskLogger, taskID string, taskClient taskguildv1conn
 						}
 
 						// Save plan result when ExitPlanMode is called.
-						if input.ToolName == "ExitPlanMode" && planFilePath != "" && taskClient != nil {
-							savePlanResult(context.Background(), taskClient, taskID, planFilePath)
+						if input.ToolName == "ExitPlanMode" && taskClient != nil {
+							var planContent string
+							if input.ToolResponse != nil {
+								if s, ok := input.ToolResponse.(string); ok {
+									planContent = s
+								} else if b, err := json.Marshal(input.ToolResponse); err == nil {
+									planContent = string(b)
+								}
+							}
+							if planContent == "" && planFilePath != "" {
+								// Fallback: read from plan file if no tool response.
+								if content, err := os.ReadFile(planFilePath); err == nil {
+									planContent = string(content)
+								}
+							}
+							if planContent != "" {
+								savePlanResult(context.Background(), taskClient, taskID, planContent)
+							}
 						}
 
 						return claudeagent.HookOutput{}, nil


### PR DESCRIPTION
## Summary
- subscribe ループでセマフォ取得がタスク claim 後にブロッキングで行われており、セマフォ満杯時にタスクが ASSIGNED のまま実行されず、subscribe ループ全体が停止するデッドロックが発生していた
- セマフォ取得を claim 前に非ブロッキング (`select default`) に変更し、空きがなければ skip して他のエージェントに任せるように修正
- task goroutine に `recover()` を追加し、panic によるプロセスクラッシュを防止。`runTask` 内の各セットアップステージに INFO レベルのローカルログを追加し、どこで止まったか診断可能に

## Test plan
- [ ] セマフォ満杯時にタスクが skip され "at max capacity, skipping task" ログが出ることを確認
- [ ] 通常時（セマフォに空きあり）のタスク実行が問題なく動作すること
- [ ] `go build ./cmd/taskguild-agent/` が通ること
- [ ] タスク実行時に各ステージのINFOログ（runTask started, generating worktree name, executing hooks, starting Claude CLI 等）が出力されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)