### PR TITLE
feat: add stop/resume buttons for running tasks

### DIFF
--- a/cmd/taskguild-server/run.go
+++ b/cmd/taskguild-server/run.go
@@ -193,9 +193,9 @@ func runServer() {
 	// Setup servers
 	projectServer := project.NewServer(projectRepo)
 	workflowServer := workflow.NewServer(workflowRepo)
-	taskServer := task.NewServer(taskRepo, workflowRepo, bus, taskLogRepo, interactionRepo)
-	interactionServer := interaction.NewServer(interactionRepo, taskRepo, bus)
 	agentManagerServer := agentmanager.NewServer(agentManagerRegistry, taskRepo, workflowRepo, agentRepo, interactionRepo, projectRepo, skillRepo, scriptRepo, taskLogRepo, permissionRepo, scpRepo, bus, scriptBroker)
+	taskServer := task.NewServer(taskRepo, workflowRepo, bus, agentManagerServer, agentManagerServer, taskLogRepo, interactionRepo)
+	interactionServer := interaction.NewServer(interactionRepo, taskRepo, bus)
 	agentChangeNotifier := &agentChangeNotifier{
 		registry:    agentManagerRegistry,
 		projectRepo: projectRepo,

--- a/frontend/src/components/organisms/TaskBoard.tsx
+++ b/frontend/src/components/organisms/TaskBoard.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, useState, type RefObject } from 'react'
 import { createPortal } from 'react-dom'
 import { useQuery, useMutation } from '@connectrpc/connect-query'
-import { listTasks, updateTaskStatus } from '@taskguild/proto/taskguild/v1/task-TaskService_connectquery.ts'
+import { listTasks, updateTaskStatus, stopTask, resumeTask } from '@taskguild/proto/taskguild/v1/task-TaskService_connectquery.ts'
 import { listAgents } from '@taskguild/proto/taskguild/v1/agent-AgentService_connectquery.ts'
 import type { Workflow, WorkflowStatus } from '@taskguild/proto/taskguild/v1/workflow_pb.ts'
 import type { Task } from '@taskguild/proto/taskguild/v1/task_pb.ts'
@@ -75,6 +75,8 @@ export function TaskBoard({ projectId, workflow, headerActionsRef }: TaskBoardPr
   const [showCleanDialog, setShowCleanDialog] = useState(false)
 
   const statusMut = useMutation(updateTaskStatus)
+  const stopMut = useMutation(stopTask)
+  const resumeMut = useMutation(resumeTask)
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -373,6 +375,20 @@ export function TaskBoard({ projectId, workflow, headerActionsRef }: TaskBoardPr
     [tasks],
   )
 
+  const handleStopTask = useCallback(
+    (taskId: string) => {
+      stopMut.mutate({ id: taskId }, { onSuccess: () => refetch() })
+    },
+    [stopMut, refetch],
+  )
+
+  const handleResumeTask = useCallback(
+    (taskId: string) => {
+      resumeMut.mutate({ id: taskId }, { onSuccess: () => refetch() })
+    },
+    [resumeMut, refetch],
+  )
+
   /** Navigate to a related task (open its detail modal) */
   const handleNavigateTask = useCallback((taskId: string) => {
     setEditingTaskId(taskId)
@@ -425,6 +441,8 @@ export function TaskBoard({ projectId, workflow, headerActionsRef }: TaskBoardPr
                 defaultUseWorktree={workflow.defaultUseWorktree}
                 childTasksByParentId={childTasksByParentId}
                 parentTaskById={parentTaskById}
+                onStop={handleStopTask}
+                onResume={handleResumeTask}
               />
             ))}
           </div>
@@ -516,6 +534,8 @@ function StatusColumn({
   defaultUseWorktree,
   childTasksByParentId,
   parentTaskById,
+  onStop,
+  onResume,
 }: {
   projectId: string
   workflowId: string
@@ -533,6 +553,8 @@ function StatusColumn({
   defaultUseWorktree?: boolean
   childTasksByParentId: Map<string, { id: string; title: string; statusId: string }[]>
   parentTaskById: Map<string, { id: string; title: string }>
+  onStop: (taskId: string) => void
+  onResume: (taskId: string) => void
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: status.id })
   const [showCreateModal, setShowCreateModal] = useState(false)
@@ -604,6 +626,9 @@ function StatusColumn({
               onTransition={onTransition}
               childCount={childTasksByParentId.get(task.id)?.length}
               parentTaskTitle={parentTaskById.get(task.id)?.title}
+              onStop={onStop}
+              onResume={onResume}
+              statusHasAgent={!!status.agentId}
             />
           ))}
           {tasks.length === 0 && (

--- a/frontend/src/components/organisms/TaskCard.tsx
+++ b/frontend/src/components/organisms/TaskCard.tsx
@@ -3,7 +3,7 @@ import { useDraggable } from '@dnd-kit/core'
 import { useNavigate } from '@tanstack/react-router'
 import type { Task } from '@taskguild/proto/taskguild/v1/task_pb.ts'
 import { TaskAssignmentStatus } from '@taskguild/proto/taskguild/v1/task_pb.ts'
-import { Bot, Clock, GitBranch, Loader, Pencil, ArrowRight, AlertTriangle, CopyPlus, ArrowUpRight, Layers } from 'lucide-react'
+import { Bot, Clock, GitBranch, Loader, Pencil, ArrowRight, AlertTriangle, CopyPlus, ArrowUpRight, Layers, Square, Play } from 'lucide-react'
 import { shortId } from '@/lib/id'
 import { Badge } from '../atoms/index.ts'
 import { DropdownMenu } from '../molecules/index.ts'
@@ -27,9 +27,15 @@ interface TaskCardProps {
   childCount?: number
   /** Parent task title (when this task is a child) */
   parentTaskTitle?: string
+  /** Callback to stop a running task */
+  onStop?: (taskId: string) => void
+  /** Callback to resume a stopped task */
+  onResume?: (taskId: string) => void
+  /** Whether the current status has an agent configured (for resume button) */
+  statusHasAgent?: boolean
 }
 
-export function TaskCard({ task, onEdit, onCreateChild, isDragOverlay, transitionTargets, onTransition, childCount, parentTaskTitle }: TaskCardProps) {
+export function TaskCard({ task, onEdit, onCreateChild, isDragOverlay, transitionTargets, onTransition, childCount, parentTaskTitle, onStop, onResume, statusHasAgent }: TaskCardProps) {
   const navigate = useNavigate()
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: task.id,
@@ -65,6 +71,34 @@ export function TaskCard({ task, onEdit, onCreateChild, isDragOverlay, transitio
           {task.title}
         </h4>
         <div className="flex items-center gap-1 shrink-0">
+          {/* Stop button (visible when task is running) */}
+          {isAgentRunning && onStop && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onStop(task.id)
+              }}
+              onPointerDown={(e) => e.stopPropagation()}
+              className="opacity-100 md:opacity-0 md:group-hover:opacity-100 shrink-0 p-1 text-red-400 hover:text-red-300 hover:bg-red-500/10 rounded transition-all"
+              title="Stop task"
+            >
+              <Square className="w-3.5 h-3.5" />
+            </button>
+          )}
+          {/* Resume button (visible when task is stopped and status has agent) */}
+          {!isAgentRunning && task.assignmentStatus === TaskAssignmentStatus.UNASSIGNED && statusHasAgent && onResume && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onResume(task.id)
+              }}
+              onPointerDown={(e) => e.stopPropagation()}
+              className="opacity-100 md:opacity-0 md:group-hover:opacity-100 shrink-0 p-1 text-green-400 hover:text-green-300 hover:bg-green-500/10 rounded transition-all"
+              title="Resume task"
+            >
+              <Play className="w-3.5 h-3.5" />
+            </button>
+          )}
           {/* Transition button (visible on mobile when transitions available) */}
           {hasTransitions && onTransition && (
             <>

--- a/frontend/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/frontend/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { useQuery, useMutation } from '@connectrpc/connect-query'
-import { getTask, listTasks, updateTaskStatus } from '@taskguild/proto/taskguild/v1/task-TaskService_connectquery.ts'
+import { getTask, listTasks, updateTaskStatus, stopTask, resumeTask } from '@taskguild/proto/taskguild/v1/task-TaskService_connectquery.ts'
 import { getProject } from '@taskguild/proto/taskguild/v1/project-ProjectService_connectquery.ts'
 import { listWorkflows } from '@taskguild/proto/taskguild/v1/workflow-WorkflowService_connectquery.ts'
 import { listInteractions, respondToInteraction, expireInteraction, sendMessage } from '@taskguild/proto/taskguild/v1/interaction-InteractionService_connectquery.ts'
@@ -34,6 +34,8 @@ import {
   Layers,
   Loader,
   Pencil,
+  Play,
+  Square,
 } from 'lucide-react'
 
 export const Route = createFileRoute('/projects/$projectId/tasks/$taskId')({
@@ -57,6 +59,8 @@ function TaskDetailPage() {
   const respondMut = useMutation(respondToInteraction)
   const expireMut = useMutation(expireInteraction)
   const sendMut = useMutation(sendMessage)
+  const stopMut = useMutation(stopTask)
+  const resumeMut = useMutation(resumeTask)
 
   const task = taskData?.task
   const project = projectData?.project
@@ -106,6 +110,9 @@ function TaskDetailPage() {
   // Force-move is only blocked when agent is actively running (assigned).
   // Pending tasks (agent not yet started) are allowed to be force-moved.
   const isForceMoveBlocked = task?.assignmentStatus === TaskAssignmentStatus.ASSIGNED
+
+  // Check if current status has an agent configured (for resume button visibility).
+  const currentStatusHasAgent = !!(currentStatus?.agentId)
 
   // Force-transition confirmation dialog state
   const [forceTransitionTarget, setForceTransitionTarget] = useState<{ id: string; name: string } | null>(null)
@@ -232,6 +239,16 @@ function TaskDetailPage() {
     )
   }, [expireMut, refetchInteractions])
 
+  const handleStopTask = () => {
+    if (!task) return
+    stopMut.mutate({ id: task.id }, { onSuccess: () => refetchTask() })
+  }
+
+  const handleResumeTask = () => {
+    if (!task) return
+    resumeMut.mutate({ id: task.id }, { onSuccess: () => refetchTask() })
+  }
+
   const handleSendMessage = (message: string) => {
     sendMut.mutate(
       { taskId, message },
@@ -296,6 +313,27 @@ function TaskDetailPage() {
                 <Clock className="w-3 h-3" />
                 Unassigned
               </span>
+            )}
+
+            {task.assignmentStatus === TaskAssignmentStatus.ASSIGNED && (
+              <button
+                onClick={handleStopTask}
+                disabled={stopMut.isPending}
+                className="flex items-center gap-1 px-3 py-1 text-xs bg-red-500/10 border border-red-500/30 rounded-lg text-red-400 hover:bg-red-500/20 hover:border-red-500/50 hover:text-red-300 transition-colors disabled:opacity-50"
+              >
+                <Square className="w-3 h-3" />
+                Stop
+              </button>
+            )}
+            {task.assignmentStatus === TaskAssignmentStatus.UNASSIGNED && currentStatusHasAgent && (
+              <button
+                onClick={handleResumeTask}
+                disabled={resumeMut.isPending}
+                className="flex items-center gap-1 px-3 py-1 text-xs bg-green-500/10 border border-green-500/30 rounded-lg text-green-400 hover:bg-green-500/20 hover:border-green-500/50 hover:text-green-300 transition-colors disabled:opacity-50"
+              >
+                <Play className="w-3 h-3" />
+                Resume
+              </button>
             )}
 
             {allowedTransitions.map((toId) => {

--- a/internal/agentmanager/task_handler.go
+++ b/internal/agentmanager/task_handler.go
@@ -3,6 +3,7 @@ package agentmanager
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"strconv"
 	"time"
@@ -324,6 +325,28 @@ func (s *Server) ReportTaskResult(ctx context.Context, req *connect.Request[task
 	}
 
 	if req.Msg.ErrorMessage != "" {
+		// If stopped by user, skip retry and go straight to UNASSIGNED.
+		if t.Metadata["_stopped_by_user"] == "true" {
+			slog.Info("task stopped by user, skipping retry",
+				"task_id", t.ID,
+			)
+			delete(t.Metadata, "_stopped_by_user")
+			delete(t.Metadata, retryMetadataKey)
+			t.AssignmentStatus = task.AssignmentStatusUnassigned
+
+			if err := s.taskRepo.Update(ctx, t); err != nil {
+				return nil, err
+			}
+
+			eventMeta["reason"] = "stopped_by_user"
+			s.eventBus.PublishNew(
+				taskguildv1.EventType_EVENT_TYPE_TASK_UPDATED,
+				t.ID, "", eventMeta,
+			)
+
+			return connect.NewResponse(&taskguildv1.ReportTaskResultResponse{}), nil
+		}
+
 		// Task failed — check if we should retry.
 		retryCount := 0
 		if rc, ok := t.Metadata[retryMetadataKey]; ok {
@@ -751,4 +774,66 @@ func (s *Server) ClaimTask(ctx context.Context, req *connect.Request[taskguildv1
 		AgentConfigId: agentConfigID,
 		Metadata:      enrichedMetadata,
 	}), nil
+}
+
+// RequestTaskStop sends a CancelTaskCommand to the agent running the given task.
+func (s *Server) RequestTaskStop(taskID string, assignedAgentID string) error {
+	sent := s.registry.SendCommand(assignedAgentID, &taskguildv1.AgentCommand{
+		Command: &taskguildv1.AgentCommand_CancelTask{
+			CancelTask: &taskguildv1.CancelTaskCommand{
+				TaskId: taskID,
+				Reason: "stopped by user",
+			},
+		},
+	})
+	if !sent {
+		return fmt.Errorf("agent %s not connected", assignedAgentID)
+	}
+	slog.Info("task stop command sent",
+		"task_id", taskID,
+		"agent_id", assignedAgentID,
+	)
+	return nil
+}
+
+// RequestTaskResume re-triggers orchestration for a stopped task by setting it
+// to PENDING and broadcasting a TaskAvailableCommand.
+func (s *Server) RequestTaskResume(ctx context.Context, t *task.Task) error {
+	t.AssignmentStatus = task.AssignmentStatusPending
+	t.UpdatedAt = time.Now()
+	if err := s.taskRepo.Update(ctx, t); err != nil {
+		return err
+	}
+
+	wf, err := s.workflowRepo.Get(ctx, t.WorkflowID)
+	if err != nil {
+		return err
+	}
+	agentConfigID := wf.FindAgentIDForStatus(t.StatusID)
+	if agentConfigID == "" {
+		return fmt.Errorf("no agent configured for status %s", t.StatusID)
+	}
+
+	var projectName string
+	if p, pErr := s.projectRepo.Get(ctx, t.ProjectID); pErr == nil {
+		projectName = p.Name
+	}
+
+	s.registry.BroadcastCommandToProject(projectName, &taskguildv1.AgentCommand{
+		Command: &taskguildv1.AgentCommand_TaskAvailable{
+			TaskAvailable: &taskguildv1.TaskAvailableCommand{
+				TaskId:        t.ID,
+				AgentConfigId: agentConfigID,
+				Title:         t.Title,
+				Metadata:      t.Metadata,
+			},
+		},
+	})
+
+	slog.Info("task resume broadcast sent",
+		"task_id", t.ID,
+		"agent_config_id", agentConfigID,
+		"project_name", projectName,
+	)
+	return nil
 }

--- a/internal/task/server.go
+++ b/internal/task/server.go
@@ -25,18 +25,32 @@ type CascadeDeleter interface {
 	DeleteByTaskID(ctx context.Context, taskID string) (int, error)
 }
 
-type Server struct {
-	repo             Repository
-	workflowRepo     workflow.Repository
-	eventBus         *eventbus.Bus
-	cascadeDeleters  []CascadeDeleter
+// TaskStopper sends a cancel command to the agent running a task.
+type TaskStopper interface {
+	RequestTaskStop(taskID string, assignedAgentID string) error
 }
 
-func NewServer(repo Repository, workflowRepo workflow.Repository, eventBus *eventbus.Bus, cascadeDeleters ...CascadeDeleter) *Server {
+// TaskResumer re-triggers orchestration for a stopped task.
+type TaskResumer interface {
+	RequestTaskResume(ctx context.Context, t *Task) error
+}
+
+type Server struct {
+	repo            Repository
+	workflowRepo    workflow.Repository
+	eventBus        *eventbus.Bus
+	cascadeDeleters []CascadeDeleter
+	stopper         TaskStopper
+	resumer         TaskResumer
+}
+
+func NewServer(repo Repository, workflowRepo workflow.Repository, eventBus *eventbus.Bus, stopper TaskStopper, resumer TaskResumer, cascadeDeleters ...CascadeDeleter) *Server {
 	return &Server{
 		repo:            repo,
 		workflowRepo:    workflowRepo,
 		eventBus:        eventBus,
+		stopper:         stopper,
+		resumer:         resumer,
 		cascadeDeleters: cascadeDeleters,
 	}
 }
@@ -310,6 +324,115 @@ func (s *Server) UpdateTaskStatus(ctx context.Context, req *connect.Request[task
 	)
 
 	return connect.NewResponse(&taskguildv1.UpdateTaskStatusResponse{
+		Task: toProto(t),
+	}), nil
+}
+
+func (s *Server) StopTask(ctx context.Context, req *connect.Request[taskguildv1.StopTaskRequest]) (*connect.Response[taskguildv1.StopTaskResponse], error) {
+	t, err := s.repo.Get(ctx, req.Msg.Id)
+	if err != nil {
+		return nil, err
+	}
+
+	if t.AssignmentStatus != AssignmentStatusAssigned || t.AssignedAgentID == "" {
+		return nil, cerr.NewError(
+			cerr.FailedPrecondition,
+			"task is not currently running (not assigned to an agent)",
+			nil,
+		).ConnectError()
+	}
+
+	// Mark the task so ReportTaskResult skips auto-retry.
+	if t.Metadata == nil {
+		t.Metadata = make(map[string]string)
+	}
+	t.Metadata["_stopped_by_user"] = "true"
+	t.UpdatedAt = time.Now()
+	if err := s.repo.Update(ctx, t); err != nil {
+		return nil, err
+	}
+
+	// Send cancel command to the agent.
+	if err := s.stopper.RequestTaskStop(t.ID, t.AssignedAgentID); err != nil {
+		slog.Warn("failed to send stop command to agent",
+			"task_id", t.ID,
+			"agent_id", t.AssignedAgentID,
+			"error", err,
+		)
+	}
+
+	s.eventBus.PublishNew(
+		taskguildv1.EventType_EVENT_TYPE_TASK_UPDATED,
+		t.ID,
+		"",
+		map[string]string{
+			"project_id":  t.ProjectID,
+			"workflow_id": t.WorkflowID,
+			"reason":      "stopped_by_user",
+		},
+	)
+
+	return connect.NewResponse(&taskguildv1.StopTaskResponse{
+		Task: toProto(t),
+	}), nil
+}
+
+func (s *Server) ResumeTask(ctx context.Context, req *connect.Request[taskguildv1.ResumeTaskRequest]) (*connect.Response[taskguildv1.ResumeTaskResponse], error) {
+	t, err := s.repo.Get(ctx, req.Msg.Id)
+	if err != nil {
+		return nil, err
+	}
+
+	if t.AssignmentStatus != AssignmentStatusUnassigned {
+		return nil, cerr.NewError(
+			cerr.FailedPrecondition,
+			fmt.Sprintf("task cannot be resumed (assignment status: %s)", t.AssignmentStatus),
+			nil,
+		).ConnectError()
+	}
+
+	// Verify the current status has an agent configured.
+	wf, err := s.workflowRepo.Get(ctx, t.WorkflowID)
+	if err != nil {
+		return nil, err
+	}
+	if !statusHasAgent(wf, t.StatusID) {
+		return nil, cerr.NewError(
+			cerr.FailedPrecondition,
+			"current status has no agent configured; cannot resume",
+			nil,
+		).ConnectError()
+	}
+
+	// Clear stop/retry metadata for a fresh start.
+	if t.Metadata != nil {
+		delete(t.Metadata, "_stopped_by_user")
+		delete(t.Metadata, "_retry_count")
+		delete(t.Metadata, "result_error")
+	}
+
+	if err := s.resumer.RequestTaskResume(ctx, t); err != nil {
+		return nil, cerr.NewError(cerr.Internal, fmt.Sprintf("failed to resume task: %v", err), nil).ConnectError()
+	}
+
+	// Re-read the task after resume (it updates assignment status).
+	t, err = s.repo.Get(ctx, req.Msg.Id)
+	if err != nil {
+		return nil, err
+	}
+
+	s.eventBus.PublishNew(
+		taskguildv1.EventType_EVENT_TYPE_TASK_UPDATED,
+		t.ID,
+		"",
+		map[string]string{
+			"project_id":  t.ProjectID,
+			"workflow_id": t.WorkflowID,
+			"reason":      "resumed_by_user",
+		},
+	)
+
+	return connect.NewResponse(&taskguildv1.ResumeTaskResponse{
 		Task: toProto(t),
 	}), nil
 }

--- a/proto/gen/go/taskguild/v1/task.pb.go
+++ b/proto/gen/go/taskguild/v1/task.pb.go
@@ -870,6 +870,182 @@ func (x *UpdateTaskStatusResponse) GetTask() *Task {
 	return nil
 }
 
+type StopTaskRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StopTaskRequest) Reset() {
+	*x = StopTaskRequest{}
+	mi := &file_taskguild_v1_task_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StopTaskRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StopTaskRequest) ProtoMessage() {}
+
+func (x *StopTaskRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_taskguild_v1_task_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StopTaskRequest.ProtoReflect.Descriptor instead.
+func (*StopTaskRequest) Descriptor() ([]byte, []int) {
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *StopTaskRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type StopTaskResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Task          *Task                  `protobuf:"bytes,1,opt,name=task,proto3" json:"task,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StopTaskResponse) Reset() {
+	*x = StopTaskResponse{}
+	mi := &file_taskguild_v1_task_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StopTaskResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StopTaskResponse) ProtoMessage() {}
+
+func (x *StopTaskResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_taskguild_v1_task_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StopTaskResponse.ProtoReflect.Descriptor instead.
+func (*StopTaskResponse) Descriptor() ([]byte, []int) {
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *StopTaskResponse) GetTask() *Task {
+	if x != nil {
+		return x.Task
+	}
+	return nil
+}
+
+type ResumeTaskRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResumeTaskRequest) Reset() {
+	*x = ResumeTaskRequest{}
+	mi := &file_taskguild_v1_task_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResumeTaskRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResumeTaskRequest) ProtoMessage() {}
+
+func (x *ResumeTaskRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_taskguild_v1_task_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResumeTaskRequest.ProtoReflect.Descriptor instead.
+func (*ResumeTaskRequest) Descriptor() ([]byte, []int) {
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *ResumeTaskRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type ResumeTaskResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Task          *Task                  `protobuf:"bytes,1,opt,name=task,proto3" json:"task,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResumeTaskResponse) Reset() {
+	*x = ResumeTaskResponse{}
+	mi := &file_taskguild_v1_task_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResumeTaskResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResumeTaskResponse) ProtoMessage() {}
+
+func (x *ResumeTaskResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_taskguild_v1_task_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResumeTaskResponse.ProtoReflect.Descriptor instead.
+func (*ResumeTaskResponse) Descriptor() ([]byte, []int) {
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *ResumeTaskResponse) GetTask() *Task {
+	if x != nil {
+		return x.Task
+	}
+	return nil
+}
+
 type ArchiveTaskRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -879,7 +1055,7 @@ type ArchiveTaskRequest struct {
 
 func (x *ArchiveTaskRequest) Reset() {
 	*x = ArchiveTaskRequest{}
-	mi := &file_taskguild_v1_task_proto_msgTypes[13]
+	mi := &file_taskguild_v1_task_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -891,7 +1067,7 @@ func (x *ArchiveTaskRequest) String() string {
 func (*ArchiveTaskRequest) ProtoMessage() {}
 
 func (x *ArchiveTaskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_taskguild_v1_task_proto_msgTypes[13]
+	mi := &file_taskguild_v1_task_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -904,7 +1080,7 @@ func (x *ArchiveTaskRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArchiveTaskRequest.ProtoReflect.Descriptor instead.
 func (*ArchiveTaskRequest) Descriptor() ([]byte, []int) {
-	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{13}
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ArchiveTaskRequest) GetId() string {
@@ -923,7 +1099,7 @@ type ArchiveTaskResponse struct {
 
 func (x *ArchiveTaskResponse) Reset() {
 	*x = ArchiveTaskResponse{}
-	mi := &file_taskguild_v1_task_proto_msgTypes[14]
+	mi := &file_taskguild_v1_task_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -935,7 +1111,7 @@ func (x *ArchiveTaskResponse) String() string {
 func (*ArchiveTaskResponse) ProtoMessage() {}
 
 func (x *ArchiveTaskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_taskguild_v1_task_proto_msgTypes[14]
+	mi := &file_taskguild_v1_task_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -948,7 +1124,7 @@ func (x *ArchiveTaskResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArchiveTaskResponse.ProtoReflect.Descriptor instead.
 func (*ArchiveTaskResponse) Descriptor() ([]byte, []int) {
-	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{14}
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ArchiveTaskResponse) GetTask() *Task {
@@ -968,7 +1144,7 @@ type ArchiveTerminalTasksRequest struct {
 
 func (x *ArchiveTerminalTasksRequest) Reset() {
 	*x = ArchiveTerminalTasksRequest{}
-	mi := &file_taskguild_v1_task_proto_msgTypes[15]
+	mi := &file_taskguild_v1_task_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -980,7 +1156,7 @@ func (x *ArchiveTerminalTasksRequest) String() string {
 func (*ArchiveTerminalTasksRequest) ProtoMessage() {}
 
 func (x *ArchiveTerminalTasksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_taskguild_v1_task_proto_msgTypes[15]
+	mi := &file_taskguild_v1_task_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -993,7 +1169,7 @@ func (x *ArchiveTerminalTasksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArchiveTerminalTasksRequest.ProtoReflect.Descriptor instead.
 func (*ArchiveTerminalTasksRequest) Descriptor() ([]byte, []int) {
-	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{15}
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ArchiveTerminalTasksRequest) GetProjectId() string {
@@ -1020,7 +1196,7 @@ type ArchiveTerminalTasksResponse struct {
 
 func (x *ArchiveTerminalTasksResponse) Reset() {
 	*x = ArchiveTerminalTasksResponse{}
-	mi := &file_taskguild_v1_task_proto_msgTypes[16]
+	mi := &file_taskguild_v1_task_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1032,7 +1208,7 @@ func (x *ArchiveTerminalTasksResponse) String() string {
 func (*ArchiveTerminalTasksResponse) ProtoMessage() {}
 
 func (x *ArchiveTerminalTasksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_taskguild_v1_task_proto_msgTypes[16]
+	mi := &file_taskguild_v1_task_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1045,7 +1221,7 @@ func (x *ArchiveTerminalTasksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArchiveTerminalTasksResponse.ProtoReflect.Descriptor instead.
 func (*ArchiveTerminalTasksResponse) Descriptor() ([]byte, []int) {
-	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{16}
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ArchiveTerminalTasksResponse) GetArchivedTasks() []*Task {
@@ -1071,7 +1247,7 @@ type UnarchiveTaskRequest struct {
 
 func (x *UnarchiveTaskRequest) Reset() {
 	*x = UnarchiveTaskRequest{}
-	mi := &file_taskguild_v1_task_proto_msgTypes[17]
+	mi := &file_taskguild_v1_task_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1083,7 +1259,7 @@ func (x *UnarchiveTaskRequest) String() string {
 func (*UnarchiveTaskRequest) ProtoMessage() {}
 
 func (x *UnarchiveTaskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_taskguild_v1_task_proto_msgTypes[17]
+	mi := &file_taskguild_v1_task_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1096,7 +1272,7 @@ func (x *UnarchiveTaskRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnarchiveTaskRequest.ProtoReflect.Descriptor instead.
 func (*UnarchiveTaskRequest) Descriptor() ([]byte, []int) {
-	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{17}
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *UnarchiveTaskRequest) GetId() string {
@@ -1115,7 +1291,7 @@ type UnarchiveTaskResponse struct {
 
 func (x *UnarchiveTaskResponse) Reset() {
 	*x = UnarchiveTaskResponse{}
-	mi := &file_taskguild_v1_task_proto_msgTypes[18]
+	mi := &file_taskguild_v1_task_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1127,7 +1303,7 @@ func (x *UnarchiveTaskResponse) String() string {
 func (*UnarchiveTaskResponse) ProtoMessage() {}
 
 func (x *UnarchiveTaskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_taskguild_v1_task_proto_msgTypes[18]
+	mi := &file_taskguild_v1_task_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1140,7 +1316,7 @@ func (x *UnarchiveTaskResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnarchiveTaskResponse.ProtoReflect.Descriptor instead.
 func (*UnarchiveTaskResponse) Descriptor() ([]byte, []int) {
-	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{18}
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *UnarchiveTaskResponse) GetTask() *Task {
@@ -1161,7 +1337,7 @@ type ListArchivedTasksRequest struct {
 
 func (x *ListArchivedTasksRequest) Reset() {
 	*x = ListArchivedTasksRequest{}
-	mi := &file_taskguild_v1_task_proto_msgTypes[19]
+	mi := &file_taskguild_v1_task_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1173,7 +1349,7 @@ func (x *ListArchivedTasksRequest) String() string {
 func (*ListArchivedTasksRequest) ProtoMessage() {}
 
 func (x *ListArchivedTasksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_taskguild_v1_task_proto_msgTypes[19]
+	mi := &file_taskguild_v1_task_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1186,7 +1362,7 @@ func (x *ListArchivedTasksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListArchivedTasksRequest.ProtoReflect.Descriptor instead.
 func (*ListArchivedTasksRequest) Descriptor() ([]byte, []int) {
-	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{19}
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ListArchivedTasksRequest) GetProjectId() string {
@@ -1220,7 +1396,7 @@ type ListArchivedTasksResponse struct {
 
 func (x *ListArchivedTasksResponse) Reset() {
 	*x = ListArchivedTasksResponse{}
-	mi := &file_taskguild_v1_task_proto_msgTypes[20]
+	mi := &file_taskguild_v1_task_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1232,7 +1408,7 @@ func (x *ListArchivedTasksResponse) String() string {
 func (*ListArchivedTasksResponse) ProtoMessage() {}
 
 func (x *ListArchivedTasksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_taskguild_v1_task_proto_msgTypes[20]
+	mi := &file_taskguild_v1_task_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1245,7 +1421,7 @@ func (x *ListArchivedTasksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListArchivedTasksResponse.ProtoReflect.Descriptor instead.
 func (*ListArchivedTasksResponse) Descriptor() ([]byte, []int) {
-	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{20}
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ListArchivedTasksResponse) GetTasks() []*Task {
@@ -1343,6 +1519,14 @@ const file_taskguild_v1_task_proto_rawDesc = "" +
 	"\tstatus_id\x18\x02 \x01(\tR\bstatusId\x12\x14\n" +
 	"\x05force\x18\x03 \x01(\bR\x05force\"B\n" +
 	"\x18UpdateTaskStatusResponse\x12&\n" +
+	"\x04task\x18\x01 \x01(\v2\x12.taskguild.v1.TaskR\x04task\"!\n" +
+	"\x0fStopTaskRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\":\n" +
+	"\x10StopTaskResponse\x12&\n" +
+	"\x04task\x18\x01 \x01(\v2\x12.taskguild.v1.TaskR\x04task\"#\n" +
+	"\x11ResumeTaskRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"<\n" +
+	"\x12ResumeTaskResponse\x12&\n" +
 	"\x04task\x18\x01 \x01(\v2\x12.taskguild.v1.TaskR\x04task\"$\n" +
 	"\x12ArchiveTaskRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"=\n" +
@@ -1377,7 +1561,7 @@ const file_taskguild_v1_task_proto_rawDesc = "" +
 	"\"TASK_ASSIGNMENT_STATUS_UNSPECIFIED\x10\x00\x12%\n" +
 	"!TASK_ASSIGNMENT_STATUS_UNASSIGNED\x10\x01\x12\"\n" +
 	"\x1eTASK_ASSIGNMENT_STATUS_PENDING\x10\x02\x12#\n" +
-	"\x1fTASK_ASSIGNMENT_STATUS_ASSIGNED\x10\x032\xfc\x06\n" +
+	"\x1fTASK_ASSIGNMENT_STATUS_ASSIGNED\x10\x032\x98\b\n" +
 	"\vTaskService\x12O\n" +
 	"\n" +
 	"CreateTask\x12\x1f.taskguild.v1.CreateTaskRequest\x1a .taskguild.v1.CreateTaskResponse\x12F\n" +
@@ -1387,7 +1571,10 @@ const file_taskguild_v1_task_proto_rawDesc = "" +
 	"UpdateTask\x12\x1f.taskguild.v1.UpdateTaskRequest\x1a .taskguild.v1.UpdateTaskResponse\x12O\n" +
 	"\n" +
 	"DeleteTask\x12\x1f.taskguild.v1.DeleteTaskRequest\x1a .taskguild.v1.DeleteTaskResponse\x12a\n" +
-	"\x10UpdateTaskStatus\x12%.taskguild.v1.UpdateTaskStatusRequest\x1a&.taskguild.v1.UpdateTaskStatusResponse\x12R\n" +
+	"\x10UpdateTaskStatus\x12%.taskguild.v1.UpdateTaskStatusRequest\x1a&.taskguild.v1.UpdateTaskStatusResponse\x12I\n" +
+	"\bStopTask\x12\x1d.taskguild.v1.StopTaskRequest\x1a\x1e.taskguild.v1.StopTaskResponse\x12O\n" +
+	"\n" +
+	"ResumeTask\x12\x1f.taskguild.v1.ResumeTaskRequest\x1a .taskguild.v1.ResumeTaskResponse\x12R\n" +
 	"\vArchiveTask\x12 .taskguild.v1.ArchiveTaskRequest\x1a!.taskguild.v1.ArchiveTaskResponse\x12m\n" +
 	"\x14ArchiveTerminalTasks\x12).taskguild.v1.ArchiveTerminalTasksRequest\x1a*.taskguild.v1.ArchiveTerminalTasksResponse\x12X\n" +
 	"\rUnarchiveTask\x12\".taskguild.v1.UnarchiveTaskRequest\x1a#.taskguild.v1.UnarchiveTaskResponse\x12d\n" +
@@ -1407,7 +1594,7 @@ func file_taskguild_v1_task_proto_rawDescGZIP() []byte {
 }
 
 var file_taskguild_v1_task_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_taskguild_v1_task_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_taskguild_v1_task_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
 var file_taskguild_v1_task_proto_goTypes = []any{
 	(TaskAssignmentStatus)(0),            // 0: taskguild.v1.TaskAssignmentStatus
 	(*Task)(nil),                         // 1: taskguild.v1.Task
@@ -1423,67 +1610,77 @@ var file_taskguild_v1_task_proto_goTypes = []any{
 	(*DeleteTaskResponse)(nil),           // 11: taskguild.v1.DeleteTaskResponse
 	(*UpdateTaskStatusRequest)(nil),      // 12: taskguild.v1.UpdateTaskStatusRequest
 	(*UpdateTaskStatusResponse)(nil),     // 13: taskguild.v1.UpdateTaskStatusResponse
-	(*ArchiveTaskRequest)(nil),           // 14: taskguild.v1.ArchiveTaskRequest
-	(*ArchiveTaskResponse)(nil),          // 15: taskguild.v1.ArchiveTaskResponse
-	(*ArchiveTerminalTasksRequest)(nil),  // 16: taskguild.v1.ArchiveTerminalTasksRequest
-	(*ArchiveTerminalTasksResponse)(nil), // 17: taskguild.v1.ArchiveTerminalTasksResponse
-	(*UnarchiveTaskRequest)(nil),         // 18: taskguild.v1.UnarchiveTaskRequest
-	(*UnarchiveTaskResponse)(nil),        // 19: taskguild.v1.UnarchiveTaskResponse
-	(*ListArchivedTasksRequest)(nil),     // 20: taskguild.v1.ListArchivedTasksRequest
-	(*ListArchivedTasksResponse)(nil),    // 21: taskguild.v1.ListArchivedTasksResponse
-	nil,                                  // 22: taskguild.v1.Task.MetadataEntry
-	nil,                                  // 23: taskguild.v1.CreateTaskRequest.MetadataEntry
-	nil,                                  // 24: taskguild.v1.UpdateTaskRequest.MetadataEntry
-	(*timestamppb.Timestamp)(nil),        // 25: google.protobuf.Timestamp
-	(*PaginationRequest)(nil),            // 26: taskguild.v1.PaginationRequest
-	(*PaginationResponse)(nil),           // 27: taskguild.v1.PaginationResponse
+	(*StopTaskRequest)(nil),              // 14: taskguild.v1.StopTaskRequest
+	(*StopTaskResponse)(nil),             // 15: taskguild.v1.StopTaskResponse
+	(*ResumeTaskRequest)(nil),            // 16: taskguild.v1.ResumeTaskRequest
+	(*ResumeTaskResponse)(nil),           // 17: taskguild.v1.ResumeTaskResponse
+	(*ArchiveTaskRequest)(nil),           // 18: taskguild.v1.ArchiveTaskRequest
+	(*ArchiveTaskResponse)(nil),          // 19: taskguild.v1.ArchiveTaskResponse
+	(*ArchiveTerminalTasksRequest)(nil),  // 20: taskguild.v1.ArchiveTerminalTasksRequest
+	(*ArchiveTerminalTasksResponse)(nil), // 21: taskguild.v1.ArchiveTerminalTasksResponse
+	(*UnarchiveTaskRequest)(nil),         // 22: taskguild.v1.UnarchiveTaskRequest
+	(*UnarchiveTaskResponse)(nil),        // 23: taskguild.v1.UnarchiveTaskResponse
+	(*ListArchivedTasksRequest)(nil),     // 24: taskguild.v1.ListArchivedTasksRequest
+	(*ListArchivedTasksResponse)(nil),    // 25: taskguild.v1.ListArchivedTasksResponse
+	nil,                                  // 26: taskguild.v1.Task.MetadataEntry
+	nil,                                  // 27: taskguild.v1.CreateTaskRequest.MetadataEntry
+	nil,                                  // 28: taskguild.v1.UpdateTaskRequest.MetadataEntry
+	(*timestamppb.Timestamp)(nil),        // 29: google.protobuf.Timestamp
+	(*PaginationRequest)(nil),            // 30: taskguild.v1.PaginationRequest
+	(*PaginationResponse)(nil),           // 31: taskguild.v1.PaginationResponse
 }
 var file_taskguild_v1_task_proto_depIdxs = []int32{
 	0,  // 0: taskguild.v1.Task.assignment_status:type_name -> taskguild.v1.TaskAssignmentStatus
-	22, // 1: taskguild.v1.Task.metadata:type_name -> taskguild.v1.Task.MetadataEntry
-	25, // 2: taskguild.v1.Task.created_at:type_name -> google.protobuf.Timestamp
-	25, // 3: taskguild.v1.Task.updated_at:type_name -> google.protobuf.Timestamp
-	23, // 4: taskguild.v1.CreateTaskRequest.metadata:type_name -> taskguild.v1.CreateTaskRequest.MetadataEntry
+	26, // 1: taskguild.v1.Task.metadata:type_name -> taskguild.v1.Task.MetadataEntry
+	29, // 2: taskguild.v1.Task.created_at:type_name -> google.protobuf.Timestamp
+	29, // 3: taskguild.v1.Task.updated_at:type_name -> google.protobuf.Timestamp
+	27, // 4: taskguild.v1.CreateTaskRequest.metadata:type_name -> taskguild.v1.CreateTaskRequest.MetadataEntry
 	1,  // 5: taskguild.v1.CreateTaskResponse.task:type_name -> taskguild.v1.Task
 	1,  // 6: taskguild.v1.GetTaskResponse.task:type_name -> taskguild.v1.Task
-	26, // 7: taskguild.v1.ListTasksRequest.pagination:type_name -> taskguild.v1.PaginationRequest
+	30, // 7: taskguild.v1.ListTasksRequest.pagination:type_name -> taskguild.v1.PaginationRequest
 	1,  // 8: taskguild.v1.ListTasksResponse.tasks:type_name -> taskguild.v1.Task
-	27, // 9: taskguild.v1.ListTasksResponse.pagination:type_name -> taskguild.v1.PaginationResponse
-	24, // 10: taskguild.v1.UpdateTaskRequest.metadata:type_name -> taskguild.v1.UpdateTaskRequest.MetadataEntry
+	31, // 9: taskguild.v1.ListTasksResponse.pagination:type_name -> taskguild.v1.PaginationResponse
+	28, // 10: taskguild.v1.UpdateTaskRequest.metadata:type_name -> taskguild.v1.UpdateTaskRequest.MetadataEntry
 	1,  // 11: taskguild.v1.UpdateTaskResponse.task:type_name -> taskguild.v1.Task
 	1,  // 12: taskguild.v1.UpdateTaskStatusResponse.task:type_name -> taskguild.v1.Task
-	1,  // 13: taskguild.v1.ArchiveTaskResponse.task:type_name -> taskguild.v1.Task
-	1,  // 14: taskguild.v1.ArchiveTerminalTasksResponse.archived_tasks:type_name -> taskguild.v1.Task
-	1,  // 15: taskguild.v1.ArchiveTerminalTasksResponse.skipped_tasks:type_name -> taskguild.v1.Task
-	1,  // 16: taskguild.v1.UnarchiveTaskResponse.task:type_name -> taskguild.v1.Task
-	26, // 17: taskguild.v1.ListArchivedTasksRequest.pagination:type_name -> taskguild.v1.PaginationRequest
-	1,  // 18: taskguild.v1.ListArchivedTasksResponse.tasks:type_name -> taskguild.v1.Task
-	27, // 19: taskguild.v1.ListArchivedTasksResponse.pagination:type_name -> taskguild.v1.PaginationResponse
-	2,  // 20: taskguild.v1.TaskService.CreateTask:input_type -> taskguild.v1.CreateTaskRequest
-	4,  // 21: taskguild.v1.TaskService.GetTask:input_type -> taskguild.v1.GetTaskRequest
-	6,  // 22: taskguild.v1.TaskService.ListTasks:input_type -> taskguild.v1.ListTasksRequest
-	8,  // 23: taskguild.v1.TaskService.UpdateTask:input_type -> taskguild.v1.UpdateTaskRequest
-	10, // 24: taskguild.v1.TaskService.DeleteTask:input_type -> taskguild.v1.DeleteTaskRequest
-	12, // 25: taskguild.v1.TaskService.UpdateTaskStatus:input_type -> taskguild.v1.UpdateTaskStatusRequest
-	14, // 26: taskguild.v1.TaskService.ArchiveTask:input_type -> taskguild.v1.ArchiveTaskRequest
-	16, // 27: taskguild.v1.TaskService.ArchiveTerminalTasks:input_type -> taskguild.v1.ArchiveTerminalTasksRequest
-	18, // 28: taskguild.v1.TaskService.UnarchiveTask:input_type -> taskguild.v1.UnarchiveTaskRequest
-	20, // 29: taskguild.v1.TaskService.ListArchivedTasks:input_type -> taskguild.v1.ListArchivedTasksRequest
-	3,  // 30: taskguild.v1.TaskService.CreateTask:output_type -> taskguild.v1.CreateTaskResponse
-	5,  // 31: taskguild.v1.TaskService.GetTask:output_type -> taskguild.v1.GetTaskResponse
-	7,  // 32: taskguild.v1.TaskService.ListTasks:output_type -> taskguild.v1.ListTasksResponse
-	9,  // 33: taskguild.v1.TaskService.UpdateTask:output_type -> taskguild.v1.UpdateTaskResponse
-	11, // 34: taskguild.v1.TaskService.DeleteTask:output_type -> taskguild.v1.DeleteTaskResponse
-	13, // 35: taskguild.v1.TaskService.UpdateTaskStatus:output_type -> taskguild.v1.UpdateTaskStatusResponse
-	15, // 36: taskguild.v1.TaskService.ArchiveTask:output_type -> taskguild.v1.ArchiveTaskResponse
-	17, // 37: taskguild.v1.TaskService.ArchiveTerminalTasks:output_type -> taskguild.v1.ArchiveTerminalTasksResponse
-	19, // 38: taskguild.v1.TaskService.UnarchiveTask:output_type -> taskguild.v1.UnarchiveTaskResponse
-	21, // 39: taskguild.v1.TaskService.ListArchivedTasks:output_type -> taskguild.v1.ListArchivedTasksResponse
-	30, // [30:40] is the sub-list for method output_type
-	20, // [20:30] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	1,  // 13: taskguild.v1.StopTaskResponse.task:type_name -> taskguild.v1.Task
+	1,  // 14: taskguild.v1.ResumeTaskResponse.task:type_name -> taskguild.v1.Task
+	1,  // 15: taskguild.v1.ArchiveTaskResponse.task:type_name -> taskguild.v1.Task
+	1,  // 16: taskguild.v1.ArchiveTerminalTasksResponse.archived_tasks:type_name -> taskguild.v1.Task
+	1,  // 17: taskguild.v1.ArchiveTerminalTasksResponse.skipped_tasks:type_name -> taskguild.v1.Task
+	1,  // 18: taskguild.v1.UnarchiveTaskResponse.task:type_name -> taskguild.v1.Task
+	30, // 19: taskguild.v1.ListArchivedTasksRequest.pagination:type_name -> taskguild.v1.PaginationRequest
+	1,  // 20: taskguild.v1.ListArchivedTasksResponse.tasks:type_name -> taskguild.v1.Task
+	31, // 21: taskguild.v1.ListArchivedTasksResponse.pagination:type_name -> taskguild.v1.PaginationResponse
+	2,  // 22: taskguild.v1.TaskService.CreateTask:input_type -> taskguild.v1.CreateTaskRequest
+	4,  // 23: taskguild.v1.TaskService.GetTask:input_type -> taskguild.v1.GetTaskRequest
+	6,  // 24: taskguild.v1.TaskService.ListTasks:input_type -> taskguild.v1.ListTasksRequest
+	8,  // 25: taskguild.v1.TaskService.UpdateTask:input_type -> taskguild.v1.UpdateTaskRequest
+	10, // 26: taskguild.v1.TaskService.DeleteTask:input_type -> taskguild.v1.DeleteTaskRequest
+	12, // 27: taskguild.v1.TaskService.UpdateTaskStatus:input_type -> taskguild.v1.UpdateTaskStatusRequest
+	14, // 28: taskguild.v1.TaskService.StopTask:input_type -> taskguild.v1.StopTaskRequest
+	16, // 29: taskguild.v1.TaskService.ResumeTask:input_type -> taskguild.v1.ResumeTaskRequest
+	18, // 30: taskguild.v1.TaskService.ArchiveTask:input_type -> taskguild.v1.ArchiveTaskRequest
+	20, // 31: taskguild.v1.TaskService.ArchiveTerminalTasks:input_type -> taskguild.v1.ArchiveTerminalTasksRequest
+	22, // 32: taskguild.v1.TaskService.UnarchiveTask:input_type -> taskguild.v1.UnarchiveTaskRequest
+	24, // 33: taskguild.v1.TaskService.ListArchivedTasks:input_type -> taskguild.v1.ListArchivedTasksRequest
+	3,  // 34: taskguild.v1.TaskService.CreateTask:output_type -> taskguild.v1.CreateTaskResponse
+	5,  // 35: taskguild.v1.TaskService.GetTask:output_type -> taskguild.v1.GetTaskResponse
+	7,  // 36: taskguild.v1.TaskService.ListTasks:output_type -> taskguild.v1.ListTasksResponse
+	9,  // 37: taskguild.v1.TaskService.UpdateTask:output_type -> taskguild.v1.UpdateTaskResponse
+	11, // 38: taskguild.v1.TaskService.DeleteTask:output_type -> taskguild.v1.DeleteTaskResponse
+	13, // 39: taskguild.v1.TaskService.UpdateTaskStatus:output_type -> taskguild.v1.UpdateTaskStatusResponse
+	15, // 40: taskguild.v1.TaskService.StopTask:output_type -> taskguild.v1.StopTaskResponse
+	17, // 41: taskguild.v1.TaskService.ResumeTask:output_type -> taskguild.v1.ResumeTaskResponse
+	19, // 42: taskguild.v1.TaskService.ArchiveTask:output_type -> taskguild.v1.ArchiveTaskResponse
+	21, // 43: taskguild.v1.TaskService.ArchiveTerminalTasks:output_type -> taskguild.v1.ArchiveTerminalTasksResponse
+	23, // 44: taskguild.v1.TaskService.UnarchiveTask:output_type -> taskguild.v1.UnarchiveTaskResponse
+	25, // 45: taskguild.v1.TaskService.ListArchivedTasks:output_type -> taskguild.v1.ListArchivedTasksResponse
+	34, // [34:46] is the sub-list for method output_type
+	22, // [22:34] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_taskguild_v1_task_proto_init() }
@@ -1500,7 +1697,7 @@ func file_taskguild_v1_task_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_taskguild_v1_task_proto_rawDesc), len(file_taskguild_v1_task_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   24,
+			NumMessages:   28,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/gen/go/taskguild/v1/taskguildv1connect/task.connect.go
+++ b/proto/gen/go/taskguild/v1/taskguildv1connect/task.connect.go
@@ -46,6 +46,10 @@ const (
 	// TaskServiceUpdateTaskStatusProcedure is the fully-qualified name of the TaskService's
 	// UpdateTaskStatus RPC.
 	TaskServiceUpdateTaskStatusProcedure = "/taskguild.v1.TaskService/UpdateTaskStatus"
+	// TaskServiceStopTaskProcedure is the fully-qualified name of the TaskService's StopTask RPC.
+	TaskServiceStopTaskProcedure = "/taskguild.v1.TaskService/StopTask"
+	// TaskServiceResumeTaskProcedure is the fully-qualified name of the TaskService's ResumeTask RPC.
+	TaskServiceResumeTaskProcedure = "/taskguild.v1.TaskService/ResumeTask"
 	// TaskServiceArchiveTaskProcedure is the fully-qualified name of the TaskService's ArchiveTask RPC.
 	TaskServiceArchiveTaskProcedure = "/taskguild.v1.TaskService/ArchiveTask"
 	// TaskServiceArchiveTerminalTasksProcedure is the fully-qualified name of the TaskService's
@@ -67,6 +71,9 @@ type TaskServiceClient interface {
 	UpdateTask(context.Context, *connect.Request[v1.UpdateTaskRequest]) (*connect.Response[v1.UpdateTaskResponse], error)
 	DeleteTask(context.Context, *connect.Request[v1.DeleteTaskRequest]) (*connect.Response[v1.DeleteTaskResponse], error)
 	UpdateTaskStatus(context.Context, *connect.Request[v1.UpdateTaskStatusRequest]) (*connect.Response[v1.UpdateTaskStatusResponse], error)
+	// Task lifecycle control
+	StopTask(context.Context, *connect.Request[v1.StopTaskRequest]) (*connect.Response[v1.StopTaskResponse], error)
+	ResumeTask(context.Context, *connect.Request[v1.ResumeTaskRequest]) (*connect.Response[v1.ResumeTaskResponse], error)
 	// Archive operations
 	ArchiveTask(context.Context, *connect.Request[v1.ArchiveTaskRequest]) (*connect.Response[v1.ArchiveTaskResponse], error)
 	ArchiveTerminalTasks(context.Context, *connect.Request[v1.ArchiveTerminalTasksRequest]) (*connect.Response[v1.ArchiveTerminalTasksResponse], error)
@@ -121,6 +128,18 @@ func NewTaskServiceClient(httpClient connect.HTTPClient, baseURL string, opts ..
 			connect.WithSchema(taskServiceMethods.ByName("UpdateTaskStatus")),
 			connect.WithClientOptions(opts...),
 		),
+		stopTask: connect.NewClient[v1.StopTaskRequest, v1.StopTaskResponse](
+			httpClient,
+			baseURL+TaskServiceStopTaskProcedure,
+			connect.WithSchema(taskServiceMethods.ByName("StopTask")),
+			connect.WithClientOptions(opts...),
+		),
+		resumeTask: connect.NewClient[v1.ResumeTaskRequest, v1.ResumeTaskResponse](
+			httpClient,
+			baseURL+TaskServiceResumeTaskProcedure,
+			connect.WithSchema(taskServiceMethods.ByName("ResumeTask")),
+			connect.WithClientOptions(opts...),
+		),
 		archiveTask: connect.NewClient[v1.ArchiveTaskRequest, v1.ArchiveTaskResponse](
 			httpClient,
 			baseURL+TaskServiceArchiveTaskProcedure,
@@ -156,6 +175,8 @@ type taskServiceClient struct {
 	updateTask           *connect.Client[v1.UpdateTaskRequest, v1.UpdateTaskResponse]
 	deleteTask           *connect.Client[v1.DeleteTaskRequest, v1.DeleteTaskResponse]
 	updateTaskStatus     *connect.Client[v1.UpdateTaskStatusRequest, v1.UpdateTaskStatusResponse]
+	stopTask             *connect.Client[v1.StopTaskRequest, v1.StopTaskResponse]
+	resumeTask           *connect.Client[v1.ResumeTaskRequest, v1.ResumeTaskResponse]
 	archiveTask          *connect.Client[v1.ArchiveTaskRequest, v1.ArchiveTaskResponse]
 	archiveTerminalTasks *connect.Client[v1.ArchiveTerminalTasksRequest, v1.ArchiveTerminalTasksResponse]
 	unarchiveTask        *connect.Client[v1.UnarchiveTaskRequest, v1.UnarchiveTaskResponse]
@@ -192,6 +213,16 @@ func (c *taskServiceClient) UpdateTaskStatus(ctx context.Context, req *connect.R
 	return c.updateTaskStatus.CallUnary(ctx, req)
 }
 
+// StopTask calls taskguild.v1.TaskService.StopTask.
+func (c *taskServiceClient) StopTask(ctx context.Context, req *connect.Request[v1.StopTaskRequest]) (*connect.Response[v1.StopTaskResponse], error) {
+	return c.stopTask.CallUnary(ctx, req)
+}
+
+// ResumeTask calls taskguild.v1.TaskService.ResumeTask.
+func (c *taskServiceClient) ResumeTask(ctx context.Context, req *connect.Request[v1.ResumeTaskRequest]) (*connect.Response[v1.ResumeTaskResponse], error) {
+	return c.resumeTask.CallUnary(ctx, req)
+}
+
 // ArchiveTask calls taskguild.v1.TaskService.ArchiveTask.
 func (c *taskServiceClient) ArchiveTask(ctx context.Context, req *connect.Request[v1.ArchiveTaskRequest]) (*connect.Response[v1.ArchiveTaskResponse], error) {
 	return c.archiveTask.CallUnary(ctx, req)
@@ -220,6 +251,9 @@ type TaskServiceHandler interface {
 	UpdateTask(context.Context, *connect.Request[v1.UpdateTaskRequest]) (*connect.Response[v1.UpdateTaskResponse], error)
 	DeleteTask(context.Context, *connect.Request[v1.DeleteTaskRequest]) (*connect.Response[v1.DeleteTaskResponse], error)
 	UpdateTaskStatus(context.Context, *connect.Request[v1.UpdateTaskStatusRequest]) (*connect.Response[v1.UpdateTaskStatusResponse], error)
+	// Task lifecycle control
+	StopTask(context.Context, *connect.Request[v1.StopTaskRequest]) (*connect.Response[v1.StopTaskResponse], error)
+	ResumeTask(context.Context, *connect.Request[v1.ResumeTaskRequest]) (*connect.Response[v1.ResumeTaskResponse], error)
 	// Archive operations
 	ArchiveTask(context.Context, *connect.Request[v1.ArchiveTaskRequest]) (*connect.Response[v1.ArchiveTaskResponse], error)
 	ArchiveTerminalTasks(context.Context, *connect.Request[v1.ArchiveTerminalTasksRequest]) (*connect.Response[v1.ArchiveTerminalTasksResponse], error)
@@ -270,6 +304,18 @@ func NewTaskServiceHandler(svc TaskServiceHandler, opts ...connect.HandlerOption
 		connect.WithSchema(taskServiceMethods.ByName("UpdateTaskStatus")),
 		connect.WithHandlerOptions(opts...),
 	)
+	taskServiceStopTaskHandler := connect.NewUnaryHandler(
+		TaskServiceStopTaskProcedure,
+		svc.StopTask,
+		connect.WithSchema(taskServiceMethods.ByName("StopTask")),
+		connect.WithHandlerOptions(opts...),
+	)
+	taskServiceResumeTaskHandler := connect.NewUnaryHandler(
+		TaskServiceResumeTaskProcedure,
+		svc.ResumeTask,
+		connect.WithSchema(taskServiceMethods.ByName("ResumeTask")),
+		connect.WithHandlerOptions(opts...),
+	)
 	taskServiceArchiveTaskHandler := connect.NewUnaryHandler(
 		TaskServiceArchiveTaskProcedure,
 		svc.ArchiveTask,
@@ -308,6 +354,10 @@ func NewTaskServiceHandler(svc TaskServiceHandler, opts ...connect.HandlerOption
 			taskServiceDeleteTaskHandler.ServeHTTP(w, r)
 		case TaskServiceUpdateTaskStatusProcedure:
 			taskServiceUpdateTaskStatusHandler.ServeHTTP(w, r)
+		case TaskServiceStopTaskProcedure:
+			taskServiceStopTaskHandler.ServeHTTP(w, r)
+		case TaskServiceResumeTaskProcedure:
+			taskServiceResumeTaskHandler.ServeHTTP(w, r)
 		case TaskServiceArchiveTaskProcedure:
 			taskServiceArchiveTaskHandler.ServeHTTP(w, r)
 		case TaskServiceArchiveTerminalTasksProcedure:
@@ -347,6 +397,14 @@ func (UnimplementedTaskServiceHandler) DeleteTask(context.Context, *connect.Requ
 
 func (UnimplementedTaskServiceHandler) UpdateTaskStatus(context.Context, *connect.Request[v1.UpdateTaskStatusRequest]) (*connect.Response[v1.UpdateTaskStatusResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("taskguild.v1.TaskService.UpdateTaskStatus is not implemented"))
+}
+
+func (UnimplementedTaskServiceHandler) StopTask(context.Context, *connect.Request[v1.StopTaskRequest]) (*connect.Response[v1.StopTaskResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("taskguild.v1.TaskService.StopTask is not implemented"))
+}
+
+func (UnimplementedTaskServiceHandler) ResumeTask(context.Context, *connect.Request[v1.ResumeTaskRequest]) (*connect.Response[v1.ResumeTaskResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("taskguild.v1.TaskService.ResumeTask is not implemented"))
 }
 
 func (UnimplementedTaskServiceHandler) ArchiveTask(context.Context, *connect.Request[v1.ArchiveTaskRequest]) (*connect.Response[v1.ArchiveTaskResponse], error) {

--- a/proto/gen/ts/taskguild/v1/task-TaskService_connectquery.ts
+++ b/proto/gen/ts/taskguild/v1/task-TaskService_connectquery.ts
@@ -35,6 +35,18 @@ export const deleteTask = TaskService.method.deleteTask;
 export const updateTaskStatus = TaskService.method.updateTaskStatus;
 
 /**
+ * Task lifecycle control
+ *
+ * @generated from rpc taskguild.v1.TaskService.StopTask
+ */
+export const stopTask = TaskService.method.stopTask;
+
+/**
+ * @generated from rpc taskguild.v1.TaskService.ResumeTask
+ */
+export const resumeTask = TaskService.method.resumeTask;
+
+/**
  * Archive operations
  *
  * @generated from rpc taskguild.v1.TaskService.ArchiveTask

--- a/proto/gen/ts/taskguild/v1/task_pb.ts
+++ b/proto/gen/ts/taskguild/v1/task_pb.ts
@@ -14,7 +14,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file taskguild/v1/task.proto.
  */
 export const file_taskguild_v1_task: GenFile = /*@__PURE__*/
-  fileDesc("Chd0YXNrZ3VpbGQvdjEvdGFzay5wcm90bxIMdGFza2d1aWxkLnYxIr4DCgRUYXNrEgoKAmlkGAEgASgJEhIKCnByb2plY3RfaWQYAiABKAkSEwoLd29ya2Zsb3dfaWQYAyABKAkSDQoFdGl0bGUYBCABKAkSEwoLZGVzY3JpcHRpb24YBSABKAkSEQoJc3RhdHVzX2lkGAYgASgJEj0KEWFzc2lnbm1lbnRfc3RhdHVzGAcgASgOMiIudGFza2d1aWxkLnYxLlRhc2tBc3NpZ25tZW50U3RhdHVzEhkKEWFzc2lnbmVkX2FnZW50X2lkGAggASgJEhQKDHVzZV93b3JrdHJlZRgJIAEoCBIyCghtZXRhZGF0YRgLIAMoCzIgLnRhc2tndWlsZC52MS5UYXNrLk1ldGFkYXRhRW50cnkSLgoKY3JlYXRlZF9hdBgMIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLgoKdXBkYXRlZF9hdBgNIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAaLwoNTWV0YWRhdGFFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBSgQIChALUg9wZXJtaXNzaW9uX21vZGUipQIKEUNyZWF0ZVRhc2tSZXF1ZXN0EhIKCnByb2plY3RfaWQYASABKAkSEwoLd29ya2Zsb3dfaWQYAiABKAkSDQoFdGl0bGUYAyABKAkSEwoLZGVzY3JpcHRpb24YBCABKAkSFAoMdXNlX3dvcmt0cmVlGAUgASgIEj8KCG1ldGFkYXRhGAcgAygLMi0udGFza2d1aWxkLnYxLkNyZWF0ZVRhc2tSZXF1ZXN0Lk1ldGFkYXRhRW50cnkSFgoJc3RhdHVzX2lkGAggASgJSACIAQEaLwoNTWV0YWRhdGFFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBQgwKCl9zdGF0dXNfaWRKBAgGEAdSD3Blcm1pc3Npb25fbW9kZSI2ChJDcmVhdGVUYXNrUmVzcG9uc2USIAoEdGFzaxgBIAEoCzISLnRhc2tndWlsZC52MS5UYXNrIhwKDkdldFRhc2tSZXF1ZXN0EgoKAmlkGAEgASgJIjMKD0dldFRhc2tSZXNwb25zZRIgCgR0YXNrGAEgASgLMhIudGFza2d1aWxkLnYxLlRhc2sigwEKEExpc3RUYXNrc1JlcXVlc3QSEgoKcHJvamVjdF9pZBgBIAEoCRITCgt3b3JrZmxvd19pZBgCIAEoCRIRCglzdGF0dXNfaWQYAyABKAkSMwoKcGFnaW5hdGlvbhgEIAEoCzIfLnRhc2tndWlsZC52MS5QYWdpbmF0aW9uUmVxdWVzdCJsChFMaXN0VGFza3NSZXNwb25zZRIhCgV0YXNrcxgBIAMoCzISLnRhc2tndWlsZC52MS5UYXNrEjQKCnBhZ2luYXRpb24YAiABKAsyIC50YXNrZ3VpbGQudjEuUGFnaW5hdGlvblJlc3BvbnNlIvgBChFVcGRhdGVUYXNrUmVxdWVzdBIKCgJpZBgBIAEoCRINCgV0aXRsZRgCIAEoCRITCgtkZXNjcmlwdGlvbhgDIAEoCRIZCgx1c2Vfd29ya3RyZWUYBCABKAhIAIgBARI/CghtZXRhZGF0YRgGIAMoCzItLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrUmVxdWVzdC5NZXRhZGF0YUVudHJ5Gi8KDU1ldGFkYXRhRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4AUIPCg1fdXNlX3dvcmt0cmVlSgQIBRAGUg9wZXJtaXNzaW9uX21vZGUiNgoSVXBkYXRlVGFza1Jlc3BvbnNlEiAKBHRhc2sYASABKAsyEi50YXNrZ3VpbGQudjEuVGFzayIfChFEZWxldGVUYXNrUmVxdWVzdBIKCgJpZBgBIAEoCSIUChJEZWxldGVUYXNrUmVzcG9uc2UiRwoXVXBkYXRlVGFza1N0YXR1c1JlcXVlc3QSCgoCaWQYASABKAkSEQoJc3RhdHVzX2lkGAIgASgJEg0KBWZvcmNlGAMgASgIIjwKGFVwZGF0ZVRhc2tTdGF0dXNSZXNwb25zZRIgCgR0YXNrGAEgASgLMhIudGFza2d1aWxkLnYxLlRhc2siIAoSQXJjaGl2ZVRhc2tSZXF1ZXN0EgoKAmlkGAEgASgJIjcKE0FyY2hpdmVUYXNrUmVzcG9uc2USIAoEdGFzaxgBIAEoCzISLnRhc2tndWlsZC52MS5UYXNrIkYKG0FyY2hpdmVUZXJtaW5hbFRhc2tzUmVxdWVzdBISCgpwcm9qZWN0X2lkGAEgASgJEhMKC3dvcmtmbG93X2lkGAIgASgJInUKHEFyY2hpdmVUZXJtaW5hbFRhc2tzUmVzcG9uc2USKgoOYXJjaGl2ZWRfdGFza3MYASADKAsyEi50YXNrZ3VpbGQudjEuVGFzaxIpCg1za2lwcGVkX3Rhc2tzGAIgAygLMhIudGFza2d1aWxkLnYxLlRhc2siIgoUVW5hcmNoaXZlVGFza1JlcXVlc3QSCgoCaWQYASABKAkiOQoVVW5hcmNoaXZlVGFza1Jlc3BvbnNlEiAKBHRhc2sYASABKAsyEi50YXNrZ3VpbGQudjEuVGFzayJ4ChhMaXN0QXJjaGl2ZWRUYXNrc1JlcXVlc3QSEgoKcHJvamVjdF9pZBgBIAEoCRITCgt3b3JrZmxvd19pZBgCIAEoCRIzCgpwYWdpbmF0aW9uGAMgASgLMh8udGFza2d1aWxkLnYxLlBhZ2luYXRpb25SZXF1ZXN0InQKGUxpc3RBcmNoaXZlZFRhc2tzUmVzcG9uc2USIQoFdGFza3MYASADKAsyEi50YXNrZ3VpbGQudjEuVGFzaxI0CgpwYWdpbmF0aW9uGAIgASgLMiAudGFza2d1aWxkLnYxLlBhZ2luYXRpb25SZXNwb25zZSquAQoUVGFza0Fzc2lnbm1lbnRTdGF0dXMSJgoiVEFTS19BU1NJR05NRU5UX1NUQVRVU19VTlNQRUNJRklFRBAAEiUKIVRBU0tfQVNTSUdOTUVOVF9TVEFUVVNfVU5BU1NJR05FRBABEiIKHlRBU0tfQVNTSUdOTUVOVF9TVEFUVVNfUEVORElORxACEiMKH1RBU0tfQVNTSUdOTUVOVF9TVEFUVVNfQVNTSUdORUQQAzL8BgoLVGFza1NlcnZpY2USTwoKQ3JlYXRlVGFzaxIfLnRhc2tndWlsZC52MS5DcmVhdGVUYXNrUmVxdWVzdBogLnRhc2tndWlsZC52MS5DcmVhdGVUYXNrUmVzcG9uc2USRgoHR2V0VGFzaxIcLnRhc2tndWlsZC52MS5HZXRUYXNrUmVxdWVzdBodLnRhc2tndWlsZC52MS5HZXRUYXNrUmVzcG9uc2USTAoJTGlzdFRhc2tzEh4udGFza2d1aWxkLnYxLkxpc3RUYXNrc1JlcXVlc3QaHy50YXNrZ3VpbGQudjEuTGlzdFRhc2tzUmVzcG9uc2USTwoKVXBkYXRlVGFzaxIfLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrUmVxdWVzdBogLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrUmVzcG9uc2USTwoKRGVsZXRlVGFzaxIfLnRhc2tndWlsZC52MS5EZWxldGVUYXNrUmVxdWVzdBogLnRhc2tndWlsZC52MS5EZWxldGVUYXNrUmVzcG9uc2USYQoQVXBkYXRlVGFza1N0YXR1cxIlLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrU3RhdHVzUmVxdWVzdBomLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrU3RhdHVzUmVzcG9uc2USUgoLQXJjaGl2ZVRhc2sSIC50YXNrZ3VpbGQudjEuQXJjaGl2ZVRhc2tSZXF1ZXN0GiEudGFza2d1aWxkLnYxLkFyY2hpdmVUYXNrUmVzcG9uc2USbQoUQXJjaGl2ZVRlcm1pbmFsVGFza3MSKS50YXNrZ3VpbGQudjEuQXJjaGl2ZVRlcm1pbmFsVGFza3NSZXF1ZXN0GioudGFza2d1aWxkLnYxLkFyY2hpdmVUZXJtaW5hbFRhc2tzUmVzcG9uc2USWAoNVW5hcmNoaXZlVGFzaxIiLnRhc2tndWlsZC52MS5VbmFyY2hpdmVUYXNrUmVxdWVzdBojLnRhc2tndWlsZC52MS5VbmFyY2hpdmVUYXNrUmVzcG9uc2USZAoRTGlzdEFyY2hpdmVkVGFza3MSJi50YXNrZ3VpbGQudjEuTGlzdEFyY2hpdmVkVGFza3NSZXF1ZXN0GicudGFza2d1aWxkLnYxLkxpc3RBcmNoaXZlZFRhc2tzUmVzcG9uc2VCsgEKEGNvbS50YXNrZ3VpbGQudjFCCVRhc2tQcm90b1ABWkJnaXRodWIuY29tL2thenoxODcvdGFza2d1aWxkL3Byb3RvL2dlbi9nby90YXNrZ3VpbGQvdjE7dGFza2d1aWxkdjGiAgNUWFiqAgxUYXNrZ3VpbGQuVjHKAgxUYXNrZ3VpbGRcVjHiAhhUYXNrZ3VpbGRcVjFcR1BCTWV0YWRhdGHqAg1UYXNrZ3VpbGQ6OlYxYgZwcm90bzM", [file_google_protobuf_timestamp, file_taskguild_v1_common]);
+  fileDesc("Chd0YXNrZ3VpbGQvdjEvdGFzay5wcm90bxIMdGFza2d1aWxkLnYxIr4DCgRUYXNrEgoKAmlkGAEgASgJEhIKCnByb2plY3RfaWQYAiABKAkSEwoLd29ya2Zsb3dfaWQYAyABKAkSDQoFdGl0bGUYBCABKAkSEwoLZGVzY3JpcHRpb24YBSABKAkSEQoJc3RhdHVzX2lkGAYgASgJEj0KEWFzc2lnbm1lbnRfc3RhdHVzGAcgASgOMiIudGFza2d1aWxkLnYxLlRhc2tBc3NpZ25tZW50U3RhdHVzEhkKEWFzc2lnbmVkX2FnZW50X2lkGAggASgJEhQKDHVzZV93b3JrdHJlZRgJIAEoCBIyCghtZXRhZGF0YRgLIAMoCzIgLnRhc2tndWlsZC52MS5UYXNrLk1ldGFkYXRhRW50cnkSLgoKY3JlYXRlZF9hdBgMIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLgoKdXBkYXRlZF9hdBgNIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAaLwoNTWV0YWRhdGFFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBSgQIChALUg9wZXJtaXNzaW9uX21vZGUipQIKEUNyZWF0ZVRhc2tSZXF1ZXN0EhIKCnByb2plY3RfaWQYASABKAkSEwoLd29ya2Zsb3dfaWQYAiABKAkSDQoFdGl0bGUYAyABKAkSEwoLZGVzY3JpcHRpb24YBCABKAkSFAoMdXNlX3dvcmt0cmVlGAUgASgIEj8KCG1ldGFkYXRhGAcgAygLMi0udGFza2d1aWxkLnYxLkNyZWF0ZVRhc2tSZXF1ZXN0Lk1ldGFkYXRhRW50cnkSFgoJc3RhdHVzX2lkGAggASgJSACIAQEaLwoNTWV0YWRhdGFFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBQgwKCl9zdGF0dXNfaWRKBAgGEAdSD3Blcm1pc3Npb25fbW9kZSI2ChJDcmVhdGVUYXNrUmVzcG9uc2USIAoEdGFzaxgBIAEoCzISLnRhc2tndWlsZC52MS5UYXNrIhwKDkdldFRhc2tSZXF1ZXN0EgoKAmlkGAEgASgJIjMKD0dldFRhc2tSZXNwb25zZRIgCgR0YXNrGAEgASgLMhIudGFza2d1aWxkLnYxLlRhc2sigwEKEExpc3RUYXNrc1JlcXVlc3QSEgoKcHJvamVjdF9pZBgBIAEoCRITCgt3b3JrZmxvd19pZBgCIAEoCRIRCglzdGF0dXNfaWQYAyABKAkSMwoKcGFnaW5hdGlvbhgEIAEoCzIfLnRhc2tndWlsZC52MS5QYWdpbmF0aW9uUmVxdWVzdCJsChFMaXN0VGFza3NSZXNwb25zZRIhCgV0YXNrcxgBIAMoCzISLnRhc2tndWlsZC52MS5UYXNrEjQKCnBhZ2luYXRpb24YAiABKAsyIC50YXNrZ3VpbGQudjEuUGFnaW5hdGlvblJlc3BvbnNlIvgBChFVcGRhdGVUYXNrUmVxdWVzdBIKCgJpZBgBIAEoCRINCgV0aXRsZRgCIAEoCRITCgtkZXNjcmlwdGlvbhgDIAEoCRIZCgx1c2Vfd29ya3RyZWUYBCABKAhIAIgBARI/CghtZXRhZGF0YRgGIAMoCzItLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrUmVxdWVzdC5NZXRhZGF0YUVudHJ5Gi8KDU1ldGFkYXRhRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4AUIPCg1fdXNlX3dvcmt0cmVlSgQIBRAGUg9wZXJtaXNzaW9uX21vZGUiNgoSVXBkYXRlVGFza1Jlc3BvbnNlEiAKBHRhc2sYASABKAsyEi50YXNrZ3VpbGQudjEuVGFzayIfChFEZWxldGVUYXNrUmVxdWVzdBIKCgJpZBgBIAEoCSIUChJEZWxldGVUYXNrUmVzcG9uc2UiRwoXVXBkYXRlVGFza1N0YXR1c1JlcXVlc3QSCgoCaWQYASABKAkSEQoJc3RhdHVzX2lkGAIgASgJEg0KBWZvcmNlGAMgASgIIjwKGFVwZGF0ZVRhc2tTdGF0dXNSZXNwb25zZRIgCgR0YXNrGAEgASgLMhIudGFza2d1aWxkLnYxLlRhc2siHQoPU3RvcFRhc2tSZXF1ZXN0EgoKAmlkGAEgASgJIjQKEFN0b3BUYXNrUmVzcG9uc2USIAoEdGFzaxgBIAEoCzISLnRhc2tndWlsZC52MS5UYXNrIh8KEVJlc3VtZVRhc2tSZXF1ZXN0EgoKAmlkGAEgASgJIjYKElJlc3VtZVRhc2tSZXNwb25zZRIgCgR0YXNrGAEgASgLMhIudGFza2d1aWxkLnYxLlRhc2siIAoSQXJjaGl2ZVRhc2tSZXF1ZXN0EgoKAmlkGAEgASgJIjcKE0FyY2hpdmVUYXNrUmVzcG9uc2USIAoEdGFzaxgBIAEoCzISLnRhc2tndWlsZC52MS5UYXNrIkYKG0FyY2hpdmVUZXJtaW5hbFRhc2tzUmVxdWVzdBISCgpwcm9qZWN0X2lkGAEgASgJEhMKC3dvcmtmbG93X2lkGAIgASgJInUKHEFyY2hpdmVUZXJtaW5hbFRhc2tzUmVzcG9uc2USKgoOYXJjaGl2ZWRfdGFza3MYASADKAsyEi50YXNrZ3VpbGQudjEuVGFzaxIpCg1za2lwcGVkX3Rhc2tzGAIgAygLMhIudGFza2d1aWxkLnYxLlRhc2siIgoUVW5hcmNoaXZlVGFza1JlcXVlc3QSCgoCaWQYASABKAkiOQoVVW5hcmNoaXZlVGFza1Jlc3BvbnNlEiAKBHRhc2sYASABKAsyEi50YXNrZ3VpbGQudjEuVGFzayJ4ChhMaXN0QXJjaGl2ZWRUYXNrc1JlcXVlc3QSEgoKcHJvamVjdF9pZBgBIAEoCRITCgt3b3JrZmxvd19pZBgCIAEoCRIzCgpwYWdpbmF0aW9uGAMgASgLMh8udGFza2d1aWxkLnYxLlBhZ2luYXRpb25SZXF1ZXN0InQKGUxpc3RBcmNoaXZlZFRhc2tzUmVzcG9uc2USIQoFdGFza3MYASADKAsyEi50YXNrZ3VpbGQudjEuVGFzaxI0CgpwYWdpbmF0aW9uGAIgASgLMiAudGFza2d1aWxkLnYxLlBhZ2luYXRpb25SZXNwb25zZSquAQoUVGFza0Fzc2lnbm1lbnRTdGF0dXMSJgoiVEFTS19BU1NJR05NRU5UX1NUQVRVU19VTlNQRUNJRklFRBAAEiUKIVRBU0tfQVNTSUdOTUVOVF9TVEFUVVNfVU5BU1NJR05FRBABEiIKHlRBU0tfQVNTSUdOTUVOVF9TVEFUVVNfUEVORElORxACEiMKH1RBU0tfQVNTSUdOTUVOVF9TVEFUVVNfQVNTSUdORUQQAzKYCAoLVGFza1NlcnZpY2USTwoKQ3JlYXRlVGFzaxIfLnRhc2tndWlsZC52MS5DcmVhdGVUYXNrUmVxdWVzdBogLnRhc2tndWlsZC52MS5DcmVhdGVUYXNrUmVzcG9uc2USRgoHR2V0VGFzaxIcLnRhc2tndWlsZC52MS5HZXRUYXNrUmVxdWVzdBodLnRhc2tndWlsZC52MS5HZXRUYXNrUmVzcG9uc2USTAoJTGlzdFRhc2tzEh4udGFza2d1aWxkLnYxLkxpc3RUYXNrc1JlcXVlc3QaHy50YXNrZ3VpbGQudjEuTGlzdFRhc2tzUmVzcG9uc2USTwoKVXBkYXRlVGFzaxIfLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrUmVxdWVzdBogLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrUmVzcG9uc2USTwoKRGVsZXRlVGFzaxIfLnRhc2tndWlsZC52MS5EZWxldGVUYXNrUmVxdWVzdBogLnRhc2tndWlsZC52MS5EZWxldGVUYXNrUmVzcG9uc2USYQoQVXBkYXRlVGFza1N0YXR1cxIlLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrU3RhdHVzUmVxdWVzdBomLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrU3RhdHVzUmVzcG9uc2USSQoIU3RvcFRhc2sSHS50YXNrZ3VpbGQudjEuU3RvcFRhc2tSZXF1ZXN0Gh4udGFza2d1aWxkLnYxLlN0b3BUYXNrUmVzcG9uc2USTwoKUmVzdW1lVGFzaxIfLnRhc2tndWlsZC52MS5SZXN1bWVUYXNrUmVxdWVzdBogLnRhc2tndWlsZC52MS5SZXN1bWVUYXNrUmVzcG9uc2USUgoLQXJjaGl2ZVRhc2sSIC50YXNrZ3VpbGQudjEuQXJjaGl2ZVRhc2tSZXF1ZXN0GiEudGFza2d1aWxkLnYxLkFyY2hpdmVUYXNrUmVzcG9uc2USbQoUQXJjaGl2ZVRlcm1pbmFsVGFza3MSKS50YXNrZ3VpbGQudjEuQXJjaGl2ZVRlcm1pbmFsVGFza3NSZXF1ZXN0GioudGFza2d1aWxkLnYxLkFyY2hpdmVUZXJtaW5hbFRhc2tzUmVzcG9uc2USWAoNVW5hcmNoaXZlVGFzaxIiLnRhc2tndWlsZC52MS5VbmFyY2hpdmVUYXNrUmVxdWVzdBojLnRhc2tndWlsZC52MS5VbmFyY2hpdmVUYXNrUmVzcG9uc2USZAoRTGlzdEFyY2hpdmVkVGFza3MSJi50YXNrZ3VpbGQudjEuTGlzdEFyY2hpdmVkVGFza3NSZXF1ZXN0GicudGFza2d1aWxkLnYxLkxpc3RBcmNoaXZlZFRhc2tzUmVzcG9uc2VCsgEKEGNvbS50YXNrZ3VpbGQudjFCCVRhc2tQcm90b1ABWkJnaXRodWIuY29tL2thenoxODcvdGFza2d1aWxkL3Byb3RvL2dlbi9nby90YXNrZ3VpbGQvdjE7dGFza2d1aWxkdjGiAgNUWFiqAgxUYXNrZ3VpbGQuVjHKAgxUYXNrZ3VpbGRcVjHiAhhUYXNrZ3VpbGRcVjFcR1BCTWV0YWRhdGHqAg1UYXNrZ3VpbGQ6OlYxYgZwcm90bzM", [file_google_protobuf_timestamp, file_taskguild_v1_common]);
 
 /**
  * @generated from message taskguild.v1.Task
@@ -404,6 +404,74 @@ export const UpdateTaskStatusResponseSchema: GenMessage<UpdateTaskStatusResponse
   messageDesc(file_taskguild_v1_task, 12);
 
 /**
+ * @generated from message taskguild.v1.StopTaskRequest
+ */
+export type StopTaskRequest = Message<"taskguild.v1.StopTaskRequest"> & {
+  /**
+   * @generated from field: string id = 1;
+   */
+  id: string;
+};
+
+/**
+ * Describes the message taskguild.v1.StopTaskRequest.
+ * Use `create(StopTaskRequestSchema)` to create a new message.
+ */
+export const StopTaskRequestSchema: GenMessage<StopTaskRequest> = /*@__PURE__*/
+  messageDesc(file_taskguild_v1_task, 13);
+
+/**
+ * @generated from message taskguild.v1.StopTaskResponse
+ */
+export type StopTaskResponse = Message<"taskguild.v1.StopTaskResponse"> & {
+  /**
+   * @generated from field: taskguild.v1.Task task = 1;
+   */
+  task?: Task;
+};
+
+/**
+ * Describes the message taskguild.v1.StopTaskResponse.
+ * Use `create(StopTaskResponseSchema)` to create a new message.
+ */
+export const StopTaskResponseSchema: GenMessage<StopTaskResponse> = /*@__PURE__*/
+  messageDesc(file_taskguild_v1_task, 14);
+
+/**
+ * @generated from message taskguild.v1.ResumeTaskRequest
+ */
+export type ResumeTaskRequest = Message<"taskguild.v1.ResumeTaskRequest"> & {
+  /**
+   * @generated from field: string id = 1;
+   */
+  id: string;
+};
+
+/**
+ * Describes the message taskguild.v1.ResumeTaskRequest.
+ * Use `create(ResumeTaskRequestSchema)` to create a new message.
+ */
+export const ResumeTaskRequestSchema: GenMessage<ResumeTaskRequest> = /*@__PURE__*/
+  messageDesc(file_taskguild_v1_task, 15);
+
+/**
+ * @generated from message taskguild.v1.ResumeTaskResponse
+ */
+export type ResumeTaskResponse = Message<"taskguild.v1.ResumeTaskResponse"> & {
+  /**
+   * @generated from field: taskguild.v1.Task task = 1;
+   */
+  task?: Task;
+};
+
+/**
+ * Describes the message taskguild.v1.ResumeTaskResponse.
+ * Use `create(ResumeTaskResponseSchema)` to create a new message.
+ */
+export const ResumeTaskResponseSchema: GenMessage<ResumeTaskResponse> = /*@__PURE__*/
+  messageDesc(file_taskguild_v1_task, 16);
+
+/**
  * @generated from message taskguild.v1.ArchiveTaskRequest
  */
 export type ArchiveTaskRequest = Message<"taskguild.v1.ArchiveTaskRequest"> & {
@@ -418,7 +486,7 @@ export type ArchiveTaskRequest = Message<"taskguild.v1.ArchiveTaskRequest"> & {
  * Use `create(ArchiveTaskRequestSchema)` to create a new message.
  */
 export const ArchiveTaskRequestSchema: GenMessage<ArchiveTaskRequest> = /*@__PURE__*/
-  messageDesc(file_taskguild_v1_task, 13);
+  messageDesc(file_taskguild_v1_task, 17);
 
 /**
  * @generated from message taskguild.v1.ArchiveTaskResponse
@@ -435,7 +503,7 @@ export type ArchiveTaskResponse = Message<"taskguild.v1.ArchiveTaskResponse"> & 
  * Use `create(ArchiveTaskResponseSchema)` to create a new message.
  */
 export const ArchiveTaskResponseSchema: GenMessage<ArchiveTaskResponse> = /*@__PURE__*/
-  messageDesc(file_taskguild_v1_task, 14);
+  messageDesc(file_taskguild_v1_task, 18);
 
 /**
  * @generated from message taskguild.v1.ArchiveTerminalTasksRequest
@@ -457,7 +525,7 @@ export type ArchiveTerminalTasksRequest = Message<"taskguild.v1.ArchiveTerminalT
  * Use `create(ArchiveTerminalTasksRequestSchema)` to create a new message.
  */
 export const ArchiveTerminalTasksRequestSchema: GenMessage<ArchiveTerminalTasksRequest> = /*@__PURE__*/
-  messageDesc(file_taskguild_v1_task, 15);
+  messageDesc(file_taskguild_v1_task, 19);
 
 /**
  * @generated from message taskguild.v1.ArchiveTerminalTasksResponse
@@ -483,7 +551,7 @@ export type ArchiveTerminalTasksResponse = Message<"taskguild.v1.ArchiveTerminal
  * Use `create(ArchiveTerminalTasksResponseSchema)` to create a new message.
  */
 export const ArchiveTerminalTasksResponseSchema: GenMessage<ArchiveTerminalTasksResponse> = /*@__PURE__*/
-  messageDesc(file_taskguild_v1_task, 16);
+  messageDesc(file_taskguild_v1_task, 20);
 
 /**
  * @generated from message taskguild.v1.UnarchiveTaskRequest
@@ -500,7 +568,7 @@ export type UnarchiveTaskRequest = Message<"taskguild.v1.UnarchiveTaskRequest"> 
  * Use `create(UnarchiveTaskRequestSchema)` to create a new message.
  */
 export const UnarchiveTaskRequestSchema: GenMessage<UnarchiveTaskRequest> = /*@__PURE__*/
-  messageDesc(file_taskguild_v1_task, 17);
+  messageDesc(file_taskguild_v1_task, 21);
 
 /**
  * @generated from message taskguild.v1.UnarchiveTaskResponse
@@ -517,7 +585,7 @@ export type UnarchiveTaskResponse = Message<"taskguild.v1.UnarchiveTaskResponse"
  * Use `create(UnarchiveTaskResponseSchema)` to create a new message.
  */
 export const UnarchiveTaskResponseSchema: GenMessage<UnarchiveTaskResponse> = /*@__PURE__*/
-  messageDesc(file_taskguild_v1_task, 18);
+  messageDesc(file_taskguild_v1_task, 22);
 
 /**
  * @generated from message taskguild.v1.ListArchivedTasksRequest
@@ -544,7 +612,7 @@ export type ListArchivedTasksRequest = Message<"taskguild.v1.ListArchivedTasksRe
  * Use `create(ListArchivedTasksRequestSchema)` to create a new message.
  */
 export const ListArchivedTasksRequestSchema: GenMessage<ListArchivedTasksRequest> = /*@__PURE__*/
-  messageDesc(file_taskguild_v1_task, 19);
+  messageDesc(file_taskguild_v1_task, 23);
 
 /**
  * @generated from message taskguild.v1.ListArchivedTasksResponse
@@ -566,7 +634,7 @@ export type ListArchivedTasksResponse = Message<"taskguild.v1.ListArchivedTasksR
  * Use `create(ListArchivedTasksResponseSchema)` to create a new message.
  */
 export const ListArchivedTasksResponseSchema: GenMessage<ListArchivedTasksResponse> = /*@__PURE__*/
-  messageDesc(file_taskguild_v1_task, 20);
+  messageDesc(file_taskguild_v1_task, 24);
 
 /**
  * @generated from enum taskguild.v1.TaskAssignmentStatus
@@ -650,6 +718,24 @@ export const TaskService: GenService<{
     methodKind: "unary";
     input: typeof UpdateTaskStatusRequestSchema;
     output: typeof UpdateTaskStatusResponseSchema;
+  },
+  /**
+   * Task lifecycle control
+   *
+   * @generated from rpc taskguild.v1.TaskService.StopTask
+   */
+  stopTask: {
+    methodKind: "unary";
+    input: typeof StopTaskRequestSchema;
+    output: typeof StopTaskResponseSchema;
+  },
+  /**
+   * @generated from rpc taskguild.v1.TaskService.ResumeTask
+   */
+  resumeTask: {
+    methodKind: "unary";
+    input: typeof ResumeTaskRequestSchema;
+    output: typeof ResumeTaskResponseSchema;
   },
   /**
    * Archive operations

--- a/proto/taskguild/v1/task.proto
+++ b/proto/taskguild/v1/task.proto
@@ -20,6 +20,10 @@ service TaskService {
   rpc DeleteTask(DeleteTaskRequest) returns (DeleteTaskResponse);
   rpc UpdateTaskStatus(UpdateTaskStatusRequest) returns (UpdateTaskStatusResponse);
 
+  // Task lifecycle control
+  rpc StopTask(StopTaskRequest) returns (StopTaskResponse);
+  rpc ResumeTask(ResumeTaskRequest) returns (ResumeTaskResponse);
+
   // Archive operations
   rpc ArchiveTask(ArchiveTaskRequest) returns (ArchiveTaskResponse);
   rpc ArchiveTerminalTasks(ArchiveTerminalTasksRequest) returns (ArchiveTerminalTasksResponse);
@@ -129,6 +133,22 @@ message UpdateTaskStatusRequest {
   bool force = 3;
 }
 message UpdateTaskStatusResponse {
+  Task task = 1;
+}
+
+// Task lifecycle control
+
+message StopTaskRequest {
+  string id = 1;
+}
+message StopTaskResponse {
+  Task task = 1;
+}
+
+message ResumeTaskRequest {
+  string id = 1;
+}
+message ResumeTaskResponse {
   Task task = 1;
 }
 


### PR DESCRIPTION
## Summary
- Add stop and resume buttons to the task UI for controlling running agent tasks
- Add `StopTask` and `ResumeTask` RPCs to the task service proto and backend implementation
- Wire up agent manager to handle task stop/resume lifecycle

## Test plan
- [ ] Verify stop button appears on running tasks and stops the agent
- [ ] Verify resume button appears on stopped tasks and resumes the agent
- [ ] Verify task state transitions correctly between running/stopped states

🤖 Generated with [Claude Code](https://claude.com/claude-code)