### PR TITLE
fix: cancel transport context after ResultMessage to prevent post-completion hang

### DIFF
--- a/cmd/taskguild-agent/cmdlog.go
+++ b/cmd/taskguild-agent/cmdlog.go
@@ -219,9 +219,14 @@ func runQuerySyncWithLog(
 		opts.PermissionPromptToolName = "stdio"
 	}
 
+	// Create a cancellable context for the subprocess so we can terminate
+	// it promptly once the ResultMessage has been received.
+	transportCtx, transportCancel := context.WithCancel(ctx)
+	defer transportCancel()
+
 	// Create and connect the subprocess transport.
 	transport := claudeagent.NewSubprocessTransport("", opts)
-	if err := transport.Connect(ctx); err != nil {
+	if err := transport.Connect(transportCtx); err != nil {
 		return nil, err
 	}
 	defer transport.Close()
@@ -338,6 +343,10 @@ func runQuerySyncWithLog(
 					transport.EndInput()
 					stdinClosed = true
 				}
+				// Cancel the transport context so the subprocess is terminated
+				// promptly. Without this, the deferred transport.Close() may
+				// block indefinitely waiting for the process to exit on its own.
+				transportCancel()
 				tl.LogResult(result.Result, nil)
 				return result, nil
 			}


### PR DESCRIPTION
## Summary
- After receiving a ResultMessage from Claude CLI, `runQuerySyncWithLog` returns but the deferred `query.Close()` / `transport.Close()` may block indefinitely waiting for the subprocess to exit
- This prevents post-completion logic (TURN_END logging, status transitions, hooks) from executing, leaving tasks permanently stuck in "assigned" / "Develop" state
- Fix: create a dedicated `transportCtx` for the subprocess and cancel it immediately after receiving the ResultMessage, causing `exec.CommandContext` to kill the process and unblock all deferred cleanup

## Root cause
`transport.Connect(ctx)` uses `exec.CommandContext(ctx, ...)` to start the Claude process. The passed `ctx` is the outer task context which is never cancelled after result receipt. When the Claude process doesn't exit promptly after outputting the ResultMessage, `transport.Close()` blocks on `cmd.Wait()`, preventing `runQuerySyncWithLog` from returning to the caller.

## Test plan
- [ ] Build passes (`go build ./cmd/taskguild-agent/`)
- [ ] Run a task end-to-end and verify status transitions complete after Claude finishes
- [ ] Verify task logs show TURN_END and NEXT_STATUS directive entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)