### PR TITLE
fix: include transition ID in retry prompt to match test expectations

### DIFF
--- a/cmd/taskguild-agent/directive.go
+++ b/cmd/taskguild-agent/directive.go
@@ -353,7 +353,7 @@ func buildTransitionRetryPrompt(failedStatusID string, metadata map[string]strin
 	if err == nil && len(transitions) > 0 {
 		sb.WriteString("Valid transitions are:\n")
 		for _, t := range transitions {
-			sb.WriteString(fmt.Sprintf("- %s\n", t.Name))
+			sb.WriteString(fmt.Sprintf("- %s (%s)\n", t.Name, t.ID))
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Fixed `buildTransitionRetryPrompt` to include transition ID alongside the name in the retry prompt format (`- Name (ID)`)
- This aligns the implementation with test expectations

## Test plan
- [x] Existing tests pass with the updated format

🤖 Generated with [Claude Code](https://claude.com/claude-code)