### PR TITLE
fix: include transition ID in retry prompt for better debugging

### DIFF
--- a/cmd/taskguild-agent/directive.go
+++ b/cmd/taskguild-agent/directive.go
@@ -353,7 +353,7 @@ func buildTransitionRetryPrompt(failedStatusID string, metadata map[string]strin
 	if err == nil && len(transitions) > 0 {
 		sb.WriteString("Valid transitions are:\n")
 		for _, t := range transitions {
-			sb.WriteString(fmt.Sprintf("- %s\n", t.Name))
+			sb.WriteString(fmt.Sprintf("- %s (%s)\n", t.Name, t.ID))
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Include transition ID alongside transition name in the retry prompt (`buildTransitionRetryPrompt`)
- Changes format from `- TransitionName` to `- TransitionName (TransitionID)` for valid transitions listing
- Helps match test expectations and improves debuggability when transitions fail

## Test plan
- [ ] Verify retry prompt includes transition IDs in the valid transitions list
- [ ] Confirm existing tests pass with the updated format

🤖 Generated with [Claude Code](https://claude.com/claude-code)