### PR TITLE
Fix plan_result extraction from ExitPlanMode JSON response

### DIFF
--- a/cmd/taskguild-agent/toolhooks.go
+++ b/cmd/taskguild-agent/toolhooks.go
@@ -43,7 +43,17 @@ func buildToolUseHooks(tl *taskLogger, taskID string, taskClient taskguildv1conn
 							var planContent string
 							if input.ToolResponse != nil {
 								if s, ok := input.ToolResponse.(string); ok {
-									planContent = s
+									// Try to parse as JSON and extract the "plan" field.
+									var obj map[string]interface{}
+									if json.Unmarshal([]byte(s), &obj) == nil {
+										if plan, ok := obj["plan"].(string); ok {
+											planContent = plan
+										} else {
+											planContent = s
+										}
+									} else {
+										planContent = s
+									}
 								} else if m, ok := input.ToolResponse.(map[string]interface{}); ok {
 									if plan, ok := m["plan"].(string); ok {
 										planContent = plan

--- a/frontend/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/frontend/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -266,7 +266,20 @@ function TaskDetailPage() {
 
   const metadata = task.metadata ?? {}
   const resultSummary = metadata['result_summary'] ?? ''
-  const planResult = metadata['plan_result'] ?? ''
+  const rawPlanResult = metadata['plan_result'] ?? ''
+  // Handle legacy plan_result that may be stored as JSON with a "plan" field
+  const planResult = (() => {
+    if (!rawPlanResult) return ''
+    try {
+      const parsed = JSON.parse(rawPlanResult)
+      if (typeof parsed === 'object' && parsed !== null && typeof parsed.plan === 'string') {
+        return parsed.plan
+      }
+    } catch {
+      // Not JSON, use as-is (already markdown)
+    }
+    return rawPlanResult
+  })()
   const metadataEntries = Object.entries(metadata).filter(([key, v]) => v && key !== 'result_summary' && key !== 'result_status' && key !== 'result_error' && key !== 'plan_result')
 
   return (


### PR DESCRIPTION
## Summary
- **Backend**: Fix `toolhooks.go` to extract the `plan` field when `ExitPlanMode` tool response is a JSON string (not just a parsed map), preventing raw JSON from being stored as plan_result
- **Frontend**: Handle legacy `plan_result` metadata that was stored as JSON with a `plan` field, parsing it correctly for markdown display

## Test plan
- [ ] Verify new ExitPlanMode responses correctly extract the plan text in the backend
- [ ] Verify legacy plan_result values stored as JSON `{"plan": "..."}` render correctly in the frontend
- [ ] Verify plain markdown plan_result values still display correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)