### PR TITLE
fix: prevent transport.Close() from blocking on subprocess cleanup

### DIFF
--- a/cmd/taskguild-agent/cmdlog.go
+++ b/cmd/taskguild-agent/cmdlog.go
@@ -344,21 +344,19 @@ func runQuerySyncWithLog(
 					transport.EndInput()
 					stdinClosed = true
 				}
-				slog.Info("EndInput completed, cancelling transport context")
-				// Cancel the transport context and close the transport to
-				// terminate the subprocess and close its stdout pipe.
-				// Without this, the deferred query.Close() deadlocks:
-				// it waits for readMessages goroutine which is blocked on
-				// scanner.Scan() reading from the still-open stdout pipe.
-				// exec.CommandContext kills the process on cancel but does
-				// NOT close the pipe, so we must call transport.Close()
-				// explicitly to unblock the scanner.
-				transportCancel()
-				slog.Info("transport context cancelled, closing transport")
+				// Close the transport to terminate the subprocess and
+				// unblock any goroutine reading from the stdout pipe.
+				// transport.Close() closes pipes first (unblocking the
+				// scanner), then kills the process group, then waits.
+				// We intentionally do NOT call transportCancel() before
+				// Close(): exec.CommandContext's internal kill only targets
+				// the main process PID, leaving child processes (and their
+				// inherited pipe handles) alive. This races with Close()'s
+				// process-group kill and can cause cmd.Wait() to block.
+				slog.Info("closing transport")
 				transport.Close()
 				slog.Info("transport closed, logging result")
 				tl.LogResult(result.Result, nil)
-				slog.Info("result logged, returning")
 				return result, nil
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/fatih/color v1.15.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-chi/chi/v5 v5.2.2
-	github.com/kazz187/claude-agent-sdk-go v0.0.13
+	github.com/kazz187/claude-agent-sdk-go v0.0.14
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbc
 github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/kazz187/claude-agent-sdk-go v0.0.13 h1:xtyYyqS0fN93kOaVI5tCkBqnhr9RmG8jKtyfNM03w+g=
 github.com/kazz187/claude-agent-sdk-go v0.0.13/go.mod h1:avEQx0oBuhHXKd3LYfnFfT5DXrBOmTK0iEFyUzRlQss=
+github.com/kazz187/claude-agent-sdk-go v0.0.14 h1:S5xglW8Pbs6+SnnBdlpfLAEor4BlxzmfqvF8Y660/OA=
+github.com/kazz187/claude-agent-sdk-go v0.0.14/go.mod h1:avEQx0oBuhHXKd3LYfnFfT5DXrBOmTK0iEFyUzRlQss=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=


### PR DESCRIPTION
## Summary
- `runQuerySyncWithLog` が ResultMessage 受信後に `transportCancel()` → `transport.Close()` の順で呼んでいたが、`exec.CommandContext` の内部 Kill がメインプロセスにしか SIGKILL を送らず、子プロセスが stdout パイプを保持し続けることで `cmd.Wait()` がブロックする問題を修正
- `transportCancel()` の呼び出しを削除し、`transport.Close()` のみでプロセスグループごとクリーンに終了するように変更
- `claude-agent-sdk-go` を v0.0.14 に更新（`Close()` で stdout パイプを先に閉じるよう修正済み）

## Test plan
- [x] `go build ./cmd/taskguild-agent/` ビルド成功
- [x] `go test ./cmd/taskguild-agent/...` 全テスト合格
- [x] エージェント再起動後、translate_slug が正常に完了しタスクが進行することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)