### PR TITLE
fix: prevent transport.Close() blocking and improve process group cleanup

### DIFF
--- a/cmd/taskguild-agent/cmdlog.go
+++ b/cmd/taskguild-agent/cmdlog.go
@@ -344,17 +344,22 @@ func runQuerySyncWithLog(
 					transport.EndInput()
 					stdinClosed = true
 				}
-				slog.Info("EndInput completed, cancelling transport context")
-				// Cancel the transport context and close the transport to
-				// terminate the subprocess and close its stdout pipe.
+				slog.Info("EndInput completed, closing transport")
+				// Close the transport to terminate the subprocess and its
+				// process group, then close its stdout pipe.
 				// Without this, the deferred query.Close() deadlocks:
 				// it waits for readMessages goroutine which is blocked on
 				// scanner.Scan() reading from the still-open stdout pipe.
-				// exec.CommandContext kills the process on cancel but does
-				// NOT close the pipe, so we must call transport.Close()
-				// explicitly to unblock the scanner.
-				transportCancel()
-				slog.Info("transport context cancelled, closing transport")
+				//
+				// We intentionally do NOT call transportCancel() before
+				// transport.Close(). Cancelling the context triggers
+				// exec.CommandContext's internal kill which only sends
+				// SIGKILL to the main PID — grandchild processes (in their
+				// own session via Setsid) survive and keep the stdout pipe
+				// open, causing cmd.Wait() inside Close() to block.
+				// transport.Close() handles the full cleanup correctly:
+				// it kills the entire process group and waits with a
+				// SIGKILL fallback timeout.
 				transport.Close()
 				slog.Info("transport closed, logging result")
 				tl.LogResult(result.Result, nil)

--- a/cmd/taskguild-agent/run.go
+++ b/cmd/taskguild-agent/run.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -148,14 +149,21 @@ func runAgent() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Handle OS signals
+	// Handle OS signals (including SIGABRT for diagnostics).
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGABRT)
 	var sigWg conc.WaitGroup
 	sigWg.Go(func() {
 		select {
 		case sig := <-sigCh:
-			slog.Info("received signal, shutting down", "signal", sig)
+			if sig == syscall.SIGABRT {
+				slog.Error("received SIGABRT, initiating shutdown",
+					"signal", sig,
+					"num_goroutines", runtime.NumGoroutine(),
+				)
+			} else {
+				slog.Info("received signal, shutting down", "signal", sig)
+			}
 			cancel()
 		case <-ctx.Done():
 		}

--- a/pkg/sentinel/sentinel.go
+++ b/pkg/sentinel/sentinel.go
@@ -236,7 +236,22 @@ func (s *Sentinel) startChild() (*exec.Cmd, error) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	// Child inherits environment (env vars like TASKGUILD_*).
-	cmd.Env = os.Environ()
+	// Ensure GOTRACEBACK=all so crash dumps include all goroutines for diagnostics.
+	env := os.Environ()
+	hasGotraceback := false
+	for _, e := range env {
+		if strings.HasPrefix(e, "GOTRACEBACK=") {
+			hasGotraceback = true
+			break
+		}
+	}
+	if !hasGotraceback {
+		env = append(env, "GOTRACEBACK=all")
+	}
+	cmd.Env = env
+	// Start child in its own process group so stray signals sent to the
+	// sentinel's group don't accidentally reach the child.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("exec %s run: %w", s.binaryPath, err)

--- a/pkg/sentinel/sentinel.go
+++ b/pkg/sentinel/sentinel.go
@@ -282,9 +282,12 @@ func (s *Sentinel) stopChild(cmd *exec.Cmd) {
 		time.Sleep(GracePeriod)
 		// Check if process is still alive by trying to signal it.
 		if err := cmd.Process.Signal(syscall.Signal(0)); err == nil {
-			slog.Warn("grace period expired, sending SIGKILL to child", "pid", pid)
-			if err := cmd.Process.Kill(); err != nil {
-				slog.Error("failed to send SIGKILL", "pid", pid, "error", err)
+			slog.Warn("grace period expired, sending SIGKILL to child process group", "pid", pid)
+			// Kill the entire process group (pgid == pid because Setpgid is set).
+			// This ensures any child processes that haven't been cleaned up
+			// are also terminated (e.g. git commands, other non-session subprocesses).
+			if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil {
+				slog.Error("failed to send SIGKILL to process group", "pid", pid, "error", err)
 			}
 		}
 	})


### PR DESCRIPTION
## Summary
- **Fix transport.Close() deadlock**: Remove `transportCancel()` call before `transport.Close()` in cmdlog.go. Context cancellation triggered `exec.CommandContext`'s internal kill which only sent SIGKILL to the main PID, leaving grandchild processes (in their own session via Setsid) alive and keeping the stdout pipe open, causing `cmd.Wait()` to block indefinitely.
- **Improve SIGABRT handling**: Catch SIGABRT in the agent's signal handler to initiate graceful shutdown instead of crashing, with diagnostic logging (goroutine count).
- **Add GOTRACEBACK=all to child env**: Sentinel now ensures `GOTRACEBACK=all` is set for child processes so crash dumps include all goroutines for diagnostics.
- **Isolate child process group**: Sentinel starts children with `Setpgid: true` so stray signals sent to the sentinel's process group don't accidentally reach the child.
- **Kill entire process group on timeout**: Sentinel's `stopChild` now sends SIGKILL to the entire process group (`-pid`) instead of just the main process, ensuring leaked child processes are also terminated.

## Test plan
- [ ] Verify agent shuts down cleanly when transport subprocess hangs
- [ ] Verify SIGABRT is caught and logged with goroutine count
- [ ] Verify child processes are fully cleaned up on sentinel stop (no orphaned processes)
- [ ] Verify `GOTRACEBACK=all` is present in child environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)