### PR TITLE
Fix stop button to immediately update task status

### DIFF
--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -122,6 +122,19 @@ func runTask(
 	}
 	defer afterHooks()
 
+	// Defense-in-depth: if context is cancelled (e.g. user stop), report
+	// the cancellation with a fresh context so the RPC can still succeed.
+	// This defer runs after afterHooks (LIFO) but before tl.Close.
+	defer func() {
+		if ctx.Err() == context.Canceled {
+			bgCtx, bgCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer bgCancel()
+			reportTaskResult(bgCtx, client, taskID, "", "stopped by user")
+			reportAgentStatus(bgCtx, client, agentManagerID, taskID,
+				v1.AgentStatus_AGENT_STATUS_IDLE, "stopped by user")
+		}
+	}()
+
 	// Execute before_task_execution hooks.
 	logger.Info("executing before_task_execution hooks")
 	executeHooks(ctx, taskID, "before_task_execution", metadata, workDir, taskClient, tl, queryRunner)

--- a/internal/agentmanager/task_handler.go
+++ b/internal/agentmanager/task_handler.go
@@ -303,6 +303,27 @@ func (s *Server) ReportTaskResult(ctx context.Context, req *connect.Request[task
 		return nil, err
 	}
 
+	// If the task is already unassigned (e.g. stopped by user via StopTask),
+	// just update metadata without triggering retry logic.
+	if t.AssignmentStatus == task.AssignmentStatusUnassigned && t.AssignedAgentID == "" {
+		if t.Metadata == nil {
+			t.Metadata = make(map[string]string)
+		}
+		if req.Msg.Summary != "" {
+			t.Metadata["result_summary"] = req.Msg.Summary
+		}
+		if req.Msg.ErrorMessage != "" {
+			t.Metadata["result_error"] = req.Msg.ErrorMessage
+		}
+		delete(t.Metadata, "_stopped_by_user")
+		t.UpdatedAt = time.Now()
+		if err := s.taskRepo.Update(ctx, t); err != nil {
+			return nil, err
+		}
+		slog.Info("task already unassigned, updated metadata only", "task_id", t.ID)
+		return connect.NewResponse(&taskguildv1.ReportTaskResultResponse{}), nil
+	}
+
 	// Clear assigned agent.
 	t.AssignedAgentID = ""
 	t.UpdatedAt = time.Now()

--- a/internal/task/server.go
+++ b/internal/task/server.go
@@ -347,16 +347,23 @@ func (s *Server) StopTask(ctx context.Context, req *connect.Request[taskguildv1.
 		t.Metadata = make(map[string]string)
 	}
 	t.Metadata["_stopped_by_user"] = "true"
+
+	// Save agent ID before clearing — needed for the cancel command.
+	agentID := t.AssignedAgentID
+
+	// Immediately mark as unassigned so the UI updates right away.
+	t.AssignmentStatus = AssignmentStatusUnassigned
+	t.AssignedAgentID = ""
 	t.UpdatedAt = time.Now()
 	if err := s.repo.Update(ctx, t); err != nil {
 		return nil, err
 	}
 
-	// Send cancel command to the agent.
-	if err := s.stopper.RequestTaskStop(t.ID, t.AssignedAgentID); err != nil {
+	// Send cancel command to the agent (best-effort cleanup).
+	if err := s.stopper.RequestTaskStop(t.ID, agentID); err != nil {
 		slog.Warn("failed to send stop command to agent",
 			"task_id", t.ID,
-			"agent_id", t.AssignedAgentID,
+			"agent_id", agentID,
 			"error", err,
 		)
 	}


### PR DESCRIPTION
## Summary
- **StopTask**: Immediately sets task status to `UNASSIGNED` and clears `AssignedAgentID` in `StopTask` so the UI reflects the stopped state right away, instead of waiting for the agent to report back.
- **ReportTaskResult**: Adds an early-return path when a task is already unassigned (stopped by user), updating only metadata without triggering retry logic.
- **Agent runner**: Adds a deferred cleanup that uses a fresh `context.Background()` to report cancellation status even after the parent context is cancelled, ensuring the agent properly transitions to idle.

## Test plan
- [ ] Stop a running task via the UI and verify the task status updates to UNASSIGNED immediately
- [ ] Verify the agent transitions to IDLE after the stop
- [ ] Confirm that normal task completion (without stop) still works correctly
- [ ] Verify no duplicate status updates or race conditions when stop and completion overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)