### PR TITLE
fix: skip auto-transition in plan mode for interactive architect sessions

### DIFF
--- a/cmd/taskguild-agent/prompt.go
+++ b/cmd/taskguild-agent/prompt.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	claudeagent "github.com/kazz187/claude-agent-sdk-go"
 )
 
 // buildUserPrompt constructs the user prompt from enriched metadata.
@@ -109,9 +111,16 @@ func buildUserPrompt(metadata map[string]string, workDir string) string {
 	}
 
 	sb.WriteString("\n## Interactive Session\n")
-	sb.WriteString("You are in an interactive session. ")
-	sb.WriteString("If you need user input, approval, or clarification, ")
-	sb.WriteString("clearly state what you need. You will receive a response and can continue.\n")
+	if metadata["_permission_mode"] == string(claudeagent.PermissionModePlan) {
+		sb.WriteString("You are in plan mode — an interactive planning session with the user. ")
+		sb.WriteString("Your role is to explore the codebase, analyze requirements, and propose a detailed implementation plan. ")
+		sb.WriteString("Do NOT output NEXT_STATUS until the user explicitly confirms the plan is ready to proceed. ")
+		sb.WriteString("Present your plan clearly and ask the user for feedback or approval before transitioning.\n")
+	} else {
+		sb.WriteString("You are in an interactive session. ")
+		sb.WriteString("If you need user input, approval, or clarification, ")
+		sb.WriteString("clearly state what you need. You will receive a response and can continue.\n")
+	}
 	sb.WriteString("When the task is fully complete, output NEXT_STATUS on the last line.\n")
 
 	return sb.String()

--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -448,8 +448,11 @@ func runTask(
 		}
 
 		// No NEXT_STATUS output but transitions exist — try auto-transition
-		// if exactly one transition is available.
-		if transitions, err := parseAvailableTransitions(metadata); err == nil && len(transitions) == 1 {
+		// if exactly one transition is available. Skip for plan mode so
+		// the user can review and interact before transitioning.
+		if metadata["_permission_mode"] == string(claudeagent.PermissionModePlan) {
+			logger.Info("skipping auto-transition (plan mode)", "turn", turn)
+		} else if transitions, err := parseAvailableTransitions(metadata); err == nil && len(transitions) == 1 {
 			autoName := transitions[0].Name
 			logger.Info("no NEXT_STATUS output, auto-transitioning (single transition available)",
 				"next_status_name", autoName, "turn", turn)


### PR DESCRIPTION
## Summary
- Skip auto-transition when the agent is in plan mode (`PermissionModePlan`) so the architect agent can interact with the user before transitioning to the next status
- Update the interactive session prompt in plan mode to instruct the agent to explore, analyze, and propose a plan — waiting for explicit user confirmation before proceeding
- Import `claude-agent-sdk-go` in `prompt.go` to reference `PermissionModePlan` constant

## Test plan
- [ ] Verify that in plan mode, the agent does not auto-transition after a turn without `NEXT_STATUS`
- [ ] Verify that in non-plan mode, the existing auto-transition behavior (single transition) still works
- [ ] Verify that the plan mode prompt correctly instructs the agent to wait for user approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)