### PR TITLE
feat: launch agent on user comment for idle tasks

### DIFF
--- a/internal/agentmanager/task_handler.go
+++ b/internal/agentmanager/task_handler.go
@@ -251,10 +251,10 @@ func (s *Server) sendPendingTasksToStream(ctx context.Context, projectName strin
 			wfCache[t.WorkflowID] = wf
 		}
 
+		// agentConfigID may be empty when no agent is configured for the
+		// status (e.g. comment-triggered launch). ClaimTask handles this
+		// gracefully by falling back to a plain agent.
 		agentConfigID := wf.FindAgentIDForStatus(t.StatusID)
-		if agentConfigID == "" {
-			continue // no agent configured for this status
-		}
 
 		cmd := &taskguildv1.AgentCommand{
 			Command: &taskguildv1.AgentCommand_TaskAvailable{

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kazz187/taskguild/internal/agentmanager"
 	"github.com/kazz187/taskguild/internal/eventbus"
+	"github.com/kazz187/taskguild/internal/interaction"
 	"github.com/kazz187/taskguild/internal/project"
 	"github.com/kazz187/taskguild/internal/task"
 	"github.com/kazz187/taskguild/internal/workflow"
@@ -51,6 +52,8 @@ func (o *Orchestrator) Start(ctx context.Context) {
 			case taskguildv1.EventType_EVENT_TYPE_TASK_CREATED,
 				taskguildv1.EventType_EVENT_TYPE_TASK_STATUS_CHANGED:
 				o.handleTaskEvent(ctx, event)
+			case taskguildv1.EventType_EVENT_TYPE_INTERACTION_CREATED:
+				o.handleInteractionCreated(ctx, event)
 			}
 		}
 	}
@@ -105,6 +108,84 @@ func (o *Orchestrator) handleTaskEvent(ctx context.Context, event *taskguildv1.E
 	o.registry.BroadcastCommandToProject(projectName, cmd)
 
 	slog.Info("orchestrator: task available broadcast",
+		"task_id", t.ID,
+		"agent_config_id", agentConfigID,
+		"project_name", projectName,
+	)
+}
+
+// handleInteractionCreated launches an agent when a user comment is added to
+// an unassigned task, so the task is immediately acted on without requiring a
+// manual status change or resume.
+func (o *Orchestrator) handleInteractionCreated(ctx context.Context, event *taskguildv1.Event) {
+	// The event's ResourceId is the interaction ID; task_id is in metadata.
+	taskID := event.Metadata["task_id"]
+	if taskID == "" {
+		return
+	}
+
+	// Only react to user-sent comments, not agent-created interactions
+	// (permission requests, questions, etc.).
+	interProto := interaction.UnmarshalInteractionPayload(event.Payload)
+	if interProto == nil || interProto.Type != taskguildv1.InteractionType_INTERACTION_TYPE_USER_MESSAGE {
+		return
+	}
+
+	t, err := o.taskRepo.Get(ctx, taskID)
+	if err != nil {
+		slog.Error("orchestrator: failed to get task for interaction", "task_id", taskID, "error", err)
+		return
+	}
+
+	// Only launch if the task is idle (unassigned). If it's already PENDING
+	// or ASSIGNED, the running/incoming agent will see the comment.
+	if t.AssignmentStatus != task.AssignmentStatusUnassigned {
+		return
+	}
+
+	// Clear stop/retry metadata for a fresh start (same as ResumeTask).
+	if t.Metadata == nil {
+		t.Metadata = make(map[string]string)
+	}
+	delete(t.Metadata, "_stopped_by_user")
+	delete(t.Metadata, "_retry_count")
+	delete(t.Metadata, "result_error")
+
+	wf, err := o.workflowRepo.Get(ctx, t.WorkflowID)
+	if err != nil {
+		slog.Error("orchestrator: failed to get workflow for interaction", "workflow_id", t.WorkflowID, "error", err)
+		return
+	}
+
+	// agentConfigID may be empty if no agent is configured for this status.
+	// ClaimTask handles this gracefully by falling back to a plain agent.
+	agentConfigID := wf.FindAgentIDForStatus(t.StatusID)
+
+	t.AssignmentStatus = task.AssignmentStatusPending
+	t.UpdatedAt = time.Now()
+	if err := o.taskRepo.Update(ctx, t); err != nil {
+		slog.Error("orchestrator: failed to update task for comment-triggered launch", "task_id", t.ID, "error", err)
+		return
+	}
+
+	var projectName string
+	if p, err := o.projectRepo.Get(ctx, t.ProjectID); err == nil {
+		projectName = p.Name
+	}
+
+	cmd := &taskguildv1.AgentCommand{
+		Command: &taskguildv1.AgentCommand_TaskAvailable{
+			TaskAvailable: &taskguildv1.TaskAvailableCommand{
+				TaskId:        t.ID,
+				AgentConfigId: agentConfigID,
+				Title:         t.Title,
+				Metadata:      t.Metadata,
+			},
+		},
+	}
+	o.registry.BroadcastCommandToProject(projectName, cmd)
+
+	slog.Info("orchestrator: comment-triggered agent launch",
 		"task_id", t.ID,
 		"agent_config_id", agentConfigID,
 		"project_name", projectName,


### PR DESCRIPTION
## Summary
- When a user adds a comment (interaction) to an unassigned/idle task, the orchestrator now automatically launches an agent to handle it — no manual status change or resume required
- Removed the early `continue` in `sendPendingTasksToStream` that skipped tasks with no agent configured for the current status; `ClaimTask` already handles this gracefully by falling back to a plain agent
- Added `handleInteractionCreated` to the orchestrator event loop to listen for `EVENT_TYPE_INTERACTION_CREATED` events

## Test plan
- [ ] Add a comment to an unassigned task and verify an agent is launched automatically
- [ ] Confirm that commenting on an already-assigned task does not spawn a duplicate agent
- [ ] Verify tasks with no agent configured for the current status still get picked up (plain agent fallback)
- [ ] Ensure agent-created interactions (permission requests, questions) do not trigger a re-launch loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)