### PR TITLE
Slim agent prompts and improve debug logging

### DIFF
--- a/cmd/taskguild-agent/cmdlog.go
+++ b/cmd/taskguild-agent/cmdlog.go
@@ -247,6 +247,7 @@ func runQuerySyncWithLog(
 	// Log command args.
 	if args := transport.CommandArgs(); args != nil {
 		tl.LogCommandArgs(args)
+		slog.Debug("claude CLI command", "args", strings.Join(args, " "))
 	}
 
 	// Calculate initialize timeout (matching RunQuery behavior).

--- a/cmd/taskguild-agent/prompt.go
+++ b/cmd/taskguild-agent/prompt.go
@@ -7,11 +7,11 @@ import (
 )
 
 // buildUserPrompt constructs the user prompt from enriched metadata.
+// Keeps only the task content and current status — all boilerplate instructions
+// live in the system prompt (buildWorkflowContext).
 func buildUserPrompt(metadata map[string]string, workDir string) string {
 	title := metadata["_task_title"]
 	description := metadata["_task_description"]
-	currentStatusName := metadata["_current_status_name"]
-	transitionsJSON := metadata["_available_transitions"]
 
 	// If no task info in metadata, fall back to prompt or generic message.
 	if title == "" && description == "" {
@@ -22,103 +22,20 @@ func buildUserPrompt(metadata map[string]string, workDir string) string {
 	}
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("# Task: %s\n\n", title))
+	sb.WriteString(fmt.Sprintf("# Task: %s\n", title))
+	if currentStatusName := metadata["_current_status_name"]; currentStatusName != "" {
+		sb.WriteString(fmt.Sprintf("Current status: %s\n", currentStatusName))
+	}
 	if description != "" {
-		sb.WriteString(fmt.Sprintf("## Description\n%s\n\n", description))
+		sb.WriteString(fmt.Sprintf("\n%s\n", description))
 	}
-
-	// Add status transition instructions if transitions are available.
-	if transitionsJSON != "" {
-		type transitionEntry struct {
-			Name string `json:"name"`
-		}
-		var transitions []transitionEntry
-		if err := json.Unmarshal([]byte(transitionsJSON), &transitions); err == nil && len(transitions) > 0 {
-			sb.WriteString("## Status Transition\n")
-			if currentStatusName != "" {
-				sb.WriteString(fmt.Sprintf("Current status: %s\n", currentStatusName))
-			}
-			sb.WriteString("Available next statuses:\n")
-			for _, t := range transitions {
-				sb.WriteString(fmt.Sprintf("- %s\n", t.Name))
-			}
-			sb.WriteString("\nAfter completing the task, output your chosen next status on the last line:\nNEXT_STATUS: <status>\n")
-		}
-	}
-
-	sb.WriteString("\n## Updating Task Description\n")
-	sb.WriteString("You can update the task description at any time by including the following block in your output:\n")
-	sb.WriteString("TASK_DESCRIPTION_START\n")
-	sb.WriteString("Your updated task description here.\n")
-	sb.WriteString("Multiline content is supported.\n")
-	sb.WriteString("TASK_DESCRIPTION_END\n")
-	sb.WriteString("Use this to summarize planning discussions, refine requirements, or document decisions made during the session.\n")
-	sb.WriteString("The description will be saved and visible in the task UI immediately.\n")
-
-	// Add task creation instructions.
-	sb.WriteString("\n## Creating New Tasks\n")
-	sb.WriteString("You can create new tasks by including one or more CREATE_TASK blocks in your output:\n")
-	sb.WriteString("```\n")
-	sb.WriteString("CREATE_TASK_START\n")
-	sb.WriteString("title: Task title (required)\n")
-	sb.WriteString("status: Status name (optional)\n")
-	sb.WriteString("use_worktree: true or false (optional, inherits current task setting)\n")
-	sb.WriteString("worktree: existing-worktree-name (optional)\n")
-	sb.WriteString("\n")
-	sb.WriteString("Task description here.\n")
-	sb.WriteString("Multiple lines supported.\n")
-	sb.WriteString("CREATE_TASK_END\n")
-	sb.WriteString("```\n")
-	sb.WriteString("Headers are key-value pairs parsed until the first empty line. Everything after the empty line is the description.\n")
-
-	// List available workflow statuses if present.
-	if statusesJSON := metadata["_workflow_statuses"]; statusesJSON != "" {
-		type statusEntry struct {
-			Name string `json:"name"`
-		}
-		var statuses []statusEntry
-		if err := json.Unmarshal([]byte(statusesJSON), &statuses); err == nil && len(statuses) > 0 {
-			sb.WriteString("\nAvailable statuses for new tasks:\n")
-			for _, s := range statuses {
-				sb.WriteString(fmt.Sprintf("- %s\n", s.Name))
-			}
-		}
-	}
-
-	// List available worktrees.
-	if worktrees := listLocalWorktrees(workDir); len(worktrees) > 0 {
-		sb.WriteString("\nExisting worktrees:\n")
-		for _, wt := range worktrees {
-			sb.WriteString(fmt.Sprintf("- %s\n", wt))
-		}
-	}
-
-	// Add worktree instructions when the task uses a git worktree.
-	if metadata["_use_worktree"] == "true" {
-		if wt := metadata["worktree"]; wt != "" {
-			sb.WriteString("\n## Git Worktree\n")
-			sb.WriteString("This task uses a git worktree for file isolation.\n")
-			sb.WriteString(fmt.Sprintf("- Worktree branch: `worktree-%s`\n", wt))
-			sb.WriteString(fmt.Sprintf("- Worktree directory: `.claude/worktrees/%s/`\n", wt))
-			sb.WriteString("\nBefore starting work, verify you are on the correct branch:\n")
-			sb.WriteString("```\ngit branch --show-current\n```\n")
-			sb.WriteString(fmt.Sprintf("\nIf you are NOT on branch `worktree-%s`, navigate to the worktree:\n", wt))
-			sb.WriteString(fmt.Sprintf("```\ncd $(git rev-parse --show-toplevel)/.claude/worktrees/%s\n```\n", wt))
-			sb.WriteString("\nAll file modifications and commits must occur within this worktree.\n")
-		}
-	}
-
-	sb.WriteString("\n## Interactive Session\n")
-	sb.WriteString("You are in an interactive session. ")
-	sb.WriteString("If you need user input, approval, or clarification, ")
-	sb.WriteString("clearly state what you need. You will receive a response and can continue.\n")
-	sb.WriteString("When the task is fully complete, output NEXT_STATUS on the last line.\n")
 
 	return sb.String()
 }
 
-// buildWorkflowContext builds a concise workflow context block for the system prompt.
-// Returns "" if no workflow context is available.
+// buildWorkflowContext builds the workflow context block for the system prompt
+// (passed via --append-system-prompt). Contains all TaskGuild operational
+// instructions so the user prompt stays focused on task content.
 func buildWorkflowContext(metadata map[string]string) string {
 	if metadata["_workflow_id"] == "" {
 		return ""
@@ -126,13 +43,13 @@ func buildWorkflowContext(metadata map[string]string) string {
 
 	var sb strings.Builder
 	sb.WriteString("## TaskGuild Workflow Context\n")
-	sb.WriteString("You are an agent in a TaskGuild workflow. Complete your work for the current status, then transition the task forward.\n")
+	sb.WriteString("You are an agent in a TaskGuild workflow.\n")
 
 	if agentName := metadata["_agent_name"]; agentName != "" {
-		sb.WriteString(fmt.Sprintf("@%s.\n", agentName))
+		sb.WriteString(fmt.Sprintf("@\"%s (agent)\"\n", agentName))
 	}
 
-	// List all workflow statuses, marking the current one.
+	// Workflow statuses with current marker.
 	if statusesJSON := metadata["_workflow_statuses"]; statusesJSON != "" {
 		type statusEntry struct {
 			Name string `json:"name"`
@@ -140,32 +57,35 @@ func buildWorkflowContext(metadata map[string]string) string {
 		var statuses []statusEntry
 		if err := json.Unmarshal([]byte(statusesJSON), &statuses); err == nil && len(statuses) > 0 {
 			currentName := metadata["_current_status_name"]
-			sb.WriteString("\n### Workflow Statuses\n")
+			sb.WriteString("\n### Workflow\n")
 			for _, s := range statuses {
-				sb.WriteString(fmt.Sprintf("- %s", s.Name))
 				if s.Name == currentName {
-					sb.WriteString("  <-- current")
+					sb.WriteString(fmt.Sprintf("- **%s** (current)\n", s.Name))
+				} else {
+					sb.WriteString(fmt.Sprintf("- %s\n", s.Name))
 				}
-				sb.WriteString("\n")
 			}
 		}
 	}
 
-	// List available transitions.
+	// Available transitions.
 	if transitionsJSON := metadata["_available_transitions"]; transitionsJSON != "" {
 		type transitionEntry struct {
 			Name string `json:"name"`
 		}
 		var transitions []transitionEntry
 		if err := json.Unmarshal([]byte(transitionsJSON), &transitions); err == nil && len(transitions) > 0 {
-			sb.WriteString("\n### Available Transitions\n")
+			sb.WriteString("\n### Status Transition\n")
+			sb.WriteString("When your work is complete, output on the last line:\n")
+			sb.WriteString("`NEXT_STATUS: <status>`\n")
+			sb.WriteString("Available next statuses:\n")
 			for _, t := range transitions {
 				sb.WriteString(fmt.Sprintf("- %s\n", t.Name))
 			}
 		}
 	}
 
-	// List hooks only if configured.
+	// Hooks.
 	if hooksJSON := metadata["_hooks"]; hooksJSON != "" {
 		type hookEntry struct {
 			Name       string `json:"name"`
@@ -175,12 +95,48 @@ func buildWorkflowContext(metadata map[string]string) string {
 		var hooks []hookEntry
 		if err := json.Unmarshal([]byte(hooksJSON), &hooks); err == nil && len(hooks) > 0 {
 			sb.WriteString("\n### Hooks\n")
-			sb.WriteString("Hooks run automatically for this status:\n")
 			for _, h := range hooks {
 				sb.WriteString(fmt.Sprintf("- %q (%s) — %s\n", h.Name, h.ActionType, h.Trigger))
 			}
 		}
 	}
+
+	// Task description update.
+	sb.WriteString("\n### Updating Task Description\n")
+	sb.WriteString("Include this block in your output to update the task description:\n")
+	sb.WriteString("```\nTASK_DESCRIPTION_START\n<description>\nTASK_DESCRIPTION_END\n```\n")
+
+	// Task creation.
+	sb.WriteString("\n### Creating New Tasks\n")
+	sb.WriteString("```\nCREATE_TASK_START\ntitle: <required>\nstatus: <optional>\nuse_worktree: <optional, true/false>\nworktree: <optional, existing worktree name>\n\n<description>\nCREATE_TASK_END\n```\n")
+
+	// List available statuses for new tasks.
+	if statusesJSON := metadata["_workflow_statuses"]; statusesJSON != "" {
+		type statusEntry struct {
+			Name string `json:"name"`
+		}
+		var statuses []statusEntry
+		if err := json.Unmarshal([]byte(statusesJSON), &statuses); err == nil && len(statuses) > 0 {
+			names := make([]string, len(statuses))
+			for i, s := range statuses {
+				names[i] = s.Name
+			}
+			sb.WriteString(fmt.Sprintf("Available statuses: %s\n", strings.Join(names, ", ")))
+		}
+	}
+
+	// Git worktree.
+	if metadata["_use_worktree"] == "true" {
+		if wt := metadata["worktree"]; wt != "" {
+			sb.WriteString("\n### Git Worktree\n")
+			sb.WriteString(fmt.Sprintf("Branch: `worktree-%s` | Dir: `.claude/worktrees/%s/`\n", wt, wt))
+			sb.WriteString("All file modifications and commits must occur within this worktree.\n")
+		}
+	}
+
+	// Interactive session.
+	sb.WriteString("\n### Interactive Session\n")
+	sb.WriteString("If you need user input or clarification, clearly state what you need and wait for a response.\n")
 
 	return sb.String()
 }

--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -174,7 +173,18 @@ func runTask(
 		logger.Info("starting Claude CLI", "turn", turn, "session_id", sessionID)
 		logger.Debug("Claude SDK input", "turn", turn)
 		if turn == 0 {
-			logger.Debug("system prompt", "prompt", instructions)
+			// Log the actual system prompt from opts (after buildWorkflowContext appends).
+			switch sp := opts.SystemPrompt.(type) {
+			case *claudeagent.SystemPromptPreset:
+				logger.Debug("append-system-prompt", "prompt", sp.Append)
+			case string:
+				logger.Debug("system prompt", "prompt", sp)
+			default:
+				logger.Debug("system prompt", "prompt", fmt.Sprintf("%v", opts.SystemPrompt))
+			}
+			if opts.Agent != "" {
+				logger.Debug("agent", "name", opts.Agent)
+			}
 			logger.Debug("metadata", "metadata", fmt.Sprintf("%v", metadata))
 			logger.Debug("work directory", "work_dir", workDir)
 		}
@@ -589,14 +599,6 @@ func buildClaudeOptions(
 		}
 	} else {
 		opts.SystemPrompt = instructions
-	}
-
-	// Parse and pass sub-agents from metadata.
-	if subAgentsJSON := metadata["_sub_agents"]; subAgentsJSON != "" {
-		var subAgents map[string]*claudeagent.AgentDefinition
-		if err := json.Unmarshal([]byte(subAgentsJSON), &subAgents); err == nil && len(subAgents) > 0 {
-			opts.Agents = subAgents
-		}
 	}
 
 	if sessionID != "" {

--- a/internal/agentmanager/task_handler.go
+++ b/internal/agentmanager/task_handler.go
@@ -736,37 +736,6 @@ func (s *Server) ClaimTask(ctx context.Context, req *connect.Request[taskguildv1
 		}
 	}
 
-	// Build sub-agents from project's Agent definitions.
-	// All agents in the project (except the current one) are passed as sub-agents.
-	if s.agentRepo != nil {
-		agents, _, err := s.agentRepo.List(ctx, t.ProjectID, 100, 0)
-		if err == nil && len(agents) > 0 {
-			type subAgentDef struct {
-				Description string   `json:"description"`
-				Prompt      string   `json:"prompt"`
-				Tools       []string `json:"tools,omitempty"`
-				Model       string   `json:"model,omitempty"`
-			}
-			subAgents := make(map[string]subAgentDef)
-			for _, ag := range agents {
-				if ag.ID == agentConfigID {
-					continue // skip the current agent
-				}
-				subAgents[ag.Name] = subAgentDef{
-					Description: ag.Description,
-					Prompt:      ag.Prompt,
-					Tools:       ag.Tools,
-					Model:       ag.Model,
-				}
-			}
-			if len(subAgents) > 0 {
-				if b, err := json.Marshal(subAgents); err == nil {
-					enrichedMetadata["_sub_agents"] = string(b)
-				}
-			}
-		}
-	}
-
 	// Publish agent assigned event.
 	s.eventBus.PublishNew(
 		taskguildv1.EventType_EVENT_TYPE_AGENT_ASSIGNED,


### PR DESCRIPTION
## Summary
- Move all boilerplate instructions (status transitions, task creation, description updates, worktree, interactive session) from user prompt to system prompt (`--append-system-prompt`), reducing user prompt to task content only
- Eliminate triple-redundant status transition information across user prompt and system prompt
- Replace ineffective `@agentName.` with `@"agentName (agent)"` notation for agent identity
- Remove `_sub_agents` metadata building/consumption (unused overhead)
- Fix debug logging to show actual system prompt values from `opts` instead of pre-append `instructions` variable
- Add CLI command args debug logging from subprocess transport

## Test plan
- [x] `go build ./cmd/taskguild-agent/` passes
- [ ] Verify agent correctly identifies itself with new `@"agent (agent)"` notation
- [ ] Verify user prompt contains only task title, status, and description
- [ ] Verify system prompt contains all operational instructions
- [ ] Verify CLI command args appear in debug logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)