### PR TITLE
feat: seed default workflow, agents, and skills on project creation

### DIFF
--- a/cmd/taskguild-server/run.go
+++ b/cmd/taskguild-server/run.go
@@ -216,7 +216,8 @@ func runServer() {
 	scriptBroker := script.NewScriptExecutionBroker()
 
 	// Setup servers
-	projectServer := project.NewServer(projectRepo)
+	projectSeeder := project.NewSeeder(workflowRepo, agentRepo, skillRepo)
+	projectServer := project.NewServer(projectRepo, projectSeeder)
 	workflowServer := workflow.NewServer(workflowRepo)
 	agentManagerServer := agentmanager.NewServer(agentManagerRegistry, taskRepo, workflowRepo, agentRepo, interactionRepo, projectRepo, skillRepo, scriptRepo, taskLogRepo, permissionRepo, scpRepo, claudeSettingsRepo, bus, scriptBroker)
 	taskServer := task.NewServer(taskRepo, workflowRepo, bus, agentManagerServer, agentManagerServer, taskLogRepo, interactionRepo)

--- a/internal/project/seeder.go
+++ b/internal/project/seeder.go
@@ -1,0 +1,286 @@
+package project
+
+import (
+	"context"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+
+	"github.com/kazz187/taskguild/internal/agent"
+	"github.com/kazz187/taskguild/internal/skill"
+	"github.com/kazz187/taskguild/internal/workflow"
+)
+
+// Seeder creates default workflow, agents, and skills for a newly created project.
+type Seeder struct {
+	workflowRepo workflow.Repository
+	agentRepo    agent.Repository
+	skillRepo    skill.Repository
+}
+
+// NewSeeder creates a new Seeder.
+func NewSeeder(workflowRepo workflow.Repository, agentRepo agent.Repository, skillRepo skill.Repository) *Seeder {
+	return &Seeder{
+		workflowRepo: workflowRepo,
+		agentRepo:    agentRepo,
+		skillRepo:    skillRepo,
+	}
+}
+
+// Seed creates the default development workflow with architect and software-engineer
+// agents, and the create-pr skill for the given project.
+func (s *Seeder) Seed(ctx context.Context, projectID string) error {
+	now := time.Now()
+
+	// 1. Create agents.
+	architectAgent := &agent.Agent{
+		ID:             ulid.Make().String(),
+		ProjectID:      projectID,
+		Name:           "architect",
+		Description:    "system architect",
+		Prompt:         defaultArchitectPrompt,
+		Tools:          []string{"Read", "Glob", "Grep", "WebSearch", "WebFetch", "Task"},
+		Model:          "opus",
+		PermissionMode: "plan",
+		Memory:         "user",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := s.agentRepo.Create(ctx, architectAgent); err != nil {
+		return err
+	}
+
+	swEngineerAgent := &agent.Agent{
+		ID:             ulid.Make().String(),
+		ProjectID:      projectID,
+		Name:           "software-engineer",
+		Description:    "software engineer",
+		Prompt:         defaultSoftwareEngineerPrompt,
+		Tools:          []string{"Read", "Write", "Edit", "Glob", "Grep", "WebSearch", "WebFetch", "Task", "NotebookEdit"},
+		Model:          "opus",
+		PermissionMode: "acceptEdits",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := s.agentRepo.Create(ctx, swEngineerAgent); err != nil {
+		return err
+	}
+
+	// 2. Create create-pr skill.
+	createPRSkill := &skill.Skill{
+		ID:            ulid.Make().String(),
+		ProjectID:     projectID,
+		Name:          "create-pr",
+		Description:   `Use when the user wants to create a pull request or push changes to an existing PR. Examples: "create a PR", "make a pull request", "push changes", "update the PR".`,
+		Content:       defaultCreatePRSkillContent,
+		UserInvocable: true,
+		AllowedTools:  []string{"Bash", "Read", "Grep", "Glob"},
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if err := s.skillRepo.Create(ctx, createPRSkill); err != nil {
+		return err
+	}
+
+	// 3. Create development workflow referencing the created agent and skill IDs.
+	hookID := ulid.Make().String()
+	wf := &workflow.Workflow{
+		ID:        ulid.Make().String(),
+		ProjectID: projectID,
+		Name:      "development",
+		Statuses: []workflow.Status{
+			{
+				Name:                 "Draft",
+				Order:                0,
+				IsInitial:            true,
+				TransitionsTo:        []string{"Plan", "Develop"},
+				EnableAgentMDHarness: true,
+			},
+			{
+				Name:                 "Plan",
+				Order:                1,
+				TransitionsTo:        []string{"Develop"},
+				AgentID:              architectAgent.ID,
+				EnableAgentMDHarness: true,
+				PermissionMode:       "plan",
+			},
+			{
+				Name:          "Develop",
+				Order:         2,
+				TransitionsTo: []string{"Develop", "Review"},
+				AgentID:       swEngineerAgent.ID,
+				Hooks: []workflow.StatusHook{
+					{
+						ID:         hookID,
+						SkillID:    createPRSkill.ID,
+						Trigger:    workflow.HookTriggerAfterTaskExecution,
+						Name:       "create-pr",
+						ActionType: workflow.HookActionTypeSkill,
+						ActionID:   createPRSkill.ID,
+					},
+				},
+				EnableAgentMDHarness: true,
+				PermissionMode:       "acceptEdits",
+			},
+			{
+				Name:                 "Review",
+				Order:                3,
+				TransitionsTo:        []string{"Closed"},
+				EnableAgentMDHarness: true,
+			},
+			{
+				Name:                 "Closed",
+				Order:                4,
+				IsTerminal:           true,
+				TransitionsTo:        []string{},
+				EnableAgentMDHarness: true,
+			},
+		},
+		DefaultUseWorktree: true,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	if err := s.workflowRepo.Create(ctx, wf); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+const defaultArchitectPrompt = `あなたはシステム設計者です。以下の手順でタスクの仕様を策定してください。
+
+## 役割
+
+1. **現状調査**: 既存のコードベースを Read, Glob, Grep で徹底的に調査し、タスクに関連するアーキテクチャ・既存実装を把握する
+2. **仕様の明確化**: ユーザーがタスク概要欄に書いた内容の不明点・曖昧な点を洗い出し、ユーザーに質問して要件を確定させる
+3. **設計の策定**: 変更対象ファイル、実装方針、影響範囲、テスト方針を含む設計をまとめる
+4. **仕様の記録**: 確定した仕様を ` + "`TASK_DESCRIPTION_START`" + ` / ` + "`TASK_DESCRIPTION_END`" + ` ブロックでタスク概要に書き戻す
+
+## 制約
+
+- このエージェントは Plan mode で動作するため、ファイルの編集・作成・コマンド実行はできない。調査と対話に専念すること
+- 仕様が確定しユーザーが承認するまで ` + "`NEXT_STATUS`" + ` を出力しないこと。早期遷移はユーザーとの対話機会を奪う
+- 設計は次のステータス（Develop）の software-engineer エージェントが迷わず実装できる粒度で記述すること
+
+## Lessons Learned
+
+- ユーザーが明示的に承認するまで NEXT_STATUS を出力しないこと。自動遷移により対話機会が失われる。`
+
+const defaultSoftwareEngineerPrompt = `あなたはソフトウェアエンジニアです。タスクの仕様に従いコードを実装してください。
+
+## 役割
+
+1. **仕様の確認**: タスク概要に記載された設計・仕様を熟読し、実装スコープを把握する
+2. **実装**: 変更対象ファイルを特定し、仕様に沿ってコードを追加・修正する。既存コードのスタイル・パターンに合わせること
+3. **テスト**: 既存テストが壊れていないことを確認し、必要に応じてテストを追加する
+
+## 制約
+
+- 仕様に記載されていない範囲の変更（リファクタリング、機能追加等）は行わないこと
+- 実装完了後、` + "`NEXT_STATUS: Review`" + ` を出力して次のステータスに遷移すること`
+
+const defaultCreatePRSkillContent = `# Create PR / Push to Existing PR
+
+PRの作成、または既存PRへの差分pushを行うスキルです。
+
+## 手順
+
+### 1. 現在の状態を確認する
+
+以下のコマンドを**並列で**実行して現在の状態を把握してください:
+
+- ` + "`git status`" + ` — 未コミットの変更がないか確認
+- ` + "`git branch --show-current`" + ` — 現在のブランチ名を取得
+- ` + "`gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'`" + ` — リポジトリのデフォルトブランチ名を取得
+- ` + "`git log --oneline -5`" + ` — 直近のコミット履歴を確認
+
+以降、取得したデフォルトブランチ名を ` + "`<default-branch>`" + ` と表記します。
+
+### 2. ブランチの確認
+
+現在のブランチが ` + "`<default-branch>`" + ` の場合は、PRを作成できません。エラーとして報告し、処理を終了してください。
+
+### 3. 未コミットの変更がある場合 → コミットする
+
+` + "`git status`" + ` で未コミットの変更（unstaged / staged / untracked）がある場合は、コミットしてください。
+
+1. 変更内容を確認する:
+   ` + "```bash" + `
+   git diff
+   git diff --staged
+   ` + "```" + `
+2. 変更内容を分析し、適切なコミットメッセージを作成する:
+   - 変更の性質を要約する（新機能、バグ修正、リファクタリングなど）
+   - "why" を重視した簡潔な1-2文のメッセージにする
+3. コミット対象のファイルを選別する:
+   - ` + "`.env`" + `、クレデンシャル、シークレットを含むファイルは除外すること
+   - ビルド生成物やキャッシュファイル（` + "`node_modules/`" + `, ` + "`dist/`" + `, ` + "`*.pyc`" + ` 等）は除外すること
+   - 判断に迷うファイルがある場合は ` + "`.gitignore`" + ` を確認すること
+4. ステージングしてコミットする:
+   ` + "```bash" + `
+   git add <対象ファイル...>
+   git commit -m "コミットメッセージ"
+   ` + "```" + `
+
+### 4. リモートにpushする
+
+ローカルのコミットをリモートにpushします。upstream が未設定の場合があるため、常に以下のコマンドを使用してください:
+
+` + "```bash" + `
+git push -u origin HEAD
+` + "```" + `
+
+### 5. 既存PRの状態を確認する
+
+現在のブランチに紐づくPRがあるか確認してください:
+
+` + "```bash" + `
+gh pr view --json number,title,url,state 2>/dev/null
+` + "```" + `
+
+結果に応じて以下に分岐します:
+
+- **PRが存在し ` + "`state`" + ` が ` + "`OPEN`" + `** → 5A へ
+- **PRが存在し ` + "`state`" + ` が ` + "`MERGED`" + ` または ` + "`CLOSED`" + `** → 5B へ（新規PRを作成）
+- **PRが存在しない**（コマンドがエラー） → 5B へ（新規PRを作成）
+
+### 5A. 既存のオープンPRがある場合
+
+ステップ4で既にpush済みなので、PRのURLを出力してください:
+
+` + "```" + `
+TASK_METADATA: pr_url=<PRのURL>
+` + "```" + `
+
+### 5B. 新規PRを作成する
+
+以下の手順で新しいPRを作成します:
+
+1. デフォルトブランチとの差分を確認:
+   ` + "```bash" + `
+   git log <default-branch>..HEAD --oneline
+   ` + "```" + `
+
+2. 差分の内容を分析し、PRのタイトルとサマリーを作成する:
+   - タイトルは70文字以内で簡潔に。英語で記述すること
+   - サマリーには変更の要点をbullet pointsで記述
+
+3. PRを作成する:
+   ` + "```bash" + `
+   gh pr create --title "PRタイトル" --body "$(cat <<'EOF'
+   ## Summary
+   - 変更点1
+   - 変更点2
+   EOF
+   )"
+   ` + "```" + `
+
+4. 作成されたPRのURLを出力する:
+   ` + "```" + `
+   TASK_METADATA: pr_url=<PRのURL>
+   ` + "```" + `
+
+### 禁止事項
+
+- ` + "`git push --force`" + ` および ` + "`git push --force-with-lease`" + ` は絶対に行わないこと
+- コミットメッセージやPRの body に機密情報を含めないこと`

--- a/internal/project/server.go
+++ b/internal/project/server.go
@@ -15,11 +15,12 @@ import (
 var _ taskguildv1connect.ProjectServiceHandler = (*Server)(nil)
 
 type Server struct {
-	repo Repository
+	repo   Repository
+	seeder *Seeder
 }
 
-func NewServer(repo Repository) *Server {
-	return &Server{repo: repo}
+func NewServer(repo Repository, seeder *Seeder) *Server {
+	return &Server{repo: repo, seeder: seeder}
 }
 
 func (s *Server) CreateProject(ctx context.Context, req *connect.Request[taskguildv1.CreateProjectRequest]) (*connect.Response[taskguildv1.CreateProjectResponse], error) {
@@ -49,6 +50,16 @@ func (s *Server) CreateProject(ctx context.Context, req *connect.Request[taskgui
 	if err := s.repo.Create(ctx, p); err != nil {
 		return nil, err
 	}
+
+	// Seed default workflow, agents, and skills for the new project.
+	if s.seeder != nil {
+		if err := s.seeder.Seed(ctx, p.ID); err != nil {
+			// Clean up the project if seeding fails.
+			_ = s.repo.Delete(ctx, p.ID)
+			return nil, err
+		}
+	}
+
 	return connect.NewResponse(&taskguildv1.CreateProjectResponse{
 		Project: toProto(p),
 	}), nil


### PR DESCRIPTION
## Summary
- Add `project.Seeder` that automatically creates default workflow, agents, and skills when a new project is created
- Default workflow: Draft → Plan → Develop → Review → Closed with appropriate agent assignments and hooks
- Architect agent: Plan mode, read-only tools, structured specification workflow
- Software-engineer agent: acceptEdits mode, includes Edit tool, implementation-focused instructions
- Create-pr skill: improved handling for MERGED/CLOSED PRs, dynamic default branch detection, unified push command

## Changes
- `internal/project/seeder.go` (new): Seeder with default templates for workflow, agents, and skill
- `internal/project/server.go`: Inject Seeder into Server, call Seed() after CreateProject (with rollback on failure)
- `cmd/taskguild-server/run.go`: Wire up Seeder with workflow/agent/skill repositories

Note: Agent MD files, skill YAML, and template YAML changes are in `.gitignore`-ed directories and not included in this PR. They are local data updates.