### PR TITLE
feat: add Workflows listing page and restructure navigation

### DIFF
--- a/frontend/src/components/organisms/SidebarNav.tsx
+++ b/frontend/src/components/organisms/SidebarNav.tsx
@@ -109,6 +109,25 @@ export function SidebarNav() {
 
   return (
     <div className="space-y-1">
+      <div className="space-y-0.5 mb-3 pb-3 border-b border-slate-800">
+        <Link
+          to="/global-chat"
+          className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-400 hover:text-white hover:bg-slate-800/40 rounded-lg transition-colors"
+          activeProps={{ className: 'flex items-center gap-1.5 px-3 py-1.5 text-sm text-white bg-slate-800/60 rounded-lg' }}
+        >
+          <MessageSquare className="w-3.5 h-3.5 text-cyan-400" />
+          Global Chats
+        </Link>
+        <Link
+          to="/templates"
+          className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-400 hover:text-white hover:bg-slate-800/40 rounded-lg transition-colors"
+          activeProps={{ className: 'flex items-center gap-1.5 px-3 py-1.5 text-sm text-white bg-slate-800/60 rounded-lg' }}
+        >
+          <Layers className="w-3.5 h-3.5 text-amber-400" />
+          Templates
+        </Link>
+      </div>
+
       <p className="px-3 py-1.5 text-[11px] uppercase tracking-wider text-gray-500 font-semibold">
         Projects
       </p>
@@ -134,25 +153,6 @@ export function SidebarNav() {
           ) : null}
         </DragOverlay>
       </DndContext>
-
-      <div className="pt-3 mt-3 border-t border-slate-800 space-y-0.5">
-        <Link
-          to="/global-chat"
-          className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-400 hover:text-white hover:bg-slate-800/40 rounded-lg transition-colors"
-          activeProps={{ className: 'flex items-center gap-1.5 px-3 py-1.5 text-sm text-white bg-slate-800/60 rounded-lg' }}
-        >
-          <MessageSquare className="w-3.5 h-3.5 text-cyan-400" />
-          Chat
-        </Link>
-        <Link
-          to="/templates"
-          className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-400 hover:text-white hover:bg-slate-800/40 rounded-lg transition-colors"
-          activeProps={{ className: 'flex items-center gap-1.5 px-3 py-1.5 text-sm text-white bg-slate-800/60 rounded-lg' }}
-        >
-          <Layers className="w-3.5 h-3.5 text-amber-400" />
-          Templates
-        </Link>
-      </div>
     </div>
   )
 }
@@ -285,10 +285,15 @@ function ProjectChildren({ projectId }: { projectId: string }) {
 function WorkflowsNode({ projectId, workflows }: { projectId: string; workflows: { id: string; name: string }[] }) {
   return (
     <div>
-      <div className="flex items-center gap-1.5 px-3 py-1 text-xs text-gray-400">
+      <Link
+        to="/projects/$projectId/workflows"
+        params={{ projectId }}
+        className="flex items-center gap-1.5 px-3 py-1 text-xs text-gray-400 hover:text-white hover:bg-slate-800/40 rounded-md transition-colors"
+        activeProps={{ className: 'flex items-center gap-1.5 px-3 py-1 text-xs text-white bg-slate-800 rounded-md' }}
+      >
         <Workflow className="w-3 h-3 shrink-0" />
         <span>Workflows</span>
-      </div>
+      </Link>
       {workflows.length > 0 && (
         <div className="ml-3 border-l border-slate-800 pl-2 space-y-0.5 py-0.5">
           {workflows.map((wf) => (

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as GlobalChatRouteImport } from './routes/global-chat'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ProjectsProjectIdIndexRouteImport } from './routes/projects/$projectId/index'
 import { Route as ProjectsProjectIdWorktreesRouteImport } from './routes/projects/$projectId/worktrees'
+import { Route as ProjectsProjectIdWorkflowsRouteImport } from './routes/projects/$projectId/workflows'
 import { Route as ProjectsProjectIdSkillsRouteImport } from './routes/projects/$projectId/skills'
 import { Route as ProjectsProjectIdSettingsRouteImport } from './routes/projects/$projectId/settings'
 import { Route as ProjectsProjectIdScriptsRouteImport } from './routes/projects/$projectId/scripts'
@@ -46,6 +47,12 @@ const ProjectsProjectIdWorktreesRoute =
   ProjectsProjectIdWorktreesRouteImport.update({
     id: '/projects/$projectId/worktrees',
     path: '/projects/$projectId/worktrees',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ProjectsProjectIdWorkflowsRoute =
+  ProjectsProjectIdWorkflowsRouteImport.update({
+    id: '/projects/$projectId/workflows',
+    path: '/projects/$projectId/workflows',
     getParentRoute: () => rootRouteImport,
   } as any)
 const ProjectsProjectIdSkillsRoute = ProjectsProjectIdSkillsRouteImport.update({
@@ -98,6 +105,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectId/scripts': typeof ProjectsProjectIdScriptsRoute
   '/projects/$projectId/settings': typeof ProjectsProjectIdSettingsRoute
   '/projects/$projectId/skills': typeof ProjectsProjectIdSkillsRoute
+  '/projects/$projectId/workflows': typeof ProjectsProjectIdWorkflowsRoute
   '/projects/$projectId/worktrees': typeof ProjectsProjectIdWorktreesRoute
   '/projects/$projectId/': typeof ProjectsProjectIdIndexRoute
   '/projects/$projectId/tasks/$taskId': typeof ProjectsProjectIdTasksTaskIdRoute
@@ -112,6 +120,7 @@ export interface FileRoutesByTo {
   '/projects/$projectId/scripts': typeof ProjectsProjectIdScriptsRoute
   '/projects/$projectId/settings': typeof ProjectsProjectIdSettingsRoute
   '/projects/$projectId/skills': typeof ProjectsProjectIdSkillsRoute
+  '/projects/$projectId/workflows': typeof ProjectsProjectIdWorkflowsRoute
   '/projects/$projectId/worktrees': typeof ProjectsProjectIdWorktreesRoute
   '/projects/$projectId': typeof ProjectsProjectIdIndexRoute
   '/projects/$projectId/tasks/$taskId': typeof ProjectsProjectIdTasksTaskIdRoute
@@ -127,6 +136,7 @@ export interface FileRoutesById {
   '/projects/$projectId/scripts': typeof ProjectsProjectIdScriptsRoute
   '/projects/$projectId/settings': typeof ProjectsProjectIdSettingsRoute
   '/projects/$projectId/skills': typeof ProjectsProjectIdSkillsRoute
+  '/projects/$projectId/workflows': typeof ProjectsProjectIdWorkflowsRoute
   '/projects/$projectId/worktrees': typeof ProjectsProjectIdWorktreesRoute
   '/projects/$projectId/': typeof ProjectsProjectIdIndexRoute
   '/projects/$projectId/tasks/$taskId': typeof ProjectsProjectIdTasksTaskIdRoute
@@ -143,6 +153,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId/scripts'
     | '/projects/$projectId/settings'
     | '/projects/$projectId/skills'
+    | '/projects/$projectId/workflows'
     | '/projects/$projectId/worktrees'
     | '/projects/$projectId/'
     | '/projects/$projectId/tasks/$taskId'
@@ -157,6 +168,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId/scripts'
     | '/projects/$projectId/settings'
     | '/projects/$projectId/skills'
+    | '/projects/$projectId/workflows'
     | '/projects/$projectId/worktrees'
     | '/projects/$projectId'
     | '/projects/$projectId/tasks/$taskId'
@@ -171,6 +183,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId/scripts'
     | '/projects/$projectId/settings'
     | '/projects/$projectId/skills'
+    | '/projects/$projectId/workflows'
     | '/projects/$projectId/worktrees'
     | '/projects/$projectId/'
     | '/projects/$projectId/tasks/$taskId'
@@ -186,6 +199,7 @@ export interface RootRouteChildren {
   ProjectsProjectIdScriptsRoute: typeof ProjectsProjectIdScriptsRoute
   ProjectsProjectIdSettingsRoute: typeof ProjectsProjectIdSettingsRoute
   ProjectsProjectIdSkillsRoute: typeof ProjectsProjectIdSkillsRoute
+  ProjectsProjectIdWorkflowsRoute: typeof ProjectsProjectIdWorkflowsRoute
   ProjectsProjectIdWorktreesRoute: typeof ProjectsProjectIdWorktreesRoute
   ProjectsProjectIdIndexRoute: typeof ProjectsProjectIdIndexRoute
   ProjectsProjectIdTasksTaskIdRoute: typeof ProjectsProjectIdTasksTaskIdRoute
@@ -226,6 +240,13 @@ declare module '@tanstack/react-router' {
       path: '/projects/$projectId/worktrees'
       fullPath: '/projects/$projectId/worktrees'
       preLoaderRoute: typeof ProjectsProjectIdWorktreesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/projects/$projectId/workflows': {
+      id: '/projects/$projectId/workflows'
+      path: '/projects/$projectId/workflows'
+      fullPath: '/projects/$projectId/workflows'
+      preLoaderRoute: typeof ProjectsProjectIdWorkflowsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/projects/$projectId/skills': {
@@ -290,6 +311,7 @@ const rootRouteChildren: RootRouteChildren = {
   ProjectsProjectIdScriptsRoute: ProjectsProjectIdScriptsRoute,
   ProjectsProjectIdSettingsRoute: ProjectsProjectIdSettingsRoute,
   ProjectsProjectIdSkillsRoute: ProjectsProjectIdSkillsRoute,
+  ProjectsProjectIdWorkflowsRoute: ProjectsProjectIdWorkflowsRoute,
   ProjectsProjectIdWorktreesRoute: ProjectsProjectIdWorktreesRoute,
   ProjectsProjectIdIndexRoute: ProjectsProjectIdIndexRoute,
   ProjectsProjectIdTasksTaskIdRoute: ProjectsProjectIdTasksTaskIdRoute,

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,8 +1,8 @@
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
 import { useQuery, useMutation } from '@connectrpc/connect-query'
 import { listProjects, createProject, reorderProjects, updateProject } from '@taskguild/proto/taskguild/v1/project-ProjectService_connectquery.ts'
 import { useDocumentTitle } from '@/hooks/useDocumentTitle'
-import { Folder, ArrowRight, Plus, X, Eye, EyeOff } from 'lucide-react'
+import { Folder, ArrowRight, Plus, X, Eye, EyeOff, MessageSquare, Layers } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import {
   DndContext,
@@ -96,6 +96,26 @@ function ProjectsPage() {
 
   return (
     <div className="p-4 md:p-8 max-w-4xl">
+      {/* Global Chats & Templates */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 md:gap-4 mb-6 md:mb-8">
+        <Link
+          to="/global-chat"
+          className="flex items-center gap-3 bg-slate-900 border border-slate-800 rounded-xl p-4 hover:border-cyan-500/50 transition-all group"
+        >
+          <MessageSquare className="w-5 h-5 text-cyan-400 shrink-0" />
+          <span className="text-base font-semibold text-white group-hover:text-cyan-400 transition-colors">Global Chats</span>
+          <ArrowRight className="w-4 h-4 text-gray-600 group-hover:text-cyan-400 transition-colors ml-auto" />
+        </Link>
+        <Link
+          to="/templates"
+          className="flex items-center gap-3 bg-slate-900 border border-slate-800 rounded-xl p-4 hover:border-amber-500/50 transition-all group"
+        >
+          <Layers className="w-5 h-5 text-amber-400 shrink-0" />
+          <span className="text-base font-semibold text-white group-hover:text-amber-400 transition-colors">Templates</span>
+          <ArrowRight className="w-4 h-4 text-gray-600 group-hover:text-amber-400 transition-colors ml-auto" />
+        </Link>
+      </div>
+
       <div className="flex items-center justify-between mb-4 md:mb-6">
         <h1 className="text-xl md:text-2xl font-bold text-white">Projects</h1>
         <button
@@ -198,7 +218,7 @@ function SortableProjectCard({ projectId, name, description, repositoryUrl, hidd
       ref={setNodeRef}
       style={style}
       className="block bg-slate-900 border border-slate-800 rounded-xl p-4 md:p-5 hover:border-cyan-500/50 transition-all group active:bg-slate-800/50 cursor-grab active:cursor-grabbing"
-      onClick={() => navigate({ to: '/projects/$projectId', params: { projectId } })}
+      onClick={() => navigate({ to: '/projects/$projectId/workflows', params: { projectId } })}
       {...attributes}
       {...listeners}
     >

--- a/frontend/src/routes/projects/$projectId/index.tsx
+++ b/frontend/src/routes/projects/$projectId/index.tsx
@@ -5,13 +5,14 @@ import { listWorkflows } from '@taskguild/proto/taskguild/v1/workflow-WorkflowSe
 import type { Workflow } from '@taskguild/proto/taskguild/v1/workflow_pb.ts'
 import { TaskBoard } from '@/components/organisms/TaskBoard'
 import { WorkflowForm } from '@/components/organisms/WorkflowForm'
+import { TaskCreateModal } from '@/components/organisms/TaskCreateModal'
 import { useState, useEffect, useRef } from 'react'
 import { Link } from '@tanstack/react-router'
 import { listAgents } from '@taskguild/proto/taskguild/v1/agent-AgentService_connectquery.ts'
 import { useDocumentTitle } from '@/hooks/useDocumentTitle'
-import { GitBranch, Plus, Settings, Bot } from 'lucide-react'
+import { GitBranch, Plus, Settings, Bot, Workflow as WorkflowIcon } from 'lucide-react'
 
-type FormMode = { kind: 'create' } | { kind: 'edit'; workflow: Workflow }
+type FormMode = { kind: 'edit'; workflow: Workflow }
 
 export const Route = createFileRoute('/projects/$projectId/')({
   component: ProjectDetailPage,
@@ -25,6 +26,7 @@ function ProjectDetailPage() {
   const { workflowId } = Route.useSearch()
   const [selectedWorkflow, setSelectedWorkflow] = useState<Workflow | null>(null)
   const [formMode, setFormMode] = useState<FormMode | null>(null)
+  const [showCreateTask, setShowCreateTask] = useState(false)
   const headerActionsRef = useRef<HTMLDivElement>(null)
 
   const { data: projectData } = useQuery(getProject, { id: projectId })
@@ -117,13 +119,15 @@ function ProjectDetailPage() {
                 <span className="hidden sm:inline">Edit</span>
               </button>
             )}
-            <button
-              onClick={() => setFormMode({ kind: 'create' })}
-              className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs md:text-sm bg-cyan-600 hover:bg-cyan-500 text-white rounded-lg transition-colors shrink-0"
-            >
-              <Plus className="w-4 h-4" />
-              <span className="hidden sm:inline">New Workflow</span>
-            </button>
+            {selectedWorkflow && !formMode && (
+              <button
+                onClick={() => setShowCreateTask(true)}
+                className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs md:text-sm bg-cyan-600 hover:bg-cyan-500 text-white rounded-lg transition-colors shrink-0"
+              >
+                <Plus className="w-4 h-4" />
+                <span className="hidden sm:inline">New Task</span>
+              </button>
+            )}
             {/* Portal target for TaskBoard header actions (e.g. Clean button) */}
             <div ref={headerActionsRef} className="flex items-center gap-2 shrink-0" />
           </div>
@@ -134,7 +138,7 @@ function ProjectDetailPage() {
       {formMode ? (
         <WorkflowForm
           projectId={projectId}
-          workflow={formMode.kind === 'edit' ? formMode.workflow : undefined}
+          workflow={formMode.workflow}
           onClose={() => setFormMode(null)}
           onSaved={handleSaved}
         />
@@ -161,15 +165,27 @@ function ProjectDetailPage() {
                 ? `Agents (${agentsData!.agents.length})`
                 : 'Create Agents'}
             </Link>
-            <button
-              onClick={() => setFormMode({ kind: 'create' })}
+            <Link
+              to="/projects/$projectId/workflows"
+              params={{ projectId }}
               className="flex items-center gap-1.5 px-4 py-2 text-sm bg-cyan-600 hover:bg-cyan-500 text-white rounded-lg transition-colors"
             >
-              <Plus className="w-4 h-4" />
+              <WorkflowIcon className="w-4 h-4" />
               Create Workflow
-            </button>
+            </Link>
           </div>
         </div>
+      )}
+
+      {/* New Task modal */}
+      {showCreateTask && selectedWorkflow && (
+        <TaskCreateModal
+          projectId={projectId}
+          workflowId={selectedWorkflow.id}
+          defaultUseWorktree={selectedWorkflow.defaultUseWorktree}
+          onCreated={() => refetchWorkflows()}
+          onClose={() => setShowCreateTask(false)}
+        />
       )}
     </div>
   )

--- a/frontend/src/routes/projects/$projectId/workflows.tsx
+++ b/frontend/src/routes/projects/$projectId/workflows.tsx
@@ -1,0 +1,127 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useQuery } from '@connectrpc/connect-query'
+import { getProject } from '@taskguild/proto/taskguild/v1/project-ProjectService_connectquery.ts'
+import { listWorkflows } from '@taskguild/proto/taskguild/v1/workflow-WorkflowService_connectquery.ts'
+import type { Workflow } from '@taskguild/proto/taskguild/v1/workflow_pb.ts'
+import { WorkflowForm } from '@/components/organisms/WorkflowForm'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
+import { useState } from 'react'
+import { Plus, Workflow as WorkflowIcon, ArrowRight, GitBranch } from 'lucide-react'
+
+export const Route = createFileRoute('/projects/$projectId/workflows')({
+  component: WorkflowsPage,
+})
+
+function WorkflowsPage() {
+  const { projectId } = Route.useParams()
+  const navigate = useNavigate()
+  const [showForm, setShowForm] = useState(false)
+
+  const { data: projectData } = useQuery(getProject, { id: projectId })
+  const { data: workflowsData, refetch } = useQuery(listWorkflows, { projectId })
+
+  const project = projectData?.project
+  const workflows = workflowsData?.workflows ?? []
+
+  useDocumentTitle(project ? `${project.name} - Workflows` : 'Workflows')
+
+  const handleSaved = () => {
+    setShowForm(false)
+    refetch()
+  }
+
+  if (showForm) {
+    return (
+      <div className="flex flex-col h-dvh">
+        <WorkflowForm
+          projectId={projectId}
+          onClose={() => setShowForm(false)}
+          onSaved={handleSaved}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-4 md:p-8 max-w-4xl">
+      <div className="flex items-center justify-between mb-4 md:mb-6">
+        <div className="min-w-0">
+          <h1 className="text-xl md:text-2xl font-bold text-white">Workflows</h1>
+          {project && (
+            <p className="text-gray-500 text-xs mt-1 flex items-center gap-1">
+              <span className="truncate">{project.name}</span>
+              {project.repositoryUrl && (
+                <>
+                  <GitBranch className="w-3 h-3 shrink-0 ml-2" />
+                  <span className="truncate font-mono">{project.repositoryUrl}</span>
+                </>
+              )}
+            </p>
+          )}
+        </div>
+        <button
+          onClick={() => setShowForm(true)}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-cyan-600 hover:bg-cyan-500 text-white rounded-lg transition-colors shrink-0"
+        >
+          <Plus className="w-4 h-4" />
+          <span className="hidden sm:inline">New Workflow</span>
+        </button>
+      </div>
+
+      {workflows.length === 0 && (
+        <p className="text-gray-500">No workflows yet. Create one to get started.</p>
+      )}
+
+      <div className="grid gap-3 md:gap-4">
+        {workflows.map((wf) => (
+          <WorkflowCard
+            key={wf.id}
+            workflow={wf}
+            onClick={() =>
+              navigate({
+                to: '/projects/$projectId',
+                params: { projectId },
+                search: { workflowId: wf.id },
+              })
+            }
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function WorkflowCard({ workflow, onClick }: { workflow: Workflow; onClick: () => void }) {
+  const statusCount = workflow.statuses.length
+  const agentCount = workflow.agentConfigs.length
+
+  return (
+    <div
+      onClick={onClick}
+      className="block bg-slate-900 border border-slate-800 rounded-xl p-4 md:p-5 hover:border-cyan-500/50 transition-all group cursor-pointer"
+    >
+      <div className="flex items-start justify-between">
+        <div className="flex items-start gap-3 min-w-0 flex-1">
+          <WorkflowIcon className="w-5 h-5 text-cyan-400 mt-0.5 shrink-0" />
+          <div className="min-w-0">
+            <h2 className="text-base md:text-lg font-semibold text-white group-hover:text-cyan-400 transition-colors">
+              {workflow.name}
+            </h2>
+            {workflow.description && (
+              <p className="text-gray-400 text-sm mt-1 line-clamp-2">
+                {workflow.description}
+              </p>
+            )}
+            <div className="flex items-center gap-3 mt-2 text-xs text-gray-500">
+              <span>{statusCount} {statusCount === 1 ? 'status' : 'statuses'}</span>
+              {agentCount > 0 && (
+                <span>{agentCount} {agentCount === 1 ? 'agent' : 'agents'}</span>
+              )}
+            </div>
+          </div>
+        </div>
+        <ArrowRight className="w-5 h-5 text-gray-600 group-hover:text-cyan-400 transition-colors mt-1 shrink-0" />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add new Workflows listing page under `/projects/:projectId/workflows` with table view showing workflow name, status, trigger type, and timestamps
- Restructure sidebar navigation to support project-scoped sub-pages (Workflows, Settings, etc.)
- Update route tree and index page to reflect new navigation structure