### PR TITLE
Shorten worktree paths in task log display

### DIFF
--- a/frontend/src/components/atoms/WorktreePath.tsx
+++ b/frontend/src/components/atoms/WorktreePath.tsx
@@ -1,0 +1,29 @@
+import { parseWorktreePaths } from '../../lib/worktreePath.ts'
+
+/**
+ * Renders text that may contain worktree paths with shortened display and hover tooltips.
+ * Worktree path prefixes are replaced with "$worktree" and hovering shows the full path.
+ */
+export function WorktreePath({ text, className }: { text: string; className?: string }) {
+  const segments = parseWorktreePaths(text)
+
+  // Fast path: no worktree paths found — render plain text.
+  if (segments.length === 1 && segments[0].kind === 'text') {
+    return <span className={className}>{text}</span>
+  }
+
+  return (
+    <span className={className}>
+      {segments.map((seg, i) =>
+        seg.kind === 'text' ? (
+          <span key={i}>{seg.value}</span>
+        ) : (
+          <span key={i} title={seg.fullPath} className="cursor-help">
+            <span className="text-cyan-500/70">$worktree</span>
+            {seg.shortened.slice('$worktree'.length)}
+          </span>
+        ),
+      )}
+    </span>
+  )
+}

--- a/frontend/src/components/organisms/TimelineEntry.tsx
+++ b/frontend/src/components/organisms/TimelineEntry.tsx
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react'
 import { formatTime } from './InputBar.tsx'
 import { Badge } from '../atoms/index.ts'
+import { WorktreePath } from '../atoms/WorktreePath.tsx'
 import { MarkdownDescription } from './MarkdownDescription.tsx'
 
 export type TimelineItem =
@@ -222,7 +223,7 @@ function SimpleLogEntry({ log }: { log: TaskLog }) {
           {log.message}
         </pre>
       ) : (
-        <span className={`truncate flex-1 min-w-0 ${levelColor}`}>{log.message}</span>
+        <WorktreePath text={log.message} className={`truncate flex-1 min-w-0 ${levelColor}`} />
       )}
     </div>
   )
@@ -246,7 +247,7 @@ function ExpandableLogEntry({ log }: { log: TaskLog }) {
         </span>
         <span className="shrink-0 mt-0.5">{icon}</span>
         <span className={`text-[11px] w-16 shrink-0 mt-0.5 ${levelColor}`}>{typeLabel}</span>
-        <span className={`truncate flex-1 min-w-0 ${levelColor}`}>{log.message}</span>
+        <WorktreePath text={log.message} className={`truncate flex-1 min-w-0 ${levelColor}`} />
         <span className="shrink-0 mt-0.5 text-gray-600">
           {expanded ? (
             <ChevronDown className="w-3 h-3" />
@@ -394,13 +395,19 @@ function JsonKeyValueDisplay({ raw }: { raw: string }) {
   const entries = Object.entries(parsed as Record<string, unknown>)
   if (entries.length === 0) return null
 
+  const pathKeys = new Set(['file_path', 'path', 'notebook_path'])
+
   return (
     <div className="bg-slate-900/50 rounded px-2 py-1 max-h-48 overflow-y-auto space-y-1">
       {entries.map(([key, value]) => (
         <div key={key}>
           <div className="text-[10px] text-gray-500 font-medium capitalize">{key}</div>
           <div className="text-[11px] text-gray-400 font-mono whitespace-pre-wrap break-all">
-            {formatValue(value)}
+            {pathKeys.has(key) && typeof value === 'string' ? (
+              <WorktreePath text={value} />
+            ) : (
+              formatValue(value)
+            )}
           </div>
         </div>
       ))}

--- a/frontend/src/lib/worktreePath.ts
+++ b/frontend/src/lib/worktreePath.ts
@@ -1,0 +1,55 @@
+// Worktree path shortening utilities.
+// Detects paths like ".../.claude/worktrees/{name}/..." and shortens to "$worktree/...".
+
+const WORKTREE_PATTERN = /(?:\/[^/]+)*\/\.claude\/worktrees\/[^/]+\//
+
+/**
+ * Shorten a single file path that starts with a worktree root.
+ * Returns the shortened path and the full worktree prefix for tooltip display.
+ */
+export function shortenWorktreePath(path: string): { shortened: string; worktreePrefix: string | null } {
+  const match = path.match(WORKTREE_PATTERN)
+  if (!match) return { shortened: path, worktreePrefix: null }
+  const prefix = match[0]
+  const rest = path.slice(prefix.length)
+  return { shortened: `$worktree/${rest}`, worktreePrefix: prefix.replace(/\/$/, '') }
+}
+
+/**
+ * Find and shorten worktree paths within arbitrary text (e.g., log messages like "Read: /full/path/file.ts").
+ * Returns segments that can be rendered with tooltips on the worktree portions.
+ */
+export type TextSegment =
+  | { kind: 'text'; value: string }
+  | { kind: 'worktree'; shortened: string; fullPath: string }
+
+const WORKTREE_PATH_IN_TEXT = /((?:\/[^/\s]+)*\/\.claude\/worktrees\/[^/\s]+\/[^\s]*)/g
+
+export function parseWorktreePaths(text: string): TextSegment[] {
+  const segments: TextSegment[] = []
+  let lastIndex = 0
+
+  for (const match of text.matchAll(WORKTREE_PATH_IN_TEXT)) {
+    const fullPath = match[1]
+    const start = match.index!
+
+    if (start > lastIndex) {
+      segments.push({ kind: 'text', value: text.slice(lastIndex, start) })
+    }
+
+    const { shortened } = shortenWorktreePath(fullPath)
+    segments.push({ kind: 'worktree', shortened, fullPath })
+    lastIndex = start + fullPath.length
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ kind: 'text', value: text.slice(lastIndex) })
+  }
+
+  // If no worktree paths found, return single text segment.
+  if (segments.length === 0) {
+    return [{ kind: 'text', value: text }]
+  }
+
+  return segments
+}


### PR DESCRIPTION
## Summary
- Add `WorktreePath` component that detects `.claude/worktrees/` paths and shortens them to `$worktree/...` with hover tooltip showing the full path
- Add `parseWorktreePaths` / `shortenWorktreePath` utility functions in `lib/worktreePath.ts`
- Apply shortened paths to log messages in `TimelineEntry` (both simple and expandable entries) and to JSON detail fields (`file_path`, `path`, `notebook_path`)