### PR TITLE
Fix: change hover cursor to pointer on shortened worktree paths

### DIFF
--- a/frontend/src/components/atoms/WorktreePath.tsx
+++ b/frontend/src/components/atoms/WorktreePath.tsx
@@ -18,7 +18,7 @@ export function WorktreePath({ text, className }: { text: string; className?: st
         seg.kind === 'text' ? (
           <span key={i}>{seg.value}</span>
         ) : (
-          <span key={i} title={seg.fullPath} className="cursor-help">
+          <span key={i} title={seg.fullPath} className="cursor-pointer">
             <span className="text-cyan-500/70">$worktree</span>
             {seg.shortened.slice('$worktree'.length)}
           </span>


### PR DESCRIPTION
## Summary
- Change the hover cursor from `help` (?) to `pointer` (hand) on shortened worktree paths in the task log display
- Improves UX by using a more intuitive cursor style for clickable/hoverable elements