### PR TITLE
Unify H2 headings with shared PageHeading component

### DIFF
--- a/frontend/src/components/molecules/PageHeading.tsx
+++ b/frontend/src/components/molecules/PageHeading.tsx
@@ -1,0 +1,18 @@
+import type { ComponentType, ReactNode, SVGProps } from 'react'
+
+export interface PageHeadingProps {
+  icon: ComponentType<SVGProps<SVGSVGElement>>
+  title: string
+  iconColor?: string
+  children?: ReactNode
+}
+
+export function PageHeading({ icon: Icon, title, iconColor = 'text-cyan-400', children }: PageHeadingProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <Icon className={`w-5 h-5 ${iconColor}`} />
+      <h2 className="text-lg md:text-xl font-bold text-white">{title}</h2>
+      {children}
+    </div>
+  )
+}

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -2,3 +2,4 @@ export { Modal, type ModalProps, type ModalHeaderProps, type ModalBodyProps, typ
 export { Card, type CardProps } from './Card.tsx'
 export { FormField, type FormFieldProps } from './FormField.tsx'
 export { DropdownMenu, type DropdownMenuProps, type DropdownMenuItemProps } from './DropdownMenu.tsx'
+export { PageHeading, type PageHeadingProps } from './PageHeading.tsx'

--- a/frontend/src/components/organisms/AgentList.tsx
+++ b/frontend/src/components/organisms/AgentList.tsx
@@ -17,7 +17,7 @@ import { Bot, Plus, Trash2, Edit2, RefreshCw, X, Save, Cloud, Layers, Copy, Aler
 import { useEventSubscription } from '@/hooks/useEventSubscription'
 import { Button } from '../atoms/index.ts'
 import { Input, Textarea, Select, Badge, Checkbox } from '../atoms/index.ts'
-import { Card, FormField, Modal } from '../molecules/index.ts'
+import { Card, FormField, Modal, PageHeading } from '../molecules/index.ts'
 
 const AVAILABLE_TOOLS = [
   'Read', 'Write', 'Edit', 'Glob', 'Grep', 'Bash',
@@ -318,9 +318,7 @@ export function AgentList({ projectId, editAgentId, mode }: { projectId: string;
   return (
     <div className="p-4 md:p-6 max-w-4xl mx-auto">
       <div className="flex items-center justify-between mb-4 md:mb-6">
-        <div className="flex items-center gap-2">
-          <Bot className="w-5 h-5 text-cyan-400" />
-          <h2 className="text-lg md:text-xl font-bold text-white">Agents</h2>
+        <PageHeading icon={Bot} title="Agents" iconColor="text-cyan-400">
           <Badge color="gray" size="xs" pill variant="outline">
             {agents.length}
           </Badge>
@@ -329,7 +327,7 @@ export function AgentList({ projectId, editAgentId, mode }: { projectId: string;
               {diffs.length} diff{diffs.length > 1 ? 's' : ''}
             </Badge>
           )}
-        </div>
+        </PageHeading>
         <div className="flex items-center gap-2">
           <Button
             variant="secondary"

--- a/frontend/src/components/organisms/ClaudeSettingsList.tsx
+++ b/frontend/src/components/organisms/ClaudeSettingsList.tsx
@@ -2,8 +2,8 @@ import { useState, useEffect } from 'react'
 import { useQuery, useMutation } from '@connectrpc/connect-query'
 import { getClaudeSettings, updateClaudeSettings, syncClaudeSettingsFromDir } from '@taskguild/proto/taskguild/v1/claude_settings-ClaudeSettingsService_connectquery.ts'
 import { Settings, Save, RefreshCw } from 'lucide-react'
-import { Button, Input, Checkbox } from '../atoms/index.ts'
-import { Card } from '../molecules/index.ts'
+import { Button, Input, Checkbox, Badge } from '../atoms/index.ts'
+import { Card, PageHeading } from '../molecules/index.ts'
 
 export function ClaudeSettingsList({ projectId }: { projectId: string }) {
   const { data, refetch, isLoading } = useQuery(getClaudeSettings, { projectId })
@@ -61,18 +61,13 @@ export function ClaudeSettingsList({ projectId }: { projectId: string }) {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="p-2 bg-violet-500/10 rounded-lg">
-            <Settings className="w-5 h-5 text-violet-400" />
-          </div>
-          <div>
-            <h1 className="text-lg font-semibold text-white">Claude Settings</h1>
-            <p className="text-xs text-gray-500">
-              Configure .claude/settings.json for this project
-              {dirty && <span className="text-amber-400 ml-2">* unsaved changes</span>}
-            </p>
-          </div>
-        </div>
+        <PageHeading icon={Settings} title="Claude Settings" iconColor="text-violet-400">
+          {dirty && (
+            <Badge color="amber" size="xs" pill variant="outline">
+              unsaved
+            </Badge>
+          )}
+        </PageHeading>
         <div className="flex items-center gap-2">
           <Button
             variant="secondary"

--- a/frontend/src/components/organisms/PermissionList.tsx
+++ b/frontend/src/components/organisms/PermissionList.tsx
@@ -3,7 +3,7 @@ import { useQuery, useMutation } from '@connectrpc/connect-query'
 import { getPermissions, updatePermissions, syncPermissionsFromDir } from '@taskguild/proto/taskguild/v1/permission-PermissionService_connectquery.ts'
 import { Shield, Plus, X, Save, RefreshCw } from 'lucide-react'
 import { Button, Input, Select, Badge } from '../atoms/index.ts'
-import { Card } from '../molecules/index.ts'
+import { Card, PageHeading } from '../molecules/index.ts'
 
 type PermissionCategory = 'allow' | 'ask' | 'deny'
 
@@ -130,18 +130,16 @@ export function PermissionList({ projectId }: { projectId: string }) {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="p-2 bg-cyan-500/10 rounded-lg">
-            <Shield className="w-5 h-5 text-cyan-400" />
-          </div>
-          <div>
-            <h1 className="text-lg font-semibold text-white">Permissions</h1>
-            <p className="text-xs text-gray-500">
-              {totalRules} rule{totalRules !== 1 ? 's' : ''} defined
-              {dirty && <span className="text-amber-400 ml-2">* unsaved changes</span>}
-            </p>
-          </div>
-        </div>
+        <PageHeading icon={Shield} title="Permissions" iconColor="text-cyan-400">
+          <Badge color="gray" size="xs" pill variant="outline">
+            {totalRules}
+          </Badge>
+          {dirty && (
+            <Badge color="amber" size="xs" pill variant="outline">
+              unsaved
+            </Badge>
+          )}
+        </PageHeading>
         <div className="flex items-center gap-2">
           <Button
             variant="secondary"

--- a/frontend/src/components/organisms/ScriptList.tsx
+++ b/frontend/src/components/organisms/ScriptList.tsx
@@ -21,7 +21,7 @@ import { EventType } from '@taskguild/proto/taskguild/v1/event_pb.ts'
 import { Terminal, Plus, Trash2, Edit2, RefreshCw, X, Save, Cloud, Play, Square, CheckCircle, XCircle, StopCircle, Loader2, Layers, Copy, AlertTriangle, Server, Monitor } from 'lucide-react'
 import { useEventSubscription } from '@/hooks/useEventSubscription'
 import { Button, Input, Textarea, Badge } from '../atoms/index.ts'
-import { Card, FormField, Modal } from '../molecules/index.ts'
+import { Card, FormField, Modal, PageHeading } from '../molecules/index.ts'
 import { emptyForm, scriptToForm, diffTypeLabel } from './ScriptListUtils'
 import type { ScriptFormData } from './ScriptListUtils'
 import { LogOutput } from './LogOutput'
@@ -202,18 +202,16 @@ export function ScriptList({ projectId }: { projectId: string }) {
   return (
     <div className="p-6 max-w-4xl mx-auto">
       <div className="flex items-center justify-between mb-6">
-        <div className="flex items-center gap-2">
-          <Terminal className="w-5 h-5 text-green-400" />
-          <h2 className="text-xl font-bold text-white">Scripts</h2>
-          <span className="text-xs text-gray-500 bg-slate-800 rounded-full px-2 py-0.5">
+        <PageHeading icon={Terminal} title="Scripts" iconColor="text-green-400">
+          <Badge color="gray" size="xs" pill variant="outline">
             {scripts.length}
-          </span>
+          </Badge>
           {diffs.length > 0 && (
             <Badge color="amber" size="xs" variant="outline" pill icon={<AlertTriangle className="w-2.5 h-2.5" />}>
               {diffs.length} diff{diffs.length > 1 ? 's' : ''}
             </Badge>
           )}
-        </div>
+        </PageHeading>
         <div className="flex items-center gap-2">
           <Button
             variant="ghost"

--- a/frontend/src/components/organisms/SingleCommandPermissionList.tsx
+++ b/frontend/src/components/organisms/SingleCommandPermissionList.tsx
@@ -9,7 +9,7 @@ import {
 import type { SingleCommandPermission } from '@taskguild/proto/taskguild/v1/single_command_permission_pb.ts'
 import { Terminal, Plus, Trash2, Edit2, X, Check } from 'lucide-react'
 import { Button, Input, Select, Badge } from '../atoms/index.ts'
-import { Card, FormField } from '../molecules/index.ts'
+import { Card, FormField, PageHeading } from '../molecules/index.ts'
 
 type PermissionType = 'command' | 'redirect'
 
@@ -115,17 +115,11 @@ export function SingleCommandPermissionList({ projectId }: { projectId: string }
     <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="p-2 bg-purple-500/10 rounded-lg">
-            <Terminal className="w-5 h-5 text-purple-400" />
-          </div>
-          <div>
-            <h2 className="text-lg font-semibold text-white">Single Command Allow List</h2>
-            <p className="text-xs text-gray-500">
-              {permissions.length} rule{permissions.length !== 1 ? 's' : ''} defined
-            </p>
-          </div>
-        </div>
+        <PageHeading icon={Terminal} title="Single Command Allow List" iconColor="text-purple-400">
+          <Badge color="gray" size="xs" pill variant="outline">
+            {permissions.length}
+          </Badge>
+        </PageHeading>
         <Button
           variant="primary"
           size="sm"

--- a/frontend/src/components/organisms/SkillList.tsx
+++ b/frontend/src/components/organisms/SkillList.tsx
@@ -7,7 +7,7 @@ import type { Template } from '@taskguild/proto/taskguild/v1/template_pb.ts'
 import { Sparkles, Plus, Trash2, Edit2, RefreshCw, X, Save, Cloud, Layers, Copy } from 'lucide-react'
 import { Button } from '../atoms/index.ts'
 import { Input, Textarea, Select, Checkbox, Badge } from '../atoms/index.ts'
-import { Card, FormField } from '../molecules/index.ts'
+import { Card, FormField, PageHeading } from '../molecules/index.ts'
 
 const AVAILABLE_TOOLS = [
   'Read', 'Write', 'Edit', 'Glob', 'Grep', 'Bash',
@@ -184,13 +184,11 @@ export function SkillList({ projectId }: { projectId: string }) {
   return (
     <div className="p-6 max-w-4xl mx-auto">
       <div className="flex items-center justify-between mb-6">
-        <div className="flex items-center gap-2">
-          <Sparkles className="w-5 h-5 text-purple-400" />
-          <h2 className="text-xl font-bold text-white">Skills</h2>
-          <span className="text-xs text-gray-500 bg-slate-800 rounded-full px-2 py-0.5">
+        <PageHeading icon={Sparkles} title="Skills" iconColor="text-purple-400">
+          <Badge color="gray" size="xs" pill variant="outline">
             {skills.length}
-          </span>
-        </div>
+          </Badge>
+        </PageHeading>
         <div className="flex items-center gap-2">
           <Button
             variant="ghost"

--- a/frontend/src/components/organisms/WorktreeList.tsx
+++ b/frontend/src/components/organisms/WorktreeList.tsx
@@ -18,7 +18,7 @@ import { useEventSubscription } from '@/hooks/useEventSubscription'
 import { transport } from '@/lib/transport'
 import { GitFork, GitBranch, RefreshCw, Trash2, AlertTriangle, FileText, Home, Download, CheckCircle2, XCircle, ClipboardList, Sparkles, ChevronDown, ChevronRight, Loader2 } from 'lucide-react'
 import { Button, Badge } from '../atoms/index.ts'
-import { Card, Modal } from '../molecules/index.ts'
+import { Card, Modal, PageHeading } from '../molecules/index.ts'
 
 // --- Git pull main result hook ---
 
@@ -225,13 +225,11 @@ export function WorktreeList({ projectId }: { projectId: string }) {
     <div className="p-4 md:p-6 max-w-4xl mx-auto">
       {/* Header */}
       <div className="flex items-center justify-between mb-4 md:mb-6">
-        <div className="flex items-center gap-2">
-          <GitFork className="w-5 h-5 text-cyan-400" />
-          <h2 className="text-lg md:text-xl font-bold text-white">Worktrees</h2>
+        <PageHeading icon={GitFork} title="Worktrees" iconColor="text-cyan-400">
           <Badge color="gray" size="xs" pill variant="outline">
             {worktrees.length}
           </Badge>
-        </div>
+        </PageHeading>
         <div className="flex items-center gap-2">
           <Button
             variant="secondary"

--- a/frontend/src/routes/projects/$projectId/chat.tsx
+++ b/frontend/src/routes/projects/$projectId/chat.tsx
@@ -12,7 +12,9 @@ import { useNotificationSound } from '@/hooks/useNotificationSound'
 import { TimelineEntry, type TimelineItem } from '@/components/organisms/TimelineEntry'
 import { PendingRequestsPanel } from '@/components/organisms/PendingRequestsPanel'
 import { shortId } from '@/lib/id'
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, MessageSquare } from 'lucide-react'
+import { PageHeading } from '@/components/molecules/index.ts'
+import { Badge } from '@/components/atoms/index.ts'
 import { ConnectionIndicator } from '@/components/organisms/ConnectionIndicator'
 
 export const Route = createFileRoute('/projects/$projectId/chat')({
@@ -131,10 +133,11 @@ function ProjectChatPage() {
             <span className="sm:hidden">Back</span>
           </Link>
         </div>
-        <h1 className="text-lg md:text-xl font-bold text-white">Chat</h1>
-        <p className="text-xs text-gray-500 mt-1">
-          All interactions across {tasks.length} task{tasks.length !== 1 ? 's' : ''}
-        </p>
+        <PageHeading icon={MessageSquare} title="Chat" iconColor="text-cyan-400">
+          <Badge color="gray" size="xs" pill variant="outline">
+            {tasks.length} task{tasks.length !== 1 ? 's' : ''}
+          </Badge>
+        </PageHeading>
       </div>
 
       {/* Timeline area */}

--- a/frontend/src/routes/projects/$projectId/workflows.tsx
+++ b/frontend/src/routes/projects/$projectId/workflows.tsx
@@ -6,7 +6,9 @@ import type { Workflow } from '@taskguild/proto/taskguild/v1/workflow_pb.ts'
 import { WorkflowForm } from '@/components/organisms/WorkflowForm'
 import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 import { useState } from 'react'
-import { Plus, Workflow as WorkflowIcon, ArrowRight, GitBranch } from 'lucide-react'
+import { Plus, Workflow as WorkflowIcon, ArrowRight } from 'lucide-react'
+import { PageHeading } from '@/components/molecules/index.ts'
+import { Badge } from '@/components/atoms/index.ts'
 
 export const Route = createFileRoute('/projects/$projectId/workflows')({
   component: WorkflowsPage,
@@ -45,20 +47,11 @@ function WorkflowsPage() {
   return (
     <div className="p-4 md:p-8 max-w-4xl">
       <div className="flex items-center justify-between mb-4 md:mb-6">
-        <div className="min-w-0">
-          <h1 className="text-xl md:text-2xl font-bold text-white">Workflows</h1>
-          {project && (
-            <p className="text-gray-500 text-xs mt-1 flex items-center gap-1">
-              <span className="truncate">{project.name}</span>
-              {project.repositoryUrl && (
-                <>
-                  <GitBranch className="w-3 h-3 shrink-0 ml-2" />
-                  <span className="truncate font-mono">{project.repositoryUrl}</span>
-                </>
-              )}
-            </p>
-          )}
-        </div>
+        <PageHeading icon={WorkflowIcon} title="Workflows" iconColor="text-cyan-400">
+          <Badge color="gray" size="xs" pill variant="outline">
+            {workflows.length}
+          </Badge>
+        </PageHeading>
         <button
           onClick={() => setShowForm(true)}
           className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-cyan-600 hover:bg-cyan-500 text-white rounded-lg transition-colors shrink-0"


### PR DESCRIPTION
## Summary
- Extract a reusable `PageHeading` component for consistent H2 headings across second-level pages
- Replace inline H2 heading styles in AgentList, ClaudeSettingsList, PermissionList, ScriptList, SingleCommandPermissionList, SkillList, WorktreeList, chat, and workflows pages
- Reduce duplicated styling code (net -6 lines) while improving visual consistency