### PR TITLE
feat: display Claude mode on task cards and unify page headings

### DIFF
--- a/cmd/taskguild-agent/directive.go
+++ b/cmd/taskguild-agent/directive.go
@@ -424,6 +424,17 @@ func saveWorktreeName(ctx context.Context, taskClient taskguildv1connect.TaskSer
 	}
 }
 
+func saveClaudeMode(ctx context.Context, taskClient taskguildv1connect.TaskServiceClient, taskID, mode string) {
+	logger := clog.LoggerFromContext(ctx)
+	_, err := taskClient.UpdateTask(ctx, connect.NewRequest(&v1.UpdateTaskRequest{
+		Id:       taskID,
+		Metadata: map[string]string{"claude_mode": mode},
+	}))
+	if err != nil {
+		logger.Error("failed to save claude_mode", "error", err)
+	}
+}
+
 func saveTaskDescription(ctx context.Context, taskClient taskguildv1connect.TaskServiceClient, taskID, description string) {
 	logger := clog.LoggerFromContext(ctx)
 	_, err := taskClient.UpdateTask(ctx, connect.NewRequest(&v1.UpdateTaskRequest{

--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -81,6 +81,7 @@ func runTask(
 	var modeMu sync.Mutex
 
 	logger.Info("runTask started", "agent_name", metadata["_agent_name"], "use_worktree", metadata["_use_worktree"], "claude_mode", currentMode)
+	saveClaudeMode(ctx, taskClient, taskID, currentMode)
 	reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_RUNNING, "starting task")
 
 	// Initialize task logger for structured log streaming.
@@ -183,6 +184,10 @@ func runTask(
 			modeMu.Unlock()
 			if old != newMode {
 				logger.Info("claude mode changed", "old_mode", old, "new_mode", newMode)
+				tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
+					fmt.Sprintf("Mode changed: %s → %s", old, newMode),
+					map[string]string{"old_mode": old, "new_mode": newMode})
+				saveClaudeMode(ctx, taskClient, taskID, newMode)
 			}
 		})
 		// Override StderrCallback to also send to task logger.

--- a/frontend/src/components/organisms/TaskCard.tsx
+++ b/frontend/src/components/organisms/TaskCard.tsx
@@ -192,6 +192,14 @@ export function TaskCard({ task, onEdit, onCreateChild, isDragOverlay, transitio
         </div>
       )}
 
+      {/* Claude mode indicator */}
+      {task.metadata?.['claude_mode'] && (
+        <div className="mt-1.5 flex items-center gap-1 text-xs text-gray-500 truncate">
+          <Play className="w-3 h-3 shrink-0" />
+          <span className="truncate font-mono">{task.metadata['claude_mode']}</span>
+        </div>
+      )}
+
       {/* Worktree indicator */}
       {task.useWorktree && (
         <div className="mt-1.5 flex items-center gap-1 text-xs text-gray-500 truncate">


### PR DESCRIPTION
## Summary
- Save and propagate the actual Claude mode (e.g. code, plan) to task metadata and task logs, so users can see which mode the agent is operating in
- Display the current Claude mode indicator on TaskCard components
- Extract a shared `PageHeading` molecule component and unify H2 headings across all second-level pages (Agents, Scripts, Skills, Worktrees, Permissions, Claude Settings, Chat, Workflows)

## Test plan
- [ ] Verify Claude mode is displayed on task cards when a task has `claude_mode` metadata
- [ ] Verify mode change is logged in task logs with old/new mode
- [ ] Verify all second-level pages render headings consistently using `PageHeading`
- [ ] Verify no visual regressions on any of the affected pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)