### PR TITLE
Fix: show task titles instead of IDs in Project Chat & unify H2 headings

### DIFF
--- a/frontend/src/routes/projects/$projectId/chat.tsx
+++ b/frontend/src/routes/projects/$projectId/chat.tsx
@@ -43,8 +43,14 @@ function ProjectChatPage() {
     for (const t of tasks) {
       m.set(t.id, t.title)
     }
+    // Supplement from listInteractions response (includes archived tasks)
+    if (interactionsData?.taskTitles) {
+      for (const [id, title] of Object.entries(interactionsData.taskTitles)) {
+        if (!m.has(id)) m.set(id, title)
+      }
+    }
     return m
-  }, [tasks])
+  }, [tasks, interactionsData?.taskTitles])
 
   // Wrap interactions as TimelineItems
   const timelineItems = useMemo<TimelineItem[]>(


### PR DESCRIPTION
## Summary
- Show task titles instead of task IDs in the Project Chat view for better readability
- Introduce a shared `PageHeading` component to unify H2 headings across all second-level pages
- Refactor `AgentList`, `ClaudeSettingsList`, `PermissionList`, `ScriptList`, `SingleCommandPermissionList`, `SkillList`, `WorktreeList`, and `workflows` page to use the new `PageHeading` component