### PR TITLE
feat: per-status session ID management with fork-session on agent change

### DIFF
--- a/cmd/taskguild-agent/directive.go
+++ b/cmd/taskguild-agent/directive.go
@@ -400,11 +400,21 @@ func handleStatusTransition(
 	return nil
 }
 
-func saveSessionID(ctx context.Context, taskClient taskguildv1connect.TaskServiceClient, taskID, sessionID string) {
+func saveSessionID(ctx context.Context, taskClient taskguildv1connect.TaskServiceClient, taskID, sessionID, statusName, agentName string) {
 	logger := clog.LoggerFromContext(ctx)
+	meta := map[string]string{"session_id": sessionID}
+	if statusName != "" {
+		meta["session_id:"+statusName] = sessionID
+		if agentName != "" {
+			meta["session_agent:"+statusName] = agentName
+		}
+	}
+	if agentName != "" {
+		meta["_last_session_agent"] = agentName
+	}
 	_, err := taskClient.UpdateTask(ctx, connect.NewRequest(&v1.UpdateTaskRequest{
 		Id:       taskID,
-		Metadata: map[string]string{"session_id": sessionID},
+		Metadata: meta,
 	}))
 	if err != nil {
 		logger.Error("failed to save session_id", "error", err)

--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -163,7 +163,7 @@ func runTask(
 		runInteractionListener(ctx, interClient, taskID, waiter)
 	})
 
-	sessionID := metadata["session_id"]
+	sessionID, forkSession := resolveSession(metadata)
 	prompt := buildUserPrompt(metadata, workDir)
 	hasTransitions := metadata["_available_transitions"] != ""
 	logger.Info("task setup complete, entering turn loop", "has_session", sessionID != "", "has_transitions", hasTransitions)
@@ -177,7 +177,7 @@ func runTask(
 	statusTransitionRetries := 0
 
 	for turn := 0; ; turn++ {
-		opts := buildClaudeOptions(instructions, workDir, metadata, sessionID, worktreeName, client, taskClient, ctx, taskID, agentManagerID, waiter, permCache, scpCache, tl, func(newMode string) {
+		opts := buildClaudeOptions(instructions, workDir, metadata, sessionID, forkSession, worktreeName, client, taskClient, ctx, taskID, agentManagerID, waiter, permCache, scpCache, tl, func(newMode string) {
 			modeMu.Lock()
 			old := currentMode
 			currentMode = newMode
@@ -259,7 +259,9 @@ func runTask(
 		// Save session ID for resume.
 		if result.Result != nil && result.Result.SessionID != "" {
 			sessionID = result.Result.SessionID
-			saveSessionID(ctx, taskClient, taskID, sessionID)
+			forkSession = false // fork done, normal resume from here
+			saveSessionID(ctx, taskClient, taskID, sessionID,
+				metadata["_current_status_name"], metadata["_agent_name"])
 		}
 
 		// Handle errors with backoff retry.
@@ -566,12 +568,43 @@ func runTask(
 	}
 }
 
+// resolveSession determines which session ID to use and whether to fork.
+// It checks per-status sessions first (for same-status retries), then falls
+// back to the global session_id and compares agents to decide on forking.
+func resolveSession(metadata map[string]string) (sessionID string, forkSession bool) {
+	currentStatus := metadata["_current_status_name"]
+	currentAgent := metadata["_agent_name"]
+
+	// 1. Check for existing session in current status (same-status retry).
+	if currentStatus != "" {
+		if sid := metadata["session_id:"+currentStatus]; sid != "" {
+			return sid, false
+		}
+	}
+
+	// 2. Check global session ID.
+	globalSID := metadata["session_id"]
+	if globalSID == "" {
+		return "", false // new task
+	}
+
+	// 3. Compare with previous agent — fork if agent changed.
+	lastAgent := metadata["_last_session_agent"]
+	if lastAgent != "" && currentAgent != "" && lastAgent != currentAgent {
+		return globalSID, true
+	}
+
+	// 4. Same agent or unknown → normal resume.
+	return globalSID, false
+}
+
 // buildClaudeOptions constructs ClaudeAgentOptions for each turn.
 func buildClaudeOptions(
 	instructions string,
 	workDir string,
 	metadata map[string]string,
 	sessionID string,
+	forkSession bool,
 	worktreeName string,
 	client taskguildv1connect.AgentManagerServiceClient,
 	taskClient taskguildv1connect.TaskServiceClient,
@@ -641,6 +674,9 @@ func buildClaudeOptions(
 
 	if sessionID != "" {
 		opts.Resume = sessionID
+		if forkSession {
+			opts.ForkSession = true
+		}
 	}
 
 	// Set --worktree flag whenever worktree is enabled. This ensures Claude CLI

--- a/cmd/taskguild-agent/runner_test.go
+++ b/cmd/taskguild-agent/runner_test.go
@@ -327,3 +327,90 @@ NEXT_STATUS: Develop`
 	}
 	assert.True(t, foundDesc, "expected a description update via UpdateTask")
 }
+
+func TestResolveSession(t *testing.T) {
+	tests := []struct {
+		name            string
+		metadata        map[string]string
+		wantSessionID   string
+		wantForkSession bool
+	}{
+		{
+			name:            "new task, no session",
+			metadata:        map[string]string{},
+			wantSessionID:   "",
+			wantForkSession: false,
+		},
+		{
+			name: "same-status retry with per-status session",
+			metadata: map[string]string{
+				"_current_status_name": "Plan",
+				"_agent_name":         "architect",
+				"session_id":          "global-sess",
+				"session_id:Plan":     "plan-sess",
+			},
+			wantSessionID:   "plan-sess",
+			wantForkSession: false,
+		},
+		{
+			name: "agent changed, should fork",
+			metadata: map[string]string{
+				"_current_status_name": "Develop",
+				"_agent_name":         "senior-engineer",
+				"session_id":          "global-sess",
+				"_last_session_agent": "architect",
+			},
+			wantSessionID:   "global-sess",
+			wantForkSession: true,
+		},
+		{
+			name: "same agent, normal resume",
+			metadata: map[string]string{
+				"_current_status_name": "Plan",
+				"_agent_name":         "architect",
+				"session_id":          "global-sess",
+				"_last_session_agent": "architect",
+			},
+			wantSessionID:   "global-sess",
+			wantForkSession: false,
+		},
+		{
+			name: "legacy task without _last_session_agent",
+			metadata: map[string]string{
+				"_current_status_name": "Plan",
+				"_agent_name":         "architect",
+				"session_id":          "global-sess",
+			},
+			wantSessionID:   "global-sess",
+			wantForkSession: false,
+		},
+		{
+			name: "no agent name, normal resume",
+			metadata: map[string]string{
+				"_current_status_name": "Plan",
+				"session_id":          "global-sess",
+				"_last_session_agent": "architect",
+			},
+			wantSessionID:   "global-sess",
+			wantForkSession: false,
+		},
+		{
+			name: "no status name, falls back to global",
+			metadata: map[string]string{
+				"session_id":          "global-sess",
+				"_last_session_agent": "architect",
+				"_agent_name":         "senior-engineer",
+			},
+			wantSessionID:   "global-sess",
+			wantForkSession: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sessionID, forkSession := resolveSession(tt.metadata)
+			assert.Equal(t, tt.wantSessionID, sessionID)
+			assert.Equal(t, tt.wantForkSession, forkSession)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add per-status session ID tracking so same-status retries resume the correct session (`session_id:<status>` metadata)
- Fork session when agent changes between statuses, enabling clean context handoff via `ForkSession` flag
- Store `_last_session_agent` and `session_agent:<status>` metadata for agent change detection
- Add `resolveSession()` helper with comprehensive test coverage (7 cases)