### PR TITLE
refactor: restructure cmd-log path to include projectID

### DIFF
--- a/cmd/taskguild-agent/cmdlog.go
+++ b/cmd/taskguild-agent/cmdlog.go
@@ -40,17 +40,21 @@ type turnLog struct {
 
 // newTurnLog creates a new turn log file and writes the header.
 // If workDir is empty, logging is disabled (all methods become no-ops).
-func newTurnLog(workDir, taskID, label string) *turnLog {
+func newTurnLog(workDir, projectID, taskID, label string) *turnLog {
 	if workDir == "" {
 		return &turnLog{}
 	}
 
-	dir := taskID
-	if dir == "" {
-		dir = "_system"
+	projectDir := projectID
+	if projectDir == "" {
+		projectDir = "_system"
+	}
+	taskDir := taskID
+	if taskDir == "" {
+		taskDir = "_system"
 	}
 
-	logDir := filepath.Join(workDir, ".claude", "cmd-logs", dir)
+	logDir := filepath.Join(workDir, ".taskguild", "logs", projectDir, taskDir)
 	if err := os.MkdirAll(logDir, 0o755); err != nil {
 		slog.Warn("failed to create cmd-log directory", "dir", logDir, "error", err)
 		return &turnLog{}
@@ -80,7 +84,7 @@ func newTurnLog(workDir, taskID, label string) *turnLog {
 	}
 
 	tl := &turnLog{file: f}
-	tl.write(fmt.Sprintf("# Turn log: %s\n# Task: %s\n# Label: %s\n", ts, taskID, label))
+	tl.write(fmt.Sprintf("# Turn log: %s\n# Project: %s\n# Task: %s\n# Label: %s\n", ts, projectID, taskID, label))
 	return tl
 }
 
@@ -214,14 +218,14 @@ func runQuerySyncWithLog(
 	ctx context.Context,
 	prompt string,
 	options *claudeagent.ClaudeAgentOptions,
-	workDir, taskID, label string,
+	workDir, projectID, taskID, label string,
 ) (*claudeagent.QueryResult, error) {
 	opts := claudeagent.ClaudeAgentOptions{}
 	if options != nil {
 		opts = *options
 	}
 
-	tl := newTurnLog(workDir, taskID, label)
+	tl := newTurnLog(workDir, projectID, taskID, label)
 	defer tl.Close()
 
 	// Configure permission prompt tool name (matching RunQuery behavior).

--- a/cmd/taskguild-agent/query_runner.go
+++ b/cmd/taskguild-agent/query_runner.go
@@ -19,13 +19,15 @@ type QueryRunner interface {
 
 // subprocessQueryRunner is the production implementation that delegates to
 // runQuerySyncWithLog to launch a real Claude CLI subprocess.
-type subprocessQueryRunner struct{}
+type subprocessQueryRunner struct {
+	projectID string
+}
 
-func (subprocessQueryRunner) RunQuerySync(
+func (r subprocessQueryRunner) RunQuerySync(
 	ctx context.Context,
 	prompt string,
 	options *claudeagent.ClaudeAgentOptions,
 	workDir, taskID, label string,
 ) (*claudeagent.QueryResult, error) {
-	return runQuerySyncWithLog(ctx, prompt, options, workDir, taskID, label)
+	return runQuerySyncWithLog(ctx, prompt, options, workDir, r.projectID, taskID, label)
 }

--- a/cmd/taskguild-agent/run.go
+++ b/cmd/taskguild-agent/run.go
@@ -474,7 +474,7 @@ func runSubscribeLoop(
 				}()
 
 				slog.Info("launching runTask goroutine", "task_id", tID)
-				runTask(taskCtx, client, taskClient, interClient, cfg.AgentManagerID, tID, instructions, metadata, cfg.WorkDir, permCache, scpCache, subprocessQueryRunner{})
+				runTask(taskCtx, client, taskClient, interClient, cfg.AgentManagerID, tID, instructions, metadata, cfg.WorkDir, permCache, scpCache, subprocessQueryRunner{projectID: metadata["_project_id"]})
 				slog.Info("runTask goroutine finished", "task_id", tID)
 			})
 
@@ -627,7 +627,7 @@ func runSubscribeLoop(
 				}()
 
 				slog.Info("launching runTask goroutine (assigned)", "task_id", tID)
-				runTask(taskCtx, client, taskClient, interClient, cfg.AgentManagerID, tID, instructions, metadata, cfg.WorkDir, permCache, scpCache, subprocessQueryRunner{})
+				runTask(taskCtx, client, taskClient, interClient, cfg.AgentManagerID, tID, instructions, metadata, cfg.WorkDir, permCache, scpCache, subprocessQueryRunner{projectID: metadata["_project_id"]})
 				slog.Info("runTask goroutine finished (assigned)", "task_id", tID)
 			})
 


### PR DESCRIPTION
## Summary
- Restructure log directory from `.claude/cmd-logs/{taskID}` to `.taskguild/logs/{projectID}/{taskID}` for better organization
- Thread `projectID` through `subprocessQueryRunner`, `runQuerySyncWithLog`, and `newTurnLog`
- Include project ID in turn log headers