### PR TITLE
Remove unnecessary session metadata fields

### DIFF
--- a/cmd/taskguild-agent/directive.go
+++ b/cmd/taskguild-agent/directive.go
@@ -400,21 +400,11 @@ func handleStatusTransition(
 	return nil
 }
 
-func saveSessionID(ctx context.Context, taskClient taskguildv1connect.TaskServiceClient, taskID, sessionID, statusName, agentName string) {
+func saveSessionID(ctx context.Context, taskClient taskguildv1connect.TaskServiceClient, taskID, sessionID string) {
 	logger := clog.LoggerFromContext(ctx)
-	meta := map[string]string{"session_id": sessionID}
-	if statusName != "" {
-		meta["session_id:"+statusName] = sessionID
-		if agentName != "" {
-			meta["session_agent:"+statusName] = agentName
-		}
-	}
-	if agentName != "" {
-		meta["_last_session_agent"] = agentName
-	}
 	_, err := taskClient.UpdateTask(ctx, connect.NewRequest(&v1.UpdateTaskRequest{
 		Id:       taskID,
-		Metadata: meta,
+		Metadata: map[string]string{"session_id": sessionID},
 	}))
 	if err != nil {
 		logger.Error("failed to save session_id", "error", err)

--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -260,8 +260,7 @@ func runTask(
 		if result.Result != nil && result.Result.SessionID != "" {
 			sessionID = result.Result.SessionID
 			forkSession = false // fork done, normal resume from here
-			saveSessionID(ctx, taskClient, taskID, sessionID,
-				metadata["_current_status_name"], metadata["_agent_name"])
+			saveSessionID(ctx, taskClient, taskID, sessionID)
 		}
 
 		// Handle errors with backoff retry.
@@ -569,33 +568,8 @@ func runTask(
 }
 
 // resolveSession determines which session ID to use and whether to fork.
-// It checks per-status sessions first (for same-status retries), then falls
-// back to the global session_id and compares agents to decide on forking.
 func resolveSession(metadata map[string]string) (sessionID string, forkSession bool) {
-	currentStatus := metadata["_current_status_name"]
-	currentAgent := metadata["_agent_name"]
-
-	// 1. Check for existing session in current status (same-status retry).
-	if currentStatus != "" {
-		if sid := metadata["session_id:"+currentStatus]; sid != "" {
-			return sid, false
-		}
-	}
-
-	// 2. Check global session ID.
-	globalSID := metadata["session_id"]
-	if globalSID == "" {
-		return "", false // new task
-	}
-
-	// 3. Compare with previous agent — fork if agent changed.
-	lastAgent := metadata["_last_session_agent"]
-	if lastAgent != "" && currentAgent != "" && lastAgent != currentAgent {
-		return globalSID, true
-	}
-
-	// 4. Same agent or unknown → normal resume.
-	return globalSID, false
+	return metadata["session_id"], false
 }
 
 // buildClaudeOptions constructs ClaudeAgentOptions for each turn.

--- a/cmd/taskguild-agent/runner_test.go
+++ b/cmd/taskguild-agent/runner_test.go
@@ -342,67 +342,12 @@ func TestResolveSession(t *testing.T) {
 			wantForkSession: false,
 		},
 		{
-			name: "same-status retry with per-status session",
+			name: "has global session",
 			metadata: map[string]string{
-				"_current_status_name": "Plan",
-				"_agent_name":         "architect",
-				"session_id":          "global-sess",
-				"session_id:Plan":     "plan-sess",
-			},
-			wantSessionID:   "plan-sess",
-			wantForkSession: false,
-		},
-		{
-			name: "agent changed, should fork",
-			metadata: map[string]string{
-				"_current_status_name": "Develop",
-				"_agent_name":         "senior-engineer",
-				"session_id":          "global-sess",
-				"_last_session_agent": "architect",
-			},
-			wantSessionID:   "global-sess",
-			wantForkSession: true,
-		},
-		{
-			name: "same agent, normal resume",
-			metadata: map[string]string{
-				"_current_status_name": "Plan",
-				"_agent_name":         "architect",
-				"session_id":          "global-sess",
-				"_last_session_agent": "architect",
+				"session_id": "global-sess",
 			},
 			wantSessionID:   "global-sess",
 			wantForkSession: false,
-		},
-		{
-			name: "legacy task without _last_session_agent",
-			metadata: map[string]string{
-				"_current_status_name": "Plan",
-				"_agent_name":         "architect",
-				"session_id":          "global-sess",
-			},
-			wantSessionID:   "global-sess",
-			wantForkSession: false,
-		},
-		{
-			name: "no agent name, normal resume",
-			metadata: map[string]string{
-				"_current_status_name": "Plan",
-				"session_id":          "global-sess",
-				"_last_session_agent": "architect",
-			},
-			wantSessionID:   "global-sess",
-			wantForkSession: false,
-		},
-		{
-			name: "no status name, falls back to global",
-			metadata: map[string]string{
-				"session_id":          "global-sess",
-				"_last_session_agent": "architect",
-				"_agent_name":         "senior-engineer",
-			},
-			wantSessionID:   "global-sess",
-			wantForkSession: true,
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Simplify `resolveSession` to only use the global `session_id`, removing per-status session tracking and agent-based fork logic
- Remove unused `statusName` and `agentName` parameters from `saveSessionID`
- Clean up related test cases that are no longer applicable

This removes complexity around per-status session IDs (`session_id:<status>`) and agent change detection (`_last_session_agent`, `session_agent:<status>`) that are no longer needed.