### PR TITLE
fix: only report stopped-by-user for explicit cancellations

### DIFF
--- a/cmd/taskguild-agent/hooks_test.go
+++ b/cmd/taskguild-agent/hooks_test.go
@@ -296,7 +296,7 @@ func TestRunTask_WithAfterHooks(t *testing.T) {
 
 	runTask(ctx, tc.agentClient, tc.taskClient, tc.interClient,
 		"agent-mgr-1", "task-with-hooks", "instructions", metadata,
-		t.TempDir(), permCache, scpCache, qr)
+		t.TempDir(), permCache, scpCache, qr, func() bool { return false })
 
 	// Verify both main task and hook were executed
 	calls := qr.getCalls()

--- a/cmd/taskguild-agent/run.go
+++ b/cmd/taskguild-agent/run.go
@@ -34,6 +34,19 @@ var scriptTracker struct {
 	reject  bool // true once SIGUSR1 is received; prevents new script starts
 }
 
+// userStoppedTasks tracks which tasks were explicitly stopped by the user
+// (via CancelTaskCommand) as opposed to system-initiated cancellations
+// (SIGINT/SIGTERM, task re-assignment). This prevents false "stopped by user"
+// reports when context is cancelled for non-user reasons.
+var userStoppedTasks struct {
+	mu      sync.Mutex
+	stopped map[string]bool
+}
+
+func init() {
+	userStoppedTasks.stopped = make(map[string]bool)
+}
+
 // safeGo launches f in a new goroutine with panic recovery using conc.WaitGroup.
 func safeGo(name string, f func()) {
 	var wg conc.WaitGroup
@@ -465,6 +478,9 @@ func runSubscribeLoop(
 					mu.Lock()
 					delete(activeTasks, tID)
 					mu.Unlock()
+					userStoppedTasks.mu.Lock()
+					delete(userStoppedTasks.stopped, tID)
+					userStoppedTasks.mu.Unlock()
 					taskCancel()
 				}()
 				defer func() {
@@ -473,8 +489,14 @@ func runSubscribeLoop(
 					}
 				}()
 
+				isUserStopped := func() bool {
+					userStoppedTasks.mu.Lock()
+					defer userStoppedTasks.mu.Unlock()
+					return userStoppedTasks.stopped[tID]
+				}
+
 				slog.Info("launching runTask goroutine", "task_id", tID)
-				runTask(taskCtx, client, taskClient, interClient, cfg.AgentManagerID, tID, instructions, metadata, cfg.WorkDir, permCache, scpCache, subprocessQueryRunner{projectID: metadata["_project_id"]})
+				runTask(taskCtx, client, taskClient, interClient, cfg.AgentManagerID, tID, instructions, metadata, cfg.WorkDir, permCache, scpCache, subprocessQueryRunner{projectID: metadata["_project_id"]}, isUserStopped)
 				slog.Info("runTask goroutine finished", "task_id", tID)
 			})
 
@@ -568,6 +590,10 @@ func runSubscribeLoop(
 			reason := cancelCmd.GetReason()
 			slog.Info("cancel request for task", "task_id", taskID, "reason", reason)
 
+			userStoppedTasks.mu.Lock()
+			userStoppedTasks.stopped[taskID] = true
+			userStoppedTasks.mu.Unlock()
+
 			mu.Lock()
 			if cancelFn, ok := activeTasks[taskID]; ok {
 				cancelFn()
@@ -618,6 +644,9 @@ func runSubscribeLoop(
 					mu.Lock()
 					delete(activeTasks, tID)
 					mu.Unlock()
+					userStoppedTasks.mu.Lock()
+					delete(userStoppedTasks.stopped, tID)
+					userStoppedTasks.mu.Unlock()
 					taskCancel()
 				}()
 				defer func() {
@@ -626,8 +655,14 @@ func runSubscribeLoop(
 					}
 				}()
 
+				isUserStopped := func() bool {
+					userStoppedTasks.mu.Lock()
+					defer userStoppedTasks.mu.Unlock()
+					return userStoppedTasks.stopped[tID]
+				}
+
 				slog.Info("launching runTask goroutine (assigned)", "task_id", tID)
-				runTask(taskCtx, client, taskClient, interClient, cfg.AgentManagerID, tID, instructions, metadata, cfg.WorkDir, permCache, scpCache, subprocessQueryRunner{projectID: metadata["_project_id"]})
+				runTask(taskCtx, client, taskClient, interClient, cfg.AgentManagerID, tID, instructions, metadata, cfg.WorkDir, permCache, scpCache, subprocessQueryRunner{projectID: metadata["_project_id"]}, isUserStopped)
 				slog.Info("runTask goroutine finished (assigned)", "task_id", tID)
 			})
 

--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -67,6 +67,7 @@ func runTask(
 	permCache *permissionCache,
 	scpCache *singleCommandPermissionCache,
 	queryRunner QueryRunner,
+	isUserStopped func() bool,
 ) {
 	// Create task-scoped logger and embed in context.
 	logger := slog.Default().With("task_id", taskID)
@@ -138,11 +139,14 @@ func runTask(
 	}
 	defer afterHooks()
 
-	// Defense-in-depth: if context is cancelled (e.g. user stop), report
+	// Defense-in-depth: if context is cancelled by user stop, report
 	// the cancellation with a fresh context so the RPC can still succeed.
+	// Only report "stopped by user" when the user explicitly stopped the task;
+	// system-initiated cancellations (e.g. task re-assignment after status
+	// transition) should not produce this error.
 	// This defer runs after afterHooks (LIFO) but before tl.Close.
 	defer func() {
-		if ctx.Err() == context.Canceled {
+		if ctx.Err() == context.Canceled && isUserStopped() {
 			bgCtx, bgCancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer bgCancel()
 			reportTaskResult(bgCtx, client, taskID, "", "stopped by user")
@@ -438,9 +442,9 @@ func runTask(
 					tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_WARN,
 						"Max status transition retries reached, completing without transition", nil)
 					displaySummary := stripNextStatus(summary)
+					afterHooks()
 					reportTaskResult(ctx, client, taskID, displaySummary, "")
 					reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_IDLE, "task completed (invalid transition after retries)")
-					afterHooks()
 					maybeRunAgentMDHarness(ctx, metadata, taskID, displaySummary, workDir, tl, client, queryRunner)
 					return
 				}
@@ -460,16 +464,16 @@ func runTask(
 			tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
 				fmt.Sprintf("Task completed with status transition (turn %d)", turn),
 				map[string]string{"next_status": nextStatusID})
+			// Run after hooks before unassigning/transitioning so that hooks
+			// still observe the current status and the task remains ASSIGNED
+			// until all hooks complete.
+			logger.Info("running after hooks")
+			afterHooks()
+			logger.Info("after hooks completed")
 			logger.Info("reporting task result")
 			reportTaskResult(ctx, client, taskID, displaySummary, "")
 			logger.Info("reporting agent status IDLE")
 			reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_IDLE, "task completed")
-			// Run after hooks before transitioning status so that hooks
-			// still observe the current status and the transition happens
-			// only after all hooks complete.
-			logger.Info("running after hooks")
-			afterHooks()
-			logger.Info("after hooks completed")
 			// Launch AGENT.md harness in background goroutine if enabled.
 			maybeRunAgentMDHarness(ctx, metadata, taskID, displaySummary, workDir, tl, client, queryRunner)
 			logger.Info("calling handleStatusTransition", "next_status", nextStatusID)
@@ -488,6 +492,7 @@ func runTask(
 			logger.Info("completed at terminal status", "turn", turn)
 			tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
 				fmt.Sprintf("Task completed at terminal status (turn %d)", turn), nil)
+			afterHooks()
 			reportTaskResult(ctx, client, taskID, summary, "")
 			reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_IDLE, "task completed")
 			// Launch AGENT.md harness in background goroutine if enabled.
@@ -503,9 +508,9 @@ func runTask(
 				"next_status_name", autoName, "turn", turn)
 			tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
 				fmt.Sprintf("No NEXT_STATUS output; auto-transitioning to %s", autoName), nil)
+			afterHooks()
 			reportTaskResult(ctx, client, taskID, summary, "")
 			reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_IDLE, "task completed (auto-transition)")
-			afterHooks()
 			maybeRunAgentMDHarness(ctx, metadata, taskID, summary, workDir, tl, client, queryRunner)
 			if err := handleStatusTransition(ctx, taskClient, taskID, autoName, metadata, tl); err != nil {
 				logger.Error("auto status transition failed", "error", err)
@@ -526,11 +531,11 @@ func runTask(
 				logger.Warn("max user response retries reached, force-completing task", "retries", userResponseRetries-1)
 				tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_WARN,
 					"Max user response retries reached, force-completing task", nil)
-				reportTaskResult(ctx, client, taskID, summary, "")
-				reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_IDLE, "task force-completed (no NEXT_STATUS after retries)")
 				// Attempt auto-transition on force-complete so the task
 				// does not remain stuck at the current status.
 				afterHooks()
+				reportTaskResult(ctx, client, taskID, summary, "")
+				reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_IDLE, "task force-completed (no NEXT_STATUS after retries)")
 				if err := handleStatusTransition(ctx, taskClient, taskID, "", metadata, tl); err != nil {
 					logger.Warn("auto-transition on force-complete failed", "error", err)
 					tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_WARN,
@@ -550,10 +555,10 @@ func runTask(
 		}
 		if err != nil {
 			logger.Error("user response error, completing task", "error", err)
-			reportTaskResult(ctx, client, taskID, summary, "")
-			reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_IDLE, "task completed (no user response)")
 			// Attempt auto-transition so the task does not remain stuck.
 			afterHooks()
+			reportTaskResult(ctx, client, taskID, summary, "")
+			reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_IDLE, "task completed (no user response)")
 			if transErr := handleStatusTransition(ctx, taskClient, taskID, "", metadata, tl); transErr != nil {
 				logger.Warn("auto-transition on user response error failed", "error", transErr)
 			}

--- a/cmd/taskguild-agent/runner_test.go
+++ b/cmd/taskguild-agent/runner_test.go
@@ -31,7 +31,7 @@ func TestRunTask_PlanToDevelop(t *testing.T) {
 
 	runTask(ctx, tc.agentClient, tc.taskClient, tc.interClient,
 		"agent-mgr-1", "task-1", "system instructions", metadata,
-		t.TempDir(), permCache, scpCache, qr)
+		t.TempDir(), permCache, scpCache, qr, func() bool { return false })
 
 	// Verify status transition
 	tc.taskHandler.mu.Lock()
@@ -61,7 +61,7 @@ func TestRunTask_DevelopToReview(t *testing.T) {
 
 	runTask(ctx, tc.agentClient, tc.taskClient, tc.interClient,
 		"agent-mgr-1", "task-2", "system instructions", metadata,
-		t.TempDir(), permCache, scpCache, qr)
+		t.TempDir(), permCache, scpCache, qr, func() bool { return false })
 
 	tc.taskHandler.mu.Lock()
 	defer tc.taskHandler.mu.Unlock()
@@ -91,7 +91,7 @@ func TestRunTask_FullWorkflow_PlanDevelopReview(t *testing.T) {
 	}
 	runTask(ctx1, tc.agentClient, tc.taskClient, tc.interClient,
 		"agent-mgr-1", "task-full", "instructions", metadata1,
-		workDir, permCache, scpCache, qr1)
+		workDir, permCache, scpCache, qr1, func() bool { return false })
 
 	// Phase 2: Develop -> Review
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 30*time.Second)
@@ -105,7 +105,7 @@ func TestRunTask_FullWorkflow_PlanDevelopReview(t *testing.T) {
 	}
 	runTask(ctx2, tc.agentClient, tc.taskClient, tc.interClient,
 		"agent-mgr-1", "task-full", "instructions", metadata2,
-		workDir, permCache, scpCache, qr2)
+		workDir, permCache, scpCache, qr2, func() bool { return false })
 
 	// Phase 3: Review (terminal - no transitions)
 	ctx3, cancel3 := context.WithTimeout(context.Background(), 30*time.Second)
@@ -119,7 +119,7 @@ func TestRunTask_FullWorkflow_PlanDevelopReview(t *testing.T) {
 	}
 	runTask(ctx3, tc.agentClient, tc.taskClient, tc.interClient,
 		"agent-mgr-1", "task-full", "instructions", metadata3,
-		workDir, permCache, scpCache, qr3)
+		workDir, permCache, scpCache, qr3, func() bool { return false })
 
 	// Verify: exactly 2 status transitions (Plan->Develop, Develop->Review)
 	tc.taskHandler.mu.Lock()
@@ -152,7 +152,7 @@ func TestRunTask_InvalidTransitionRetry(t *testing.T) {
 
 	runTask(ctx, tc.agentClient, tc.taskClient, tc.interClient,
 		"agent-mgr-1", "task-retry", "instructions", metadata,
-		t.TempDir(), permCache, scpCache, qr)
+		t.TempDir(), permCache, scpCache, qr, func() bool { return false })
 
 	// Verify QueryRunner was called twice
 	calls := qr.getCalls()
@@ -190,7 +190,7 @@ func TestRunTask_AutoTransition_SingleTarget(t *testing.T) {
 
 	runTask(ctx, tc.agentClient, tc.taskClient, tc.interClient,
 		"agent-mgr-1", "task-auto", "instructions", metadata,
-		t.TempDir(), permCache, scpCache, qr)
+		t.TempDir(), permCache, scpCache, qr, func() bool { return false })
 
 	// Verify auto-transition to Develop
 	tc.taskHandler.mu.Lock()
@@ -221,7 +221,7 @@ func TestRunTask_TerminalStatus(t *testing.T) {
 
 	runTask(ctx, tc.agentClient, tc.taskClient, tc.interClient,
 		"agent-mgr-1", "task-terminal", "instructions", metadata,
-		t.TempDir(), permCache, scpCache, qr)
+		t.TempDir(), permCache, scpCache, qr, func() bool { return false })
 
 	// No status transitions should have been attempted
 	tc.taskHandler.mu.Lock()
@@ -267,7 +267,7 @@ NEXT_STATUS: Develop`
 
 	runTask(ctx, tc.agentClient, tc.taskClient, tc.interClient,
 		"agent-mgr-1", "task-create", "instructions", metadata,
-		t.TempDir(), permCache, scpCache, qr)
+		t.TempDir(), permCache, scpCache, qr, func() bool { return false })
 
 	// Verify CreateTask was called
 	tc.taskHandler.mu.Lock()
@@ -310,7 +310,7 @@ NEXT_STATUS: Develop`
 
 	runTask(ctx, tc.agentClient, tc.taskClient, tc.interClient,
 		"agent-mgr-1", "task-desc", "instructions", metadata,
-		t.TempDir(), permCache, scpCache, qr)
+		t.TempDir(), permCache, scpCache, qr, func() bool { return false })
 
 	// Verify UpdateTask was called with the description
 	tc.taskHandler.mu.Lock()

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -78,6 +78,16 @@ func (o *Orchestrator) handleTaskEvent(ctx context.Context, event *taskguildv1.E
 		return // no agent config for this status (terminal or manual)
 	}
 
+	// If the task is already assigned to an agent (e.g. still running hooks
+	// after a status transition triggered by that agent), skip reassignment.
+	// The running agent will unassign the task when it finishes, and the
+	// subsequent status change will re-trigger this handler.
+	if t.AssignmentStatus == task.AssignmentStatusAssigned {
+		slog.Info("orchestrator: task already assigned to agent, skipping",
+			"task_id", t.ID, "agent_id", t.AssignedAgentID)
+		return
+	}
+
 	// Set assignment status to PENDING.
 	t.AssignmentStatus = task.AssignmentStatusPending
 	t.UpdatedAt = time.Now()


### PR DESCRIPTION
## Summary
- Track user-initiated task stops (`CancelTaskCommand`) separately from system-initiated cancellations (SIGINT, task re-assignment) using a `userStoppedTasks` map, preventing false "stopped by user" error reports
- Reorder `afterHooks()` to execute before `reportTaskResult`/`reportAgentStatus` across all completion paths so hooks run while the task is still assigned
- Skip orchestrator reassignment when a task is already assigned to an agent, preventing a race condition during hook execution after status transitions