### PR TITLE
fix: rename AGENT.md Harness to Agent Markdown Harness in UI and comments

### DIFF
--- a/frontend/src/components/organisms/WorkflowForm.tsx
+++ b/frontend/src/components/organisms/WorkflowForm.tsx
@@ -31,7 +31,7 @@ interface StatusDraft {
   transitionsTo: string[] // keys
   agentId: string // reference to AgentDefinition
   hooks: HookDraft[]
-  enableAgentMdHarness: boolean // default true: review AGENT.md on status exit
+  enableAgentMdHarness: boolean // default true: review agent markdown on status exit
   agentMdHarnessExplicitlyDisabled: boolean // tracks explicit user choice
   permissionMode: string // permission mode for agents in this status
   inheritSessionFrom: string // name of status to inherit session from (fork)
@@ -665,7 +665,7 @@ export function WorkflowForm({
                     </div>
                   )}
 
-                  {/* AGENT.md Harness Toggle */}
+                  {/* Agent Markdown Harness Toggle */}
                   {!s.isTerminal && (
                     <div className="mt-2 px-1">
                       <label className="flex items-center gap-2 text-xs text-gray-400 cursor-pointer">
@@ -676,8 +676,8 @@ export function WorkflowForm({
                             agentMdHarnessExplicitlyDisabled: !e.target.checked,
                           })}
                         />
-                        <span>AGENT.md Harness</span>
-                        <span className="text-[10px] text-gray-600">(review &amp; update AGENT.md on status exit)</span>
+                        <span>Agent Markdown Harness</span>
+                        <span className="text-[10px] text-gray-600">(review &amp; update agent markdown on status exit)</span>
                       </label>
                     </div>
                   )}

--- a/internal/agentmanager/task_handler.go
+++ b/internal/agentmanager/task_handler.go
@@ -786,7 +786,7 @@ func (s *Server) ClaimTask(ctx context.Context, req *connect.Request[taskguildv1
 		}
 	}
 
-	// Inject AGENT.md harness flag for the current status.
+	// Inject agent markdown harness flag for the current status.
 	// Default is enabled (true) unless explicitly disabled.
 	for _, st := range wf.Statuses {
 		if st.Name == t.StatusID {

--- a/internal/workflow/entity.go
+++ b/internal/workflow/entity.go
@@ -57,7 +57,7 @@ type Status struct {
 	AgentID       string       `yaml:"agent_id,omitempty"`
 	Hooks         []StatusHook `yaml:"hooks,omitempty"`
 
-	// EnableAgentMDHarness controls whether a background AGENT.md review
+	// EnableAgentMDHarness controls whether a background agent markdown review
 	// harness runs when a task exits this status. Default is true (enabled).
 	EnableAgentMDHarness              bool `yaml:"enable_agent_md_harness"`
 	AgentMDHarnessExplicitlyDisabled  bool `yaml:"agent_md_harness_explicitly_disabled,omitempty"`

--- a/proto/taskguild/v1/workflow.proto
+++ b/proto/taskguild/v1/workflow.proto
@@ -80,7 +80,7 @@ message WorkflowStatus {
   // hooks
   repeated StatusHook hooks = 8;
 
-  // harness: when true, a background agent reviews and updates AGENT.md
+  // harness: when true, a background agent reviews and updates agent markdown
   // with lessons learned upon status exit. Defaults to true when not set.
   bool enable_agent_md_harness = 9;
   // Explicitly tracks whether enable_agent_md_harness was set by the user.


### PR DESCRIPTION
## Summary
- Rename "AGENT.md Harness" to "Agent Markdown Harness" in workflow settings UI labels and code comments
- There is no actual `AGENT.md` file — the real files are `.claude/agents/<name>.md`, so the old label was misleading
- Identifiers (variable names, proto field names) are unchanged for backward compatibility

## Changed files
- `frontend/src/components/organisms/WorkflowForm.tsx` — UI label & comments (4 places)
- `proto/taskguild/v1/workflow.proto` — comment (1 place)
- `internal/workflow/entity.go` — comment (1 place)
- `internal/agentmanager/task_handler.go` — comment (1 place)

## Test plan
- [ ] Go build passes (`make build` ✅)
- [ ] Open Workflow Settings UI and verify the toggle label shows "Agent Markdown Harness"
- [ ] Verify harness functionality still works correctly on status transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)