### PR TITLE
fix: harness fork transport closed and hook logs in worktree

### DIFF
--- a/cmd/taskguild-agent/harness.go
+++ b/cmd/taskguild-agent/harness.go
@@ -42,6 +42,28 @@ var globalHarnessTracker = &harnessTracker{running: make(map[string]*harnessRun)
 
 const harnessReplaceTimeout = 30 * time.Second
 
+// resolveClaudeCwd returns the directory Claude CLI should use as CWD.
+// When forking a session created inside a worktree, the CWD must match
+// the worktree directory; otherwise the CLI cannot locate the session
+// and the transport closes immediately.
+func resolveClaudeCwd(workDir string, metadata map[string]string, sessionID string) string {
+	if sessionID == "" {
+		return workDir
+	}
+	if metadata["_use_worktree"] != "true" {
+		return workDir
+	}
+	wt := metadata["worktree"]
+	if wt == "" {
+		return workDir
+	}
+	wtDir := filepath.Join(workDir, ".claude", "worktrees", wt)
+	if info, err := os.Stat(wtDir); err == nil && info.IsDir() {
+		return wtDir
+	}
+	return workDir
+}
+
 // launchOrReplace cancels any in-flight harness for the same agentMDPath,
 // waits for it to finish, then launches fn in a new goroutine.
 func (ht *harnessTracker) launchOrReplace(agentMDPath string, fn func(ctx context.Context)) {
@@ -146,10 +168,12 @@ func maybeRunAgentMDHarness(
 
 	agentMDPath := filepath.Join(workDir, ".claude", "agents", agentName+".md")
 
+	claudeCwd := resolveClaudeCwd(workDir, metadata, sessionID)
+
 	globalHarnessTracker.launchOrReplace(agentMDPath, func(harnessCtx context.Context) {
 		// Create a dedicated taskLogger for the harness goroutine.
 		harnessTL := newTaskLogger(context.Background(), client, taskID)
-		runAgentMDHarness(harnessCtx, taskID, taskTitle, taskDescription, taskSummary, workDir, agentName, harnessTL, qr, sessionID)
+		runAgentMDHarness(harnessCtx, taskID, taskTitle, taskDescription, taskSummary, workDir, claudeCwd, agentName, harnessTL, qr, sessionID)
 	})
 }
 
@@ -199,8 +223,10 @@ func runAgentMDHarnessAndWait(
 		globalHarnessTracker.mu.Unlock()
 	}
 
+	claudeCwd := resolveClaudeCwd(workDir, metadata, sessionID)
+
 	harnessTL := newTaskLogger(context.Background(), client, taskID)
-	runAgentMDHarness(ctx, taskID, taskTitle, taskDescription, taskSummary, workDir, agentName, harnessTL, qr, sessionID)
+	runAgentMDHarness(ctx, taskID, taskTitle, taskDescription, taskSummary, workDir, claudeCwd, agentName, harnessTL, qr, sessionID)
 }
 
 // runAgentMDHarness runs the agent MD review harness.
@@ -214,6 +240,7 @@ func runAgentMDHarness(
 	taskDescription string,
 	taskSummary string,
 	workDir string,
+	claudeCwd string,
 	agentName string,
 	tl *taskLogger,
 	qr QueryRunner,
@@ -255,7 +282,7 @@ func runAgentMDHarness(
 	maxTurns := harnessMaxTurns
 	opts := &claudeagent.ClaudeAgentOptions{
 		SystemPrompt:   agentMDHarnessPrompt,
-		Cwd:            workDir,
+		Cwd:            claudeCwd,
 		PermissionMode: claudeagent.PermissionModeBypassPermissions,
 		MaxTurns:       &maxTurns,
 	}

--- a/cmd/taskguild-agent/query_runner.go
+++ b/cmd/taskguild-agent/query_runner.go
@@ -20,7 +20,8 @@ type QueryRunner interface {
 // subprocessQueryRunner is the production implementation that delegates to
 // runQuerySyncWithLog to launch a real Claude CLI subprocess.
 type subprocessQueryRunner struct {
-	projectID string
+	projectID  string
+	projectDir string // main project directory, used as log base
 }
 
 func (r subprocessQueryRunner) RunQuerySync(
@@ -29,5 +30,12 @@ func (r subprocessQueryRunner) RunQuerySync(
 	options *claudeagent.ClaudeAgentOptions,
 	workDir, taskID, label string,
 ) (*claudeagent.QueryResult, error) {
-	return runQuerySyncWithLog(ctx, prompt, options, workDir, r.projectID, taskID, label)
+	// Always use the main project directory for turn log output so that
+	// logs from hooks/harness running in a worktree are co-located with
+	// the task's other logs instead of scattered under the worktree.
+	logBaseDir := workDir
+	if r.projectDir != "" {
+		logBaseDir = r.projectDir
+	}
+	return runQuerySyncWithLog(ctx, prompt, options, logBaseDir, r.projectID, taskID, label)
 }

--- a/cmd/taskguild-agent/run.go
+++ b/cmd/taskguild-agent/run.go
@@ -497,7 +497,7 @@ func runSubscribeLoop(
 				}
 
 				slog.Info("launching runTask goroutine", "task_id", tID)
-				runTask(taskCtx, client, taskClient, interClient, cfg.AgentManagerID, tID, instructions, metadata, cfg.WorkDir, permCache, scpCache, subprocessQueryRunner{projectID: metadata["_project_id"]}, isUserStopped)
+				runTask(taskCtx, client, taskClient, interClient, cfg.AgentManagerID, tID, instructions, metadata, cfg.WorkDir, permCache, scpCache, subprocessQueryRunner{projectID: metadata["_project_id"], projectDir: cfg.WorkDir}, isUserStopped)
 				slog.Info("runTask goroutine finished", "task_id", tID)
 			})
 
@@ -663,7 +663,7 @@ func runSubscribeLoop(
 				}
 
 				slog.Info("launching runTask goroutine (assigned)", "task_id", tID)
-				runTask(taskCtx, client, taskClient, interClient, cfg.AgentManagerID, tID, instructions, metadata, cfg.WorkDir, permCache, scpCache, subprocessQueryRunner{projectID: metadata["_project_id"]}, isUserStopped)
+				runTask(taskCtx, client, taskClient, interClient, cfg.AgentManagerID, tID, instructions, metadata, cfg.WorkDir, permCache, scpCache, subprocessQueryRunner{projectID: metadata["_project_id"], projectDir: cfg.WorkDir}, isUserStopped)
 				slog.Info("runTask goroutine finished (assigned)", "task_id", tID)
 			})
 


### PR DESCRIPTION
## Summary

- Fix harness `transport closed` error when forking sessions created in worktrees
- Fix hook/harness turn logs being written to worktree directory instead of main project

## Root causes

### Harness fork failure
When a task session is created inside a worktree (CWD = `.claude/worktrees/<name>/`), the harness tried to fork it with CWD = main project directory. Claude CLI could not locate the session from a different CWD, causing immediate `transport closed`.

**Fix**: Added `resolveClaudeCwd()` that detects when a worktree is active and uses the worktree directory as the Claude CLI CWD for forking.

### Log path
`RunQuerySync` used the `workDir` parameter as the base for turn log output. For hooks running in the worktree directory, logs were written to `<worktree>/.taskguild/logs/` instead of the main project's `.taskguild/logs/`.

**Fix**: `subprocessQueryRunner` now stores the main project directory and always uses it as the log base, regardless of the working directory passed to `RunQuerySync`.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Verify harness fork succeeds (no more `transport closed`)
- [ ] Verify hook/harness logs appear in main `.taskguild/logs/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)