### PR TITLE
fix: agent process hangs up to 3 minutes on sentinel hot-reload

### DIFF
--- a/cmd/taskguild-agent/run.go
+++ b/cmd/taskguild-agent/run.go
@@ -386,7 +386,6 @@ func runSubscribeLoop(
 	lastReceive.Store(time.Now().UnixNano())
 
 	watchdogDone := make(chan struct{})
-	defer close(watchdogDone)
 	var watchdogWg conc.WaitGroup
 	watchdogWg.Go(func() {
 		ticker := time.NewTicker(30 * time.Second)
@@ -406,7 +405,10 @@ func runSubscribeLoop(
 			}
 		}
 	})
-	defer watchdogWg.Wait()
+	defer func() {
+		close(watchdogDone)
+		watchdogWg.Wait()
+	}()
 
 	for stream.Receive() {
 		lastReceive.Store(time.Now().UnixNano())

--- a/pkg/sentinel/sentinel.go
+++ b/pkg/sentinel/sentinel.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -46,6 +47,7 @@ const (
 type Sentinel struct {
 	binaryPath string
 	childArgs  []string // extra arguments appended after "run"
+	hashMu     sync.RWMutex         // protects lastHash
 	lastHash   [sha256.Size]byte
 	backoff    time.Duration
 	stopCh     chan struct{} // closed when sentinel should exit
@@ -117,12 +119,13 @@ func Run(extraArgs ...string) {
 	}
 
 	// Compute initial SHA256 hash of the binary.
-	s.lastHash, err = HashFile(binaryPath)
+	initialHash, err := HashFile(binaryPath)
 	if err != nil {
 		slog.Error("failed to hash binary", "error", err)
 		os.Exit(1)
 	}
-	slog.Info("initial binary hash computed", "hash", fmt.Sprintf("%x", s.lastHash[:8]))
+	s.lastHash = initialHash
+	slog.Info("initial binary hash computed", "hash", fmt.Sprintf("%x", initialHash[:8]))
 
 	// Set up OS signal handler.
 	sigCh := make(chan os.Signal, 1)
@@ -212,8 +215,10 @@ func (s *Sentinel) mainLoop(sigCh <-chan os.Signal, updateCh <-chan struct{}) {
 			}
 			// Refresh the hash for the new binary.
 			if h, err := HashFile(s.binaryPath); err == nil {
+				s.hashMu.Lock()
 				s.lastHash = h
-				slog.Info("new binary hash", "hash", fmt.Sprintf("%x", s.lastHash[:8]))
+				s.hashMu.Unlock()
+				slog.Info("new binary hash", "hash", fmt.Sprintf("%x", h[:8]))
 			}
 			s.backoff = InitialBackoff
 
@@ -350,9 +355,12 @@ func (s *Sentinel) watchBinary(updateCh chan<- struct{}) {
 					slog.Error("failed to hash binary after event", "error", err)
 					return
 				}
-				if newHash != s.lastHash {
+				s.hashMu.RLock()
+				currentHash := s.lastHash
+				s.hashMu.RUnlock()
+				if newHash != currentHash {
 					slog.Info("binary checksum changed",
-						"old_hash", fmt.Sprintf("%x", s.lastHash[:8]),
+						"old_hash", fmt.Sprintf("%x", currentHash[:8]),
 						"new_hash", fmt.Sprintf("%x", newHash[:8]))
 					// Non-blocking send.
 					select {


### PR DESCRIPTION
## Summary
- Fix defer ordering bug in `runSubscribeLoop` watchdog that caused the agent process to hang up to 3 minutes after SIGUSR1 (hot-reload). Go defers execute in LIFO order, so `watchdogWg.Wait()` was running before `close(watchdogDone)`, blocking the watchdog goroutine from receiving its shutdown signal.
- Fix data race on `lastHash` field in sentinel by adding `sync.RWMutex` protection for concurrent access between `mainLoop` (writer) and `watchBinary`'s `time.AfterFunc` callback (reader).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/sentinel/...` passes
- [x] `go test -race ./pkg/sentinel/...` passes
- [ ] Manual test: send SIGUSR1 to running agent and confirm it exits within seconds (not 3 minutes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)