### PR TITLE
fix: Plan Result card disappears after status transitions

### DIFF
--- a/frontend/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/frontend/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -287,7 +287,7 @@ function TaskDetailPage() {
   // Show legacy result cards only when there are no RESULT log entries (backward compat for old tasks).
   const hasResultLogs = logs.some((l) => l.category === TaskLogCategory.RESULT)
   const resultSummary = hasResultLogs ? '' : (metadata['result_summary'] ?? '')
-  const rawPlanResult = hasResultLogs ? '' : (metadata['plan_result'] ?? '')
+  const rawPlanResult = metadata['plan_result'] ?? ''
   // Handle legacy plan_result that may be stored as JSON with a "plan" field
   const planResult = (() => {
     if (!rawPlanResult) return ''
@@ -445,7 +445,7 @@ function TaskDetailPage() {
           {/* Results — chronological result logs */}
           {(() => {
             const resultLogs = logs
-              .filter((l) => l.category === TaskLogCategory.RESULT)
+              .filter((l) => l.category === TaskLogCategory.RESULT && l.metadata['result_type'] !== 'plan')
               .sort((a, b) => {
                 if (!a.createdAt || !b.createdAt) return 0
                 const diff = Number(a.createdAt.seconds) - Number(b.createdAt.seconds)


### PR DESCRIPTION
## Summary
- Plan Result カードが後続ステータス（Develop等）で消える問題を修正
- `hasResultLogs` が true になると `metadata['plan_result']` を空文字に上書きしていたロジックを修正し、`plan_result` を常にメタデータから取得するよう変更
- Results セクションから `result_type="plan"` のログを除外し、Plan Result カードとの重複表示を防止

## Test plan
- [ ] タスクを Plan → Develop → Review と遷移させ、各ステータスで Plan Result カードが表示され続けることを確認
- [ ] Plan result がないタスクでは Plan Result カードが表示されないことを確認
- [ ] Results セクションに summary/error タイプのログのみ表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)