### PR TITLE
feat: workflow context に agent identity セクションを追加

### DIFF
--- a/cmd/taskguild-agent/prompt.go
+++ b/cmd/taskguild-agent/prompt.go
@@ -46,7 +46,10 @@ func buildWorkflowContext(metadata map[string]string) string {
 	sb.WriteString("You are an agent in a TaskGuild workflow.\n")
 
 	if agentName := metadata["_agent_name"]; agentName != "" {
-		sb.WriteString(fmt.Sprintf("@\"%s (agent)\"\n", agentName))
+		sb.WriteString(fmt.Sprintf("\n### Agent Identity\n"))
+		sb.WriteString(fmt.Sprintf("You are executing this task as the **%s** agent.\n", agentName))
+		sb.WriteString(fmt.Sprintf("Your agent definition file (`.claude/agents/%s.md`) has been loaded as your system prompt.\n", agentName))
+		sb.WriteString("You MUST follow all instructions, role definitions, and constraints defined in that agent definition.\n")
 	}
 
 	// Workflow statuses with current marker.


### PR DESCRIPTION
## Summary
- SDK の stream-json 出力には `--agent` フラグで指定した agent markdown file がロードされたことを確認するフィールドがないため、`--append-system-prompt` で agent identity を明示的に伝達するよう変更
- `@"architect (agent)"` という軽い注釈を、agent 名・定義ファイルパス・遵守義務を含む `### Agent Identity` セクションに置き換え

## Test plan
- [ ] agent 割り当て済みタスクを実行し、turn log の `--append-system-prompt` に `### Agent Identity` セクションが含まれることを確認
- [ ] agent 未割り当てタスクで Agent Identity セクションが出力されないことを確認