### PR TITLE
feat: wait for server readiness before agent initialization

### DIFF
--- a/cmd/taskguild-agent/run.go
+++ b/cmd/taskguild-agent/run.go
@@ -242,6 +242,14 @@ func runAgent() {
 		connect.WithInterceptors(interceptor),
 	)
 
+	// Wait for the server to be ready before making any RPC calls.
+	// This is important during sentinel hot-reload restarts where the
+	// server may still be starting up.
+	if err := waitForServer(ctx, httpClient, cfg.ServerURL); err != nil {
+		slog.Error("failed waiting for server", "error", err)
+		return
+	}
+
 	// Permission cache: shared across all tasks within this agent-manager.
 	permCache := newPermissionCache(cfg.ProjectName, client)
 
@@ -710,6 +718,61 @@ func heartbeat(ctx context.Context, client taskguildv1connect.AgentManagerServic
 			if err != nil {
 				slog.Warn("heartbeat error", "error", err)
 			}
+		}
+	}
+}
+
+// waitForServer polls the server's /health endpoint until it returns 200 OK.
+// This prevents the agent from attempting RPC calls before the server is ready,
+// which is common during sentinel hot-reload restarts.
+func waitForServer(ctx context.Context, httpClient *http.Client, serverURL string) error {
+	const (
+		initialBackoff = 1 * time.Second
+		maxBackoff     = 30 * time.Second
+		requestTimeout = 5 * time.Second
+	)
+
+	healthURL := serverURL + "/health"
+	backoff := initialBackoff
+	waited := false
+
+	for {
+		reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, healthURL, nil)
+		if err != nil {
+			cancel()
+			return fmt.Errorf("creating health request: %w", err)
+		}
+
+		resp, err := httpClient.Do(req)
+		cancel()
+
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				if waited {
+					slog.Info("server is ready")
+				}
+				return nil
+			}
+			err = fmt.Errorf("unexpected status %d", resp.StatusCode)
+		}
+
+		if !waited {
+			slog.Info("waiting for server to become ready", "url", healthURL)
+			waited = true
+		}
+		slog.Info("server not ready, retrying", "backoff", backoff, "error", err)
+
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- sentinel hot-reload 再起動時に taskguild-server がまだ起動していないタイミングで agent の初期化 sync が "connection refused" エラーになる問題を修正
- `waitForServer` 関数を追加し、RPC 呼び出し前に `/health` エンドポイントを exponential backoff (1s → 30s) でポーリングしてサーバーの起動を待つ
- context キャンセル (SIGINT/SIGTERM) にも対応し、待機中でも即座にシャットダウン可能

## Test plan
- [ ] サーバーを停止した状態で agent を起動 → "waiting for server to become ready" ログが出力されポーリングが繰り返されることを確認
- [ ] サーバーを起動 → "server is ready" ログ後に通常の sync が行われることを確認
- [ ] 待機中に Ctrl+C → 即座にシャットダウンすることを確認
- [ ] サーバーが既に起動済みの通常起動 → 遅延なく初期化が完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)