### PR TITLE
feat: Edit/Write/NotebookEdit ツールに Always Allow オプションを追加

### DIFF
--- a/cmd/taskguild-agent/interaction.go
+++ b/cmd/taskguild-agent/interaction.go
@@ -525,6 +525,12 @@ func handlePermissionRequest(
 			{Label: "Always Allow Command", Value: "always_allow_command", Description: "Allow and create rules for individual commands"},
 			{Label: "Deny", Value: "deny", Description: "Deny this tool use"},
 		}
+	} else if editTools[toolName] {
+		options = []*v1.InteractionOption{
+			{Label: "Allow", Value: "allow", Description: "Allow this tool use"},
+			{Label: "Always Allow", Value: "always_allow", Description: "Always allow this tool"},
+			{Label: "Deny", Value: "deny", Description: "Deny this tool use"},
+		}
 	} else {
 		options = []*v1.InteractionOption{
 			{Label: "Allow", Value: "allow", Description: "Allow this tool use"},
@@ -579,6 +585,14 @@ func handlePermissionRequest(
 		switch responseStr {
 		case "allow":
 			logger.Info("permission granted", "tool", toolName)
+			return claudeagent.PermissionResultAllow{}, nil
+		case "always_allow":
+			logger.Info("permission granted (always allow)", "tool", toolName)
+			if permCache != nil {
+				updates := buildPermissionUpdate(toolName, input, toolCtx.Suggestions)
+				rules := extractRuleStrings(updates)
+				go permCache.AddAndSync(ctx, rules)
+			}
 			return claudeagent.PermissionResultAllow{}, nil
 		default:
 			logger.Info("permission denied", "tool", toolName)

--- a/cmd/taskguild-agent/interaction_permission_test.go
+++ b/cmd/taskguild-agent/interaction_permission_test.go
@@ -78,9 +78,11 @@ func (m *mockAgentManagerClient) ReportAgentStatus(_ context.Context, _ *connect
 	return connect.NewResponse(&v1.ReportAgentStatusResponse{}), nil
 }
 
-func (m *mockAgentManagerClient) SyncPermissions(_ context.Context, _ *connect.Request[v1.SyncPermissionsRequest]) (*connect.Response[v1.SyncPermissionsResponse], error) {
+func (m *mockAgentManagerClient) SyncPermissions(_ context.Context, req *connect.Request[v1.SyncPermissionsRequest]) (*connect.Response[v1.SyncPermissionsResponse], error) {
 	return connect.NewResponse(&v1.SyncPermissionsResponse{
-		Permissions: &v1.PermissionSet{},
+		Permissions: &v1.PermissionSet{
+			Allow: req.Msg.GetLocalAllow(),
+		},
 	}), nil
 }
 
@@ -254,15 +256,18 @@ func TestHandlePermissionRequest_NonBashToolOptions(t *testing.T) {
 
 	inter := mock.interactions[0]
 
-	// Non-Bash tools should have 2 options: Allow and Deny.
-	if len(inter.Options) != 2 {
-		t.Errorf("expected 2 options for non-Bash tool, got %d", len(inter.Options))
+	// Edit tools (Write) should have 3 options: Allow, Always Allow, and Deny.
+	if len(inter.Options) != 3 {
+		t.Errorf("expected 3 options for edit tool, got %d", len(inter.Options))
 	}
 	if inter.Options[0].Value != "allow" {
 		t.Errorf("expected first option 'allow', got %q", inter.Options[0].Value)
 	}
-	if inter.Options[1].Value != "deny" {
-		t.Errorf("expected second option 'deny', got %q", inter.Options[1].Value)
+	if inter.Options[1].Value != "always_allow" {
+		t.Errorf("expected second option 'always_allow', got %q", inter.Options[1].Value)
+	}
+	if inter.Options[2].Value != "deny" {
+		t.Errorf("expected third option 'deny', got %q", inter.Options[2].Value)
 	}
 
 	// Should have no metadata.
@@ -472,5 +477,57 @@ func TestHandlePermissionRequest_AlwaysAllowCommand_WithRedirects(t *testing.T) 
 	}
 	if mock.addedPermissions[1].Type != "redirect" {
 		t.Errorf("expected second permission type 'redirect', got %q", mock.addedPermissions[1].Type)
+	}
+}
+
+func TestHandlePermissionRequest_AlwaysAllowEdit(t *testing.T) {
+	mock := &mockAgentManagerClient{}
+	permCache := newPermissionCache("test-project", mock)
+
+	ctx := context.Background()
+	waiter := newInteractionWaiter()
+
+	resultCh := make(chan claudeagent.PermissionResult, 1)
+	errCh := make(chan error, 1)
+	var wg conc.WaitGroup
+	wg.Go(func() {
+		result, err := handlePermissionRequest(
+			ctx, mock, "task-1", "agent-1",
+			"Edit", map[string]any{"file_path": "/tmp/test.txt"},
+			waiter, claudeagent.PermissionModeDefault,
+			claudeagent.ToolPermissionContext{},
+			permCache, nil,
+		)
+		resultCh <- result
+		errCh <- err
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	if len(mock.interactions) != 1 {
+		t.Fatalf("expected 1 interaction, got %d", len(mock.interactions))
+	}
+
+	// Simulate "always_allow" response.
+	waiter.Deliver(&v1.Interaction{
+		Id:       "test-interaction-id",
+		Status:   v1.InteractionStatus_INTERACTION_STATUS_RESPONDED,
+		Response: "always_allow",
+	})
+
+	result := <-resultCh
+	if err := <-errCh; err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := result.(claudeagent.PermissionResultAllow); !ok {
+		t.Fatalf("expected PermissionResultAllow, got %T", result)
+	}
+
+	// Wait briefly for async AddAndSync goroutine.
+	time.Sleep(100 * time.Millisecond)
+
+	// After always_allow, the permission cache should auto-allow the same tool.
+	if !permCache.Check("Edit", map[string]any{"file_path": "/tmp/other.txt"}) {
+		t.Error("expected Edit to be auto-allowed after always_allow, but cache check returned false")
 	}
 }

--- a/frontend/src/components/organisms/RequestItem.tsx
+++ b/frontend/src/components/organisms/RequestItem.tsx
@@ -82,12 +82,12 @@ function buildPatternRows(meta: BashPermissionMetadata): PatternRow[] {
   return rows
 }
 
-function getPermissionShortcutLabel(value: string, isBash: boolean): string | null {
+function getPermissionShortcutLabel(value: string, _isBash: boolean): string | null {
   switch (value) {
     case 'allow':
       return 'y'
     case 'always_allow':
-      return isBash ? null : null // hide for both bash and non-bash
+      return 'a'
     case 'always_allow_command':
       return 'a'
     case 'deny':
@@ -228,7 +228,7 @@ export function RequestItem({
   // Only filter out legacy "always_allow" if present.
   const displayOptions = useMemo(() => {
     if (!isPending) return interaction.options
-    return interaction.options.filter((opt) => opt.value !== 'always_allow')
+    return interaction.options
   }, [interaction.options, isPending])
 
   // Handle respond with special logic for always_allow_command

--- a/frontend/src/hooks/useRequestKeyboard.ts
+++ b/frontend/src/hooks/useRequestKeyboard.ts
@@ -93,16 +93,14 @@ function buildDefaultAlwaysAllowResponse(meta: BashPermissionMeta): string {
  *   y = allow, a = always_allow_command, n = deny
  *
  * For non-Bash permission requests:
- *   y = allow, n = deny
- *
- * The old Y (shift+y) = always_allow shortcut is removed.
+ *   y = allow, a = always_allow (edit tools only), n = deny
  */
 function getPermissionShortcutValue(key: string, isBash: boolean): string | null {
   switch (key) {
     case 'y':
       return 'allow'
     case 'a':
-      return isBash ? 'always_allow_command' : null
+      return isBash ? 'always_allow_command' : 'always_allow'
     case 'n':
       return 'deny'
     default:
@@ -271,13 +269,12 @@ export function useRequestKeyboard({
           const value = getPermissionShortcutValue(e.key, isBash)
           if (!value) return
 
-          // For 'y' and 'n', verify the option exists in the interaction
-          // For 'a' (always_allow_command), it's a synthetic option not in the original list
-          if (value !== 'always_allow_command') {
-            if (!selected.options.some((opt) => opt.value === value)) return
-          } else {
-            // always_allow_command is only available for bash
+          // For always_allow_command, it's a synthetic option for bash only
+          if (value === 'always_allow_command') {
             if (!isBash || !bashMeta) return
+          } else {
+            // For allow, deny, always_allow — verify the option exists in the interaction
+            if (!selected.options.some((opt) => opt.value === value)) return
           }
 
           e.preventDefault()


### PR DESCRIPTION
## Summary
- Edit/Write/NotebookEdit ツールの permission request に "Always Allow" オプションがなく、毎回個別に許可が必要だった問題を修正
- "Always Allow" 選択時に `permissionCache.AddAndSync` でルールを永続化し、以降の同ツール呼び出しを自動許可
- フロントエンドでキーボードショートカット `a` による "Always Allow" 操作に対応

## Test plan
- [x] `go build ./...` ビルド確認
- [x] `go test ./cmd/taskguild-agent/...` 全テスト pass
- [ ] 手動確認: Edit ツールの permission request に "Always Allow [a]" が表示されること
- [ ] 手動確認: "Always Allow" 選択後、同ツールが自動許可されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)