### PR TITLE
fix: git status --porcelain parsing strips leading dot from .claude/ paths

### DIFF
--- a/cmd/taskguild-agent/run.go
+++ b/cmd/taskguild-agent/run.go
@@ -828,21 +828,20 @@ func handleListWorktrees(ctx context.Context, client taskguildv1connect.AgentMan
 		statusCmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
 		statusCmd.Dir = wtDir
 		if out, err := statusCmd.Output(); err == nil {
-			lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+			lines := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
 			for _, line := range lines {
-				line = strings.TrimSpace(line)
-				if line == "" {
+				// git status --porcelain format: "XY filename" (filename starts at position 3)
+				// Do not TrimSpace: the leading space is part of the status code format
+				// and trimming shifts the offset, corrupting the filename (e.g. ".claude/" → "claude/").
+				if len(line) < 4 {
 					continue
 				}
-				// git status --porcelain format: "XY filename" (filename starts at position 3)
-				if len(line) > 3 {
-					filePath := line[3:]
-					if isClaudeInternalPath(filePath) {
-						continue
-					}
-					changedFiles = append(changedFiles, filePath)
-					hasChanges = true
+				filePath := line[3:]
+				if isClaudeInternalPath(filePath) {
+					continue
 				}
+				changedFiles = append(changedFiles, filePath)
+				hasChanges = true
 			}
 		}
 
@@ -900,15 +899,16 @@ func handleDeleteWorktree(ctx context.Context, client taskguildv1connect.AgentMa
 		statusCmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
 		statusCmd.Dir = wtDir
 		if out, err := statusCmd.Output(); err == nil {
-			raw := strings.TrimSpace(string(out))
+			raw := strings.TrimRight(string(out), "\n")
 			if raw != "" {
 				hasNonClaudeChanges := false
 				for _, line := range strings.Split(raw, "\n") {
-					line = strings.TrimSpace(line)
-					if line == "" {
+					// Do not TrimSpace: the leading space is part of the porcelain status code format
+					// and trimming shifts the offset, corrupting the filename (e.g. ".claude/" → "claude/").
+					if len(line) < 4 {
 						continue
 					}
-					if len(line) > 3 && isClaudeInternalPath(line[3:]) {
+					if isClaudeInternalPath(line[3:]) {
 						hasClaudeOnlyChanges = true
 						continue
 					}

--- a/cmd/taskguild-agent/worktree_test.go
+++ b/cmd/taskguild-agent/worktree_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsClaudeInternalPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{".claude/agents/foo.md", true},
+		{".claude/settings.json", true},
+		{".claude", true},
+		{"claude/agents/foo.md", false},
+		{"src/main.go", false},
+		{"package-lock.json", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isClaudeInternalPath(tt.path); got != tt.want {
+			t.Errorf("isClaudeInternalPath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+// TestPorcelainParsing verifies that git status --porcelain lines are parsed correctly,
+// preserving the leading dot in ".claude/" paths.
+func TestPorcelainParsing(t *testing.T) {
+	// Simulate git status --porcelain output.
+	// Format: XY filename, where X=index status, Y=worktree status, position 2=space.
+	porcelainOutput := strings.Join([]string{
+		" M .claude/agents/backend-guide.md",
+		" M .claude/settings.json",
+		"M  src/main.go",
+		"?? newfile.txt",
+		" M package-lock.json",
+	}, "\n")
+
+	lines := strings.Split(strings.TrimRight(porcelainOutput, "\n"), "\n")
+	var changedFiles []string
+	for _, line := range lines {
+		if len(line) < 4 {
+			continue
+		}
+		filePath := line[3:]
+		if isClaudeInternalPath(filePath) {
+			continue
+		}
+		changedFiles = append(changedFiles, filePath)
+	}
+
+	// .claude/ files should be filtered out; only non-.claude files remain.
+	expected := []string{"src/main.go", "newfile.txt", "package-lock.json"}
+	if len(changedFiles) != len(expected) {
+		t.Fatalf("got %d changed files %v, want %d %v", len(changedFiles), changedFiles, len(expected), expected)
+	}
+	for i, f := range changedFiles {
+		if f != expected[i] {
+			t.Errorf("changedFiles[%d] = %q, want %q", i, f, expected[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `git status --porcelain` の出力パース時に `strings.TrimSpace()` を使っていたため、ステータスコードの先頭スペースが除去されてオフセットがずれ、`.claude/` が `claude/` として解析されていたバグを修正
- `handleListWorktrees()` と `handleDeleteWorktree()` の両方で `TrimSpace` → `TrimRight("\n")` に変更し、各行のトリムも削除
- `TestIsClaudeInternalPath` と `TestPorcelainParsing` テストを追加

## Test plan
- [x] `TestIsClaudeInternalPath` — `.claude/` パスの判定が正しいことを確認
- [x] `TestPorcelainParsing` — porcelain 形式の各行から正しくファイルパスが抽出され、`.claude/` 配下のファイルがフィルタされることを確認
- [ ] worktree 一覧画面で `.claude/` 配下のファイルが changed files に表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)