### PR TITLE
feat: append-only architecture for Result/Plan/Description

### DIFF
--- a/cmd/taskguild-agent/directive.go
+++ b/cmd/taskguild-agent/directive.go
@@ -151,6 +151,18 @@ func createTaskFromDirective(
 		taskMeta["worktree"] = directive.Worktree
 	}
 
+	// If the subtask targets the same status as the parent, inherit the
+	// parent's session ID so the subtask can fork it for context continuity.
+	targetStatus := statusID
+	if targetStatus == "" {
+		targetStatus = metadata["_current_status_name"]
+	}
+	if targetStatus != "" {
+		if parentSessionID := metadata["session_id_"+targetStatus]; parentSessionID != "" {
+			taskMeta["session_id"] = parentSessionID
+		}
+	}
+
 	req := &v1.CreateTaskRequest{
 		ProjectId:   projectID,
 		WorkflowId:  workflowID,
@@ -402,7 +414,7 @@ func handleStatusTransition(
 		logger.Info("next status inherits session, keeping session_id",
 			"next_status", nextStatusID, "inherit_from", nextInherit)
 	} else {
-		saveSessionID(ctx, taskClient, taskID, "")
+		saveSessionID(ctx, taskClient, taskID, "", metadata)
 	}
 
 	_, err = taskClient.UpdateTaskStatus(ctx, connect.NewRequest(&v1.UpdateTaskStatusRequest{
@@ -441,11 +453,16 @@ func getStatusInheritSession(statusName string, metadata map[string]string) stri
 	return ""
 }
 
-func saveSessionID(ctx context.Context, taskClient taskguildv1connect.TaskServiceClient, taskID, sessionID string) {
+func saveSessionID(ctx context.Context, taskClient taskguildv1connect.TaskServiceClient, taskID, sessionID string, metadata map[string]string) {
 	logger := clog.LoggerFromContext(ctx)
+	meta := map[string]string{"session_id": sessionID}
+	// Also store per-status session ID so subtasks can inherit it.
+	if statusName := metadata["_current_status_name"]; statusName != "" {
+		meta["session_id_"+statusName] = sessionID
+	}
 	_, err := taskClient.UpdateTask(ctx, connect.NewRequest(&v1.UpdateTaskRequest{
 		Id:       taskID,
-		Metadata: map[string]string{"session_id": sessionID},
+		Metadata: meta,
 	}))
 	if err != nil {
 		logger.Error("failed to save session_id", "error", err)
@@ -489,19 +506,9 @@ func saveTaskDescription(ctx context.Context, taskClient taskguildv1connect.Task
 	}
 }
 
-func savePlanResult(ctx context.Context, taskClient taskguildv1connect.TaskServiceClient, taskID, content string, tl *taskLogger) {
+func savePlanResult(ctx context.Context, taskID, content string, tl *taskLogger) {
 	logger := clog.LoggerFromContext(ctx)
-	_, err := taskClient.UpdateTask(ctx, connect.NewRequest(&v1.UpdateTaskRequest{
-		Id:       taskID,
-		Metadata: map[string]string{"plan_result": content},
-	}))
-	if err != nil {
-		logger.Error("failed to save plan_result", "error", err)
-	} else {
-		logger.Info("plan_result saved", "content_length", len(content))
-	}
-
-	// Emit a chronological RESULT log so plan results are preserved across status transitions.
+	// Plan results are stored only as append-only RESULT logs (no metadata overwrite).
 	if tl != nil {
 		preview := content
 		if len(preview) > 200 {
@@ -513,5 +520,6 @@ func savePlanResult(ctx context.Context, taskClient taskguildv1connect.TaskServi
 				"full_text":   content,
 				"result_type": "plan",
 			})
+		logger.Info("plan_result saved as log", "content_length", len(content))
 	}
 }

--- a/cmd/taskguild-agent/prompt.go
+++ b/cmd/taskguild-agent/prompt.go
@@ -6,6 +6,14 @@ import (
 	"strings"
 )
 
+// resultHistoryEntry represents a single entry in the task result history
+// passed via _result_history metadata.
+type resultHistoryEntry struct {
+	ResultType string `json:"result_type"`
+	Text       string `json:"text"`
+	CreatedAt  string `json:"created_at"`
+}
+
 // buildUserPrompt constructs the user prompt from enriched metadata.
 // Keeps only the task content and current status — all boilerplate instructions
 // live in the system prompt (buildWorkflowContext).
@@ -28,6 +36,17 @@ func buildUserPrompt(metadata map[string]string, workDir string) string {
 	}
 	if description != "" {
 		sb.WriteString(fmt.Sprintf("\n%s\n", description))
+	}
+
+	// Append result history from previous statuses so the agent has full context.
+	if historyJSON := metadata["_result_history"]; historyJSON != "" {
+		var history []resultHistoryEntry
+		if json.Unmarshal([]byte(historyJSON), &history) == nil && len(history) > 0 {
+			sb.WriteString("\n## Previous Results\n")
+			for _, h := range history {
+				sb.WriteString(fmt.Sprintf("### %s (%s)\n%s\n\n", h.ResultType, h.CreatedAt, h.Text))
+			}
+		}
 	}
 
 	return sb.String()

--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -182,7 +182,7 @@ func runTask(
 	statusTransitionRetries := 0
 
 	for turn := 0; ; turn++ {
-		opts := buildClaudeOptions(instructions, workDir, metadata, sessionID, forkSession, worktreeName, client, taskClient, ctx, taskID, agentManagerID, waiter, permCache, scpCache, tl, func(newMode string) {
+		opts := buildClaudeOptions(instructions, workDir, metadata, sessionID, forkSession, worktreeName, client, taskClient, interClient, ctx, taskID, agentManagerID, waiter, permCache, scpCache, tl, func(newMode string) {
 			modeMu.Lock()
 			old := currentMode
 			currentMode = newMode
@@ -265,7 +265,11 @@ func runTask(
 		if result.Result != nil && result.Result.SessionID != "" {
 			sessionID = result.Result.SessionID
 			forkSession = false // fork done, normal resume from here
-			saveSessionID(ctx, taskClient, taskID, sessionID)
+			saveSessionID(ctx, taskClient, taskID, sessionID, metadata)
+			// Keep local metadata in sync for subtask session inheritance.
+			if statusName := metadata["_current_status_name"]; statusName != "" {
+				metadata["session_id_"+statusName] = sessionID
+			}
 		}
 
 		// Handle errors with backoff retry.
@@ -357,6 +361,17 @@ func runTask(
 					map[string]string{
 						"directive_type": "TASK_DESCRIPTION",
 						"turn":           fmt.Sprintf("%d", turn),
+					})
+				// Emit a RESULT log so description updates appear in the chronological results timeline.
+				descPreview := newDesc
+				if len(descPreview) > 200 {
+					descPreview = descPreview[:200] + "..."
+				}
+				tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_RESULT, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
+					descPreview,
+					map[string]string{
+						"full_text":   newDesc,
+						"result_type": "description",
 					})
 			}
 		}
@@ -608,6 +623,7 @@ func buildClaudeOptions(
 	worktreeName string,
 	client taskguildv1connect.AgentManagerServiceClient,
 	taskClient taskguildv1connect.TaskServiceClient,
+	interClient taskguildv1connect.InteractionServiceClient,
 	ctx context.Context,
 	taskID string,
 	agentManagerID string,
@@ -655,7 +671,7 @@ func buildClaudeOptions(
 		StderrCallback: func(line string) {
 			logger.Debug("claude-stderr", "line", line)
 		},
-		Hooks: buildToolUseHooks(tl, taskID, taskClient, onModeChange),
+		Hooks: buildToolUseHooks(tl, taskID, onModeChange, client, interClient, agentManagerID, waiter),
 	}
 
 	// Use --agent flag when a named agent is assigned; otherwise fall back to --system-prompt.

--- a/cmd/taskguild-agent/toolhooks.go
+++ b/cmd/taskguild-agent/toolhooks.go
@@ -8,20 +8,44 @@ import (
 	"os"
 	"strings"
 
+	"connectrpc.com/connect"
 	claudeagent "github.com/kazz187/claude-agent-sdk-go"
 	v1 "github.com/kazz187/taskguild/proto/gen/go/taskguild/v1"
 	"github.com/kazz187/taskguild/proto/gen/go/taskguild/v1/taskguildv1connect"
 )
 
-// buildToolUseHooks creates PostToolUse and PostToolUseFail hook matchers
+// buildToolUseHooks creates PreToolUse, PostToolUse and PostToolUseFail hook matchers
 // that log tool invocations (with input and output) to the task timeline.
-// When a taskClient is provided, it also tracks plan file writes and saves
-// the plan content to task metadata when ExitPlanMode is called.
-func buildToolUseHooks(tl *taskLogger, taskID string, taskClient taskguildv1connect.TaskServiceClient, onModeChange func(newMode string)) map[claudeagent.HookEvent][]*claudeagent.HookMatcher {
+// It also tracks plan file writes and saves the plan content as a RESULT log
+// when ExitPlanMode is called.
+// The PreToolUse hook intercepts ExitPlanMode to require user approval before
+// the plan is accepted and the agent exits plan mode.
+func buildToolUseHooks(
+	tl *taskLogger,
+	taskID string,
+	onModeChange func(newMode string),
+	client taskguildv1connect.AgentManagerServiceClient,
+	interClient taskguildv1connect.InteractionServiceClient,
+	agentManagerID string,
+	waiter *interactionWaiter,
+) map[claudeagent.HookEvent][]*claudeagent.HookMatcher {
 	// Track the most recently written plan file path across hook invocations.
 	var planFilePath string
 
 	return map[claudeagent.HookEvent][]*claudeagent.HookMatcher{
+		claudeagent.HookEventPreToolUse: {
+			{
+				Matcher: "",
+				Hooks: []claudeagent.HookCallback{
+					func(input claudeagent.HookInput, toolUseID string, hookCtx claudeagent.HookContext) (claudeagent.HookOutput, error) {
+						if input.ToolName != "ExitPlanMode" {
+							return claudeagent.HookOutput{}, nil
+						}
+						return handleExitPlanModeApproval(hookCtx.Signal, input, client, interClient, taskID, agentManagerID, waiter, planFilePath)
+					},
+				},
+			},
+		},
 		claudeagent.HookEventPostToolUse: {
 			{
 				Matcher: "",
@@ -44,7 +68,7 @@ func buildToolUseHooks(tl *taskLogger, taskID string, taskClient taskguildv1conn
 						}
 
 						// Save plan result when ExitPlanMode is called.
-						if input.ToolName == "ExitPlanMode" && taskClient != nil {
+						if input.ToolName == "ExitPlanMode" && tl != nil {
 							var planContent string
 							if input.ToolResponse != nil {
 								if s, ok := input.ToolResponse.(string); ok {
@@ -72,7 +96,7 @@ func buildToolUseHooks(tl *taskLogger, taskID string, taskClient taskguildv1conn
 								}
 							}
 							if planContent != "" {
-								savePlanResult(context.Background(), taskClient, taskID, planContent, tl)
+								savePlanResult(context.Background(), taskID, planContent, tl)
 							}
 						}
 
@@ -225,4 +249,126 @@ func truncateLines(s string, maxLines int) string {
 		return s
 	}
 	return strings.Join(lines[:maxLines], "\n") + "\n..."
+}
+
+// handleExitPlanModeApproval intercepts ExitPlanMode via a PreToolUse hook.
+// It reads the plan content from the tool input or the plan file, creates an
+// interaction asking the user to approve or provide feedback, and blocks the
+// tool if the user does not approve.
+func handleExitPlanModeApproval(
+	ctx context.Context,
+	input claudeagent.HookInput,
+	client taskguildv1connect.AgentManagerServiceClient,
+	interClient taskguildv1connect.InteractionServiceClient,
+	taskID string,
+	agentManagerID string,
+	waiter *interactionWaiter,
+	planFilePath string,
+) (claudeagent.HookOutput, error) {
+	logger := slog.Default().With("task_id", taskID)
+
+	// Extract plan content from ExitPlanMode input or the tracked plan file.
+	planContent := extractPlanContent(input.ToolInput, planFilePath)
+	if planContent == "" {
+		// No plan content available — allow ExitPlanMode without approval.
+		logger.Warn("ExitPlanMode called but no plan content found, allowing without approval")
+		return claudeagent.HookOutput{}, nil
+	}
+
+	// Create an interaction for user approval.
+	resp, err := client.CreateInteraction(ctx, connect.NewRequest(&v1.CreateInteractionRequest{
+		TaskId:      taskID,
+		AgentId:     agentManagerID,
+		Type:        v1.InteractionType_INTERACTION_TYPE_QUESTION,
+		Title:       "Plan review",
+		Description: planContent,
+		Options: []*v1.InteractionOption{
+			{Label: "Approve", Value: "approve", Description: "Approve the plan and proceed"},
+			{Label: "Reject", Value: "reject", Description: "Reject the plan with feedback"},
+		},
+	}))
+	if err != nil {
+		logger.Error("failed to create plan approval interaction", "error", err)
+		// On failure, allow ExitPlanMode to proceed rather than blocking indefinitely.
+		return claudeagent.HookOutput{}, nil
+	}
+
+	interactionID := resp.Msg.GetInteraction().GetId()
+	logger.Info("waiting for plan approval", "interaction_id", interactionID)
+
+	ch := waiter.Register(interactionID)
+	defer waiter.Unregister(interactionID)
+
+	select {
+	case <-ctx.Done():
+		return claudeagent.HookOutput{
+			Decision: "block",
+			Reason:   "context cancelled while waiting for plan approval",
+		}, nil
+	case inter := <-ch:
+		if inter.GetStatus() == v1.InteractionStatus_INTERACTION_STATUS_EXPIRED {
+			logger.Info("plan approval expired, blocking ExitPlanMode")
+			return claudeagent.HookOutput{
+				Decision: "block",
+				Reason:   "Plan approval expired. Please revise the plan and try again.",
+			}, nil
+		}
+
+		responseStr := inter.GetResponse()
+		logger.Info("plan approval response", "response", responseStr)
+
+		if responseStr == "approve" {
+			return claudeagent.HookOutput{}, nil
+		}
+
+		// Any other response is treated as rejection with feedback.
+		feedback := responseStr
+		if feedback == "reject" {
+			feedback = "The user rejected the plan. Please ask the user for feedback and revise the plan."
+		}
+
+		return claudeagent.HookOutput{
+			Decision: "block",
+			Reason:   fmt.Sprintf("Plan not approved. User feedback: %s", feedback),
+		}, nil
+
+	case msg := <-waiter.UserMessages():
+		// User sent a free-form message — treat as feedback and block.
+		logger.Info("user sent message during plan approval", "message_id", msg.GetId())
+		if _, expErr := interClient.ExpireInteraction(ctx, connect.NewRequest(&v1.ExpireInteractionRequest{
+			Id: interactionID,
+		})); expErr != nil {
+			logger.Error("failed to expire plan approval interaction", "error", expErr)
+		}
+
+		return claudeagent.HookOutput{
+			Decision: "block",
+			Reason:   fmt.Sprintf("Plan not approved. User feedback: %s", msg.GetTitle()),
+		}, nil
+	}
+}
+
+// extractPlanContent reads the plan content from ExitPlanMode tool input or
+// falls back to reading the tracked plan file.
+func extractPlanContent(toolInput map[string]any, planFilePath string) string {
+	// ExitPlanMode's plan field contains the plan content directly.
+	if plan, ok := toolInput["plan"].(string); ok && plan != "" {
+		return plan
+	}
+
+	// Check planFilePath from tool input.
+	if fp, ok := toolInput["planFilePath"].(string); ok && fp != "" {
+		if content, err := os.ReadFile(fp); err == nil && len(content) > 0 {
+			return string(content)
+		}
+	}
+
+	// Fallback: read from the tracked plan file written by a prior Write tool call.
+	if planFilePath != "" {
+		if content, err := os.ReadFile(planFilePath); err == nil && len(content) > 0 {
+			return string(content)
+		}
+	}
+
+	return ""
 }

--- a/frontend/src/components/organisms/TimelineEntry.tsx
+++ b/frontend/src/components/organisms/TimelineEntry.tsx
@@ -365,6 +365,7 @@ function ResultDetail({ metadata }: { metadata: Record<string, string> }) {
   const borderColor =
     resultType === 'error' ? 'border-red-500/30' :
     resultType === 'plan' ? 'border-blue-500/30' :
+    resultType === 'description' ? 'border-cyan-500/30' :
     'border-green-500/30'
 
   return (

--- a/frontend/src/routes/projects/$projectId/chat.tsx
+++ b/frontend/src/routes/projects/$projectId/chat.tsx
@@ -4,7 +4,9 @@ import { createFileRoute, Link } from '@tanstack/react-router'
 import { useQuery, useMutation } from '@connectrpc/connect-query'
 import { listTasks } from '@taskguild/proto/taskguild/v1/task-TaskService_connectquery.ts'
 import { listInteractions, respondToInteraction, expireInteraction } from '@taskguild/proto/taskguild/v1/interaction-InteractionService_connectquery.ts'
+import { listTaskLogs } from '@taskguild/proto/taskguild/v1/task_log-TaskLogService_connectquery.ts'
 import { InteractionStatus, InteractionType } from '@taskguild/proto/taskguild/v1/interaction_pb.ts'
+import { TaskLogCategory } from '@taskguild/proto/taskguild/v1/task_log_pb.ts'
 import { getProject } from '@taskguild/proto/taskguild/v1/project-ProjectService_connectquery.ts'
 import { EventType } from '@taskguild/proto/taskguild/v1/event_pb.ts'
 import { useEventSubscription } from '@/hooks/useEventSubscription'
@@ -29,6 +31,11 @@ function ProjectChatPage() {
   const { data: projectData } = useQuery(getProject, { id: projectId })
   const { data: tasksData, refetch: refetchTasks } = useQuery(listTasks, { projectId })
   const { data: interactionsData, refetch: refetchInteractions } = useQuery(listInteractions, { projectId, pagination: { limit: 0 } })
+  const { data: logsData, refetch: refetchLogs } = useQuery(listTaskLogs, {
+    taskId: '',
+    projectId,
+    pagination: { limit: 200 },
+  })
 
   const respondMut = useMutation(respondToInteraction)
   const expireMut = useMutation(expireInteraction)
@@ -36,6 +43,7 @@ function ProjectChatPage() {
   const project = projectData?.project
   const tasks = tasksData?.tasks ?? []
   const interactions = interactionsData?.interactions ?? []
+  const logs = logsData?.logs ?? []
 
   // Build task title map
   const taskMap = useMemo(() => {
@@ -49,22 +57,47 @@ function ProjectChatPage() {
         if (!m.has(id)) m.set(id, title)
       }
     }
+    // Supplement from listTaskLogs response (includes archived tasks)
+    if (logsData?.taskTitles) {
+      for (const [id, title] of Object.entries(logsData.taskTitles)) {
+        if (!m.has(id)) m.set(id, title)
+      }
+    }
     return m
-  }, [tasks, interactionsData?.taskTitles])
+  }, [tasks, interactionsData?.taskTitles, logsData?.taskTitles])
 
-  // Wrap interactions as TimelineItems
-  const timelineItems = useMemo<TimelineItem[]>(
-    () => interactions.map((interaction): TimelineItem => ({ kind: 'interaction', interaction })),
-    [interactions],
+  // Filter logs to only RESULT category (avoid noise from TOOL_USE, STDERR, etc.)
+  const filteredLogs = useMemo(
+    () => logs.filter((l) => l.category === TaskLogCategory.RESULT),
+    [logs],
   )
+
+  // Merge interactions + filtered logs into unified timeline sorted by createdAt
+  const timelineItems = useMemo<TimelineItem[]>(() => {
+    const items: TimelineItem[] = [
+      ...interactions.map((interaction): TimelineItem => ({ kind: 'interaction', interaction })),
+      ...filteredLogs.map((log): TimelineItem => ({ kind: 'log', log })),
+    ]
+    items.sort((a, b) => {
+      const tsA = a.kind === 'interaction' ? a.interaction.createdAt : a.log.createdAt
+      const tsB = b.kind === 'interaction' ? b.interaction.createdAt : b.log.createdAt
+      if (!tsA || !tsB) return 0
+      const diff = Number(tsA.seconds) - Number(tsB.seconds)
+      if (diff !== 0) return diff
+      return tsA.nanos - tsB.nanos
+    })
+    return items
+  }, [interactions, filteredLogs])
 
   const onEvent = useCallback(() => {
     refetchTasks()
     refetchInteractions()
-  }, [refetchTasks, refetchInteractions])
+    refetchLogs()
+  }, [refetchTasks, refetchInteractions, refetchLogs])
 
   const eventTypes = useMemo(() => [
     EventType.TASK_CREATED, EventType.TASK_UPDATED, EventType.INTERACTION_CREATED, EventType.INTERACTION_RESPONDED,
+    EventType.TASK_LOG,
   ], [])
 
   const { connectionStatus, reconnect } = useEventSubscription(eventTypes, projectId, onEvent)
@@ -85,7 +118,7 @@ function ProjectChatPage() {
   // Play notification sound when new pending requests arrive
   useNotificationSound(pendingRequestCount)
 
-  // Auto-scroll to bottom when new interactions arrive
+  // Auto-scroll to bottom when new items arrive
   useEffect(() => {
     if (scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight
@@ -153,15 +186,16 @@ function ProjectChatPage() {
             <p className="text-gray-500 text-sm text-center py-12">No interactions yet.</p>
           )}
           {timelineItems.map((item, idx) => {
-            if (item.kind !== 'interaction') return null
             const prev = idx > 0 ? timelineItems[idx - 1] : null
-            const taskId = item.interaction.taskId
-            const prevTaskId = prev?.kind === 'interaction' ? prev.interaction.taskId : null
+            const taskId = item.kind === 'interaction' ? item.interaction.taskId : item.log.taskId
+            const prevTaskId = prev
+              ? (prev.kind === 'interaction' ? prev.interaction.taskId : prev.log.taskId)
+              : null
             const showTaskLabel = taskId !== prevTaskId
             const taskTitle = taskMap.get(taskId) || shortId(taskId)
 
             return (
-              <div key={`i-${item.interaction.id}`}>
+              <div key={item.kind === 'interaction' ? `i-${item.interaction.id}` : `l-${item.log.id}`}>
                 {showTaskLabel && (
                   <div className="flex items-center gap-2 pt-3 pb-1">
                     <Link

--- a/frontend/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/frontend/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -284,23 +284,6 @@ function TaskDetailPage() {
   }
 
   const metadata = task.metadata ?? {}
-  // Show legacy result cards only when there are no RESULT log entries (backward compat for old tasks).
-  const hasResultLogs = logs.some((l) => l.category === TaskLogCategory.RESULT)
-  const resultSummary = hasResultLogs ? '' : (metadata['result_summary'] ?? '')
-  const rawPlanResult = metadata['plan_result'] ?? ''
-  // Handle legacy plan_result that may be stored as JSON with a "plan" field
-  const planResult = (() => {
-    if (!rawPlanResult) return ''
-    try {
-      const parsed = JSON.parse(rawPlanResult)
-      if (typeof parsed === 'object' && parsed !== null && typeof parsed.plan === 'string') {
-        return parsed.plan
-      }
-    } catch {
-      // Not JSON, use as-is (already markdown)
-    }
-    return rawPlanResult
-  })()
   const metadataEntries = Object.entries(metadata).filter(([key, v]) => v && key !== 'result_summary' && key !== 'result_status' && key !== 'result_error' && key !== 'plan_result')
 
   return (
@@ -442,10 +425,10 @@ function TaskDetailPage() {
             </div>
           )}
 
-          {/* Results — chronological result logs */}
+          {/* Results — all RESULT logs in chronological order (description, plan, summary, error) */}
           {(() => {
             const resultLogs = logs
-              .filter((l) => l.category === TaskLogCategory.RESULT && l.metadata['result_type'] !== 'plan')
+              .filter((l) => l.category === TaskLogCategory.RESULT)
               .sort((a, b) => {
                 if (!a.createdAt || !b.createdAt) return 0
                 const diff = Number(a.createdAt.seconds) - Number(b.createdAt.seconds)
@@ -462,10 +445,12 @@ function TaskDetailPage() {
                     const borderColor =
                       resultType === 'error' ? 'border-red-500/30' :
                       resultType === 'plan' ? 'border-blue-500/30' :
+                      resultType === 'description' ? 'border-cyan-500/30' :
                       'border-green-500/30'
                     const labelColor =
                       resultType === 'error' ? 'text-red-400' :
                       resultType === 'plan' ? 'text-blue-400' :
+                      resultType === 'description' ? 'text-cyan-400' :
                       'text-green-400'
                     return (
                       <div key={log.id} className={`border-l-2 ${borderColor} pl-3 py-1`}>
@@ -485,22 +470,6 @@ function TaskDetailPage() {
               </div>
             )
           })()}
-
-          {/* Plan Result */}
-          {planResult && (
-            <div className="bg-slate-900 border border-slate-800 rounded-lg p-3 md:p-4">
-              <p className="text-xs text-gray-500 uppercase tracking-wide mb-2">Plan Result</p>
-              <MarkdownDescription content={planResult} className="text-sm text-gray-300" />
-            </div>
-          )}
-
-          {/* Result Summary */}
-          {resultSummary && (
-            <div className="bg-slate-900 border border-slate-800 rounded-lg p-3 md:p-4">
-              <p className="text-xs text-gray-500 uppercase tracking-wide mb-2">Result Summary</p>
-              <MarkdownDescription content={resultSummary} className="text-sm text-gray-300" />
-            </div>
-          )}
 
           {/* Metadata */}
           {metadataEntries.length > 0 && (

--- a/internal/agentmanager/task_handler.go
+++ b/internal/agentmanager/task_handler.go
@@ -313,16 +313,10 @@ func (s *Server) ReportTaskResult(ctx context.Context, req *connect.Request[task
 	}
 
 	// If the task is already unassigned (e.g. stopped by user via StopTask),
-	// just update metadata without triggering retry logic.
+	// just emit the result log without triggering retry logic.
 	if t.AssignmentStatus == task.AssignmentStatusUnassigned && t.AssignedAgentID == "" {
 		if t.Metadata == nil {
 			t.Metadata = make(map[string]string)
-		}
-		if req.Msg.Summary != "" {
-			t.Metadata["result_summary"] = req.Msg.Summary
-		}
-		if req.Msg.ErrorMessage != "" {
-			t.Metadata["result_error"] = req.Msg.ErrorMessage
 		}
 		delete(t.Metadata, "_stopped_by_user")
 		t.UpdatedAt = time.Now()
@@ -342,15 +336,8 @@ func (s *Server) ReportTaskResult(ctx context.Context, req *connect.Request[task
 		t.Metadata = make(map[string]string)
 	}
 
-	// Store result summary/error in metadata.
-	if req.Msg.Summary != "" {
-		t.Metadata["result_summary"] = req.Msg.Summary
-	}
-	if req.Msg.ErrorMessage != "" {
-		t.Metadata["result_error"] = req.Msg.ErrorMessage
-	}
-
-	// Emit a chronological RESULT log entry so results are not lost on status transitions.
+	// Emit a chronological RESULT log entry (append-only).
+	// Result data is no longer stored in metadata to avoid overwrites.
 	s.emitResultLog(ctx, t, req.Msg.Summary, req.Msg.ErrorMessage)
 
 	eventMeta := map[string]string{
@@ -800,6 +787,31 @@ func (s *Server) ClaimTask(ctx context.Context, req *connect.Request[taskguildv1
 				enrichedMetadata["_enable_agent_md_harness"] = "false"
 			}
 			break
+		}
+	}
+
+	// Fetch RESULT logs for this task to provide history to the agent.
+	if logs, _, err := s.taskLogRepo.List(ctx, t.ID, nil, 0, 0); err == nil {
+		type resultEntry struct {
+			ResultType string `json:"result_type"`
+			Text       string `json:"text"`
+			CreatedAt  string `json:"created_at"`
+		}
+		var history []resultEntry
+		for _, l := range logs {
+			if l.Category != int32(taskguildv1.TaskLogCategory_TASK_LOG_CATEGORY_RESULT) {
+				continue
+			}
+			history = append(history, resultEntry{
+				ResultType: l.Metadata["result_type"],
+				Text:       l.Metadata["full_text"],
+				CreatedAt:  l.CreatedAt.Format(time.RFC3339),
+			})
+		}
+		if len(history) > 0 {
+			if b, err := json.Marshal(history); err == nil {
+				enrichedMetadata["_result_history"] = string(b)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- **メタデータ上書き廃止**: `result_summary`, `result_error`, `plan_result` のメタデータ書き込みを削除し、追記型の TaskLog に一本化
- **Description 更新のログ化**: `TASK_DESCRIPTION` ディレクティブ検出時に `result_type: description` の RESULT ログを発行
- **セッション ID ステータス別記録**: `session_id_{statusName}` でステータスごとにセッション ID を保存し、サブタスクが親の同一ステータスのセッションを fork してコンテキスト引き継ぎ可能に
- **エージェントへの Result 履歴渡し**: ClaimTask で RESULT ログ履歴を取得し `_result_history` としてプロンプトに含める
- **タスク詳細ページ**: Description/Plan/Summary/Error を時系列に統合表示（個別の Plan Result / Result Summary カードを削除）
- **チャットページ**: RESULT カテゴリの TaskLog を Interaction と統合して時系列表示

## Test plan
- [ ] `go build ./cmd/taskguild-agent/...` と `go build ./cmd/taskguild-server/...` でビルド確認
- [ ] `go test ./cmd/taskguild-agent/... ./internal/agentmanager/...` でテスト確認
- [ ] フロントエンド `npx tsc --noEmit` でビルド確認
- [ ] タスク実行後、Results がタスク詳細ページ上部に時系列で表示されることを確認
- [ ] Plan 承認後、Plan 結果が RESULT ログとして時系列表示に含まれることを確認
- [ ] ステータス遷移後の再割当時、エージェントのプロンプトに以前の結果履歴が含まれることを確認
- [ ] メタデータに `session_id_Plan`, `session_id_Develop` 等が記録されることを確認
- [ ] サブタスク作成時、親の同一ステータスのセッション ID が引き継がれることを確認
- [ ] チャットページで RESULT ログが時系列に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)