### PR TITLE
feat: Close task create modal on ESC key and fix Tab focus order

### DIFF
--- a/frontend/src/components/molecules/Modal.tsx
+++ b/frontend/src/components/molecules/Modal.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import type { ReactNode, MouseEvent } from 'react'
 import { X } from 'lucide-react'
 
@@ -35,6 +36,15 @@ export function Modal({
   closeOnBackdrop = true,
   children,
 }: ModalProps) {
+  useEffect(() => {
+    if (!open) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [open, onClose])
+
   if (!open) return null
 
   const handleBackdropClick = (e: MouseEvent) => {

--- a/frontend/src/components/organisms/ChildTaskCreateModal.tsx
+++ b/frontend/src/components/organisms/ChildTaskCreateModal.tsx
@@ -104,7 +104,7 @@ export function ChildTaskCreateModal({
             placeholder="Subtask title..."
           />
         </div>
-        <button onClick={onClose} className="text-gray-500 hover:text-gray-300 transition-colors shrink-0 mt-1 p-1">
+        <button tabIndex={-1} onClick={onClose} className="text-gray-500 hover:text-gray-300 transition-colors shrink-0 mt-1 p-1">
           <X className="w-5 h-5" />
         </button>
       </div>

--- a/frontend/src/components/organisms/TaskCreateModal.tsx
+++ b/frontend/src/components/organisms/TaskCreateModal.tsx
@@ -76,7 +76,7 @@ export function TaskCreateModal({ projectId, workflowId, defaultUseWorktree, onC
             placeholder="Task title..."
           />
         </div>
-        <button onClick={onClose} className="text-gray-500 hover:text-gray-300 transition-colors shrink-0 mt-1 p-1">
+        <button tabIndex={-1} onClick={onClose} className="text-gray-500 hover:text-gray-300 transition-colors shrink-0 mt-1 p-1">
           <X className="w-5 h-5" />
         </button>
       </div>


### PR DESCRIPTION
## Summary
- Add ESC key handler to `Modal` component so all modals can be closed with the Escape key
- Set `tabIndex={-1}` on the close (X) button in `TaskCreateModal` and `ChildTaskCreateModal` so Tab from Title moves directly to Description instead of the X button

## Test plan
- [ ] Open task create modal, press ESC → modal closes
- [ ] Open child task create modal, press ESC → modal closes
- [ ] In task create modal, focus Title, press Tab → focus moves to Description (not X button)
- [ ] Same Tab behavior in child task create modal
- [ ] Backdrop click still closes the modal
- [ ] X button still works via mouse click

🤖 Generated with [Claude Code](https://claude.com/claude-code)