### PR TITLE
fix: preserve per-status session_id across transitions

### DIFF
--- a/cmd/taskguild-agent/directive.go
+++ b/cmd/taskguild-agent/directive.go
@@ -160,6 +160,9 @@ func createTaskFromDirective(
 	if targetStatus != "" {
 		if parentSessionID := metadata["session_id_"+targetStatus]; parentSessionID != "" {
 			taskMeta["session_id"] = parentSessionID
+			// Mark for fork so the subtask creates its own independent session
+			// instead of directly resuming the parent's session.
+			taskMeta["_fork_session"] = "true"
 		}
 	}
 

--- a/cmd/taskguild-agent/directive.go
+++ b/cmd/taskguild-agent/directive.go
@@ -456,9 +456,13 @@ func getStatusInheritSession(statusName string, metadata map[string]string) stri
 func saveSessionID(ctx context.Context, taskClient taskguildv1connect.TaskServiceClient, taskID, sessionID string, metadata map[string]string) {
 	logger := clog.LoggerFromContext(ctx)
 	meta := map[string]string{"session_id": sessionID}
-	// Also store per-status session ID so subtasks can inherit it.
-	if statusName := metadata["_current_status_name"]; statusName != "" {
-		meta["session_id_"+statusName] = sessionID
+	// Store per-status session ID only when saving (not clearing).
+	// When clearing (sessionID == ""), we must NOT overwrite the per-status key
+	// because it needs to survive status transitions for subtask inheritance.
+	if sessionID != "" {
+		if statusName := metadata["_current_status_name"]; statusName != "" {
+			meta["session_id_"+statusName] = sessionID
+		}
 	}
 	_, err := taskClient.UpdateTask(ctx, connect.NewRequest(&v1.UpdateTaskRequest{
 		Id:       taskID,

--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -602,12 +602,15 @@ func runTask(
 }
 
 // resolveSession determines which session ID to use and whether to fork.
-// When _inherit_session_from is set, the session from the previous status is
-// forked rather than resumed directly. This allows the new agent to start with
-// the full conversation context while creating its own independent session.
+// Fork is triggered when:
+//   - _inherit_session_from is set (status transition with session inheritance), or
+//   - _fork_session is set (subtask inheriting parent's session)
+//
+// This ensures inherited sessions always create independent forks rather than
+// directly resuming the parent's session (which could cause conflicts).
 func resolveSession(metadata map[string]string) (sessionID string, forkSession bool) {
 	sid := metadata["session_id"]
-	if sid != "" && metadata["_inherit_session_from"] != "" {
+	if sid != "" && (metadata["_inherit_session_from"] != "" || metadata["_fork_session"] == "true") {
 		return sid, true
 	}
 	return sid, false


### PR DESCRIPTION
## Summary
- ステータス遷移時に `session_id_{statusName}` が消える問題を修正
- `saveSessionID` でグローバル `session_id` をクリアする際、`_current_status_name` がまだ遷移元を指しているため `session_id_Develop` 等が空文字で上書きされていた
- セッション ID が空の場合はステータス別キーを書き込まないようにし、サブタスクのセッション引き継ぎ用に保持する

## Root cause
`handleStatusTransition` → `saveSessionID(ctx, ..., "", metadata)` が呼ばれたとき:
1. `_current_status_name` はまだ遷移元 (e.g. "Develop") を指している
2. `session_id_Develop = ""` が書き込まれ、保存済みのセッション ID が消失
3. サブタスクが `session_id_Develop` を参照しても空文字になりセッション fork ができない

## Test plan
- [ ] タスクを Plan → Develop → Review → Closed と遷移させ、`session_id_Plan`/`session_id_Develop`/`session_id_Review` がすべて保持されることを確認
- [ ] サブタスク作成時に親の同一ステータスのセッション ID が引き継がれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)