### PR TITLE
fix: prevent plan review auto-approval and auto-transition in plan mode

### DIFF
--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -526,7 +526,14 @@ func runTask(
 
 		// No NEXT_STATUS output but transitions exist — try auto-transition
 		// if exactly one transition is available.
-		if transitions, err := parseAvailableTransitions(metadata); err == nil && len(transitions) == 1 {
+		// In plan mode, skip auto-transition so that the user has a chance to
+		// approve or reject the plan via ExitPlanMode before moving on.
+		isPlanMode := metadata["_permission_mode"] == string(claudeagent.PermissionModePlan)
+		if isPlanMode {
+			logger.Info("plan mode active, skipping auto-transition", "turn", turn)
+			tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_INFO,
+				"Plan mode: skipping auto-transition, waiting for user input", nil)
+		} else if transitions, err := parseAvailableTransitions(metadata); err == nil && len(transitions) == 1 {
 			autoName := transitions[0].Name
 			logger.Info("no NEXT_STATUS output, auto-transitioning (single transition available)",
 				"next_status_name", autoName, "turn", turn)
@@ -561,13 +568,17 @@ func runTask(
 					"Max user response retries reached, force-completing task", nil)
 				// Attempt auto-transition on force-complete so the task
 				// does not remain stuck at the current status.
+				// In plan mode, do NOT auto-transition — the plan must be
+				// explicitly approved via ExitPlanMode.
 				afterHooks()
 				reportTaskResult(ctx, client, taskID, summary, "")
 				reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_IDLE, "task force-completed (no NEXT_STATUS after retries)")
-				if err := handleStatusTransition(ctx, taskClient, taskID, "", metadata, tl); err != nil {
-					logger.Warn("auto-transition on force-complete failed", "error", err)
-					tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_WARN,
-						fmt.Sprintf("Auto-transition on force-complete failed: %v", err), nil)
+				if !isPlanMode {
+					if err := handleStatusTransition(ctx, taskClient, taskID, "", metadata, tl); err != nil {
+						logger.Warn("auto-transition on force-complete failed", "error", err)
+						tl.Log(v1.TaskLogCategory_TASK_LOG_CATEGORY_SYSTEM, v1.TaskLogLevel_TASK_LOG_LEVEL_WARN,
+							fmt.Sprintf("Auto-transition on force-complete failed: %v", err), nil)
+					}
 				}
 				return
 			}
@@ -584,11 +595,15 @@ func runTask(
 		if err != nil {
 			logger.Error("user response error, completing task", "error", err)
 			// Attempt auto-transition so the task does not remain stuck.
+			// In plan mode, do NOT auto-transition — the plan must be
+			// explicitly approved via ExitPlanMode.
 			afterHooks()
 			reportTaskResult(ctx, client, taskID, summary, "")
 			reportAgentStatus(ctx, client, agentManagerID, taskID, v1.AgentStatus_AGENT_STATUS_IDLE, "task completed (no user response)")
-			if transErr := handleStatusTransition(ctx, taskClient, taskID, "", metadata, tl); transErr != nil {
-				logger.Warn("auto-transition on user response error failed", "error", transErr)
+			if !isPlanMode {
+				if transErr := handleStatusTransition(ctx, taskClient, taskID, "", metadata, tl); transErr != nil {
+					logger.Warn("auto-transition on user response error failed", "error", transErr)
+				}
 			}
 			return
 		}

--- a/cmd/taskguild-agent/runner_test.go
+++ b/cmd/taskguild-agent/runner_test.go
@@ -368,6 +368,110 @@ func TestRunTask_SessionPerStatusOnTransition(t *testing.T) {
 	assert.Equal(t, "Review", tc.taskHandler.updateTaskStatusReqs[0].StatusId)
 }
 
+// TestRunTask_PlanMode_AutoTransitionBlocked verifies that when the agent is
+// in plan mode and does not output NEXT_STATUS, the auto-transition is
+// suppressed (the system waits for user input instead of auto-transitioning).
+func TestRunTask_PlanMode_AutoTransitionBlocked(t *testing.T) {
+	tc := newTestClients()
+	defer tc.Close()
+
+	// Use a short timeout — the task should block waiting for user input
+	// and then be cancelled by context.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	metadata := baseMetadata("Plan", `[{"name":"Develop"}]`)
+	metadata["_permission_mode"] = "plan"
+
+	qr := &mockQueryRunner{
+		results: []mockQueryRunnerResult{
+			// Agent finishes without NEXT_STATUS (e.g. ExitPlanMode was
+			// blocked or the hook timed out on the CLI side).
+			{Result: makeResult("I've completed the planning phase.")},
+		},
+	}
+
+	permCache := newPermissionCache("test", tc.agentClient)
+	scpCache := newSingleCommandPermissionCache("test", tc.agentClient)
+
+	runTask(ctx, tc.agentClient, tc.taskClient, tc.interClient,
+		"agent-mgr-1", "task-plan-block", "instructions", metadata,
+		t.TempDir(), permCache, scpCache, qr, func() bool { return false })
+
+	// In plan mode, auto-transition must NOT fire.
+	tc.taskHandler.mu.Lock()
+	defer tc.taskHandler.mu.Unlock()
+	assert.Empty(t, tc.taskHandler.updateTaskStatusReqs,
+		"no status transition expected in plan mode without explicit NEXT_STATUS")
+}
+
+// TestRunTask_NonPlanMode_AutoTransitionUnchanged verifies that auto-transition
+// still works normally for non-plan-mode statuses with a single target.
+func TestRunTask_NonPlanMode_AutoTransitionUnchanged(t *testing.T) {
+	tc := newTestClients()
+	defer tc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	metadata := baseMetadata("Plan", `[{"name":"Develop"}]`)
+	// No _permission_mode set (or explicitly not "plan")
+	metadata["_permission_mode"] = "default"
+
+	qr := &mockQueryRunner{
+		results: []mockQueryRunnerResult{
+			{Result: makeResult("I've completed the planning phase.")},
+		},
+	}
+
+	permCache := newPermissionCache("test", tc.agentClient)
+	scpCache := newSingleCommandPermissionCache("test", tc.agentClient)
+
+	runTask(ctx, tc.agentClient, tc.taskClient, tc.interClient,
+		"agent-mgr-1", "task-auto-default", "instructions", metadata,
+		t.TempDir(), permCache, scpCache, qr, func() bool { return false })
+
+	// Non-plan mode: auto-transition should fire.
+	tc.taskHandler.mu.Lock()
+	defer tc.taskHandler.mu.Unlock()
+	require.Len(t, tc.taskHandler.updateTaskStatusReqs, 1)
+	assert.Equal(t, "Develop", tc.taskHandler.updateTaskStatusReqs[0].StatusId)
+}
+
+// TestRunTask_PlanMode_ExplicitNextStatusAllowed verifies that when the agent
+// is in plan mode and explicitly outputs NEXT_STATUS, the transition proceeds.
+// This covers the case where the ExitPlanMode hook was approved and the agent
+// then outputs NEXT_STATUS.
+func TestRunTask_PlanMode_ExplicitNextStatusAllowed(t *testing.T) {
+	tc := newTestClients()
+	defer tc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	metadata := baseMetadata("Plan", `[{"name":"Develop"}]`)
+	metadata["_permission_mode"] = "plan"
+
+	qr := &mockQueryRunner{
+		results: []mockQueryRunnerResult{
+			{Result: makeResult("Plan approved.\nNEXT_STATUS: Develop")},
+		},
+	}
+
+	permCache := newPermissionCache("test", tc.agentClient)
+	scpCache := newSingleCommandPermissionCache("test", tc.agentClient)
+
+	runTask(ctx, tc.agentClient, tc.taskClient, tc.interClient,
+		"agent-mgr-1", "task-plan-explicit", "instructions", metadata,
+		t.TempDir(), permCache, scpCache, qr, func() bool { return false })
+
+	// Explicit NEXT_STATUS should be honored even in plan mode.
+	tc.taskHandler.mu.Lock()
+	defer tc.taskHandler.mu.Unlock()
+	require.Len(t, tc.taskHandler.updateTaskStatusReqs, 1)
+	assert.Equal(t, "Develop", tc.taskHandler.updateTaskStatusReqs[0].StatusId)
+}
+
 func TestResolveSession(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/cmd/taskguild-agent/toolhooks.go
+++ b/cmd/taskguild-agent/toolhooks.go
@@ -36,7 +36,8 @@ func buildToolUseHooks(
 		claudeagent.HookEventPreToolUse: {
 			{
 				Matcher: "",
-				Hooks: []claudeagent.HookCallback{
+				Timeout: 300, // 5 minutes – must be long enough for the user to review and approve/reject the plan.
+				Hooks:   []claudeagent.HookCallback{
 					func(input claudeagent.HookInput, toolUseID string, hookCtx claudeagent.HookContext) (claudeagent.HookOutput, error) {
 						if input.ToolName != "ExitPlanMode" {
 							return claudeagent.HookOutput{}, nil


### PR DESCRIPTION
## Summary
- Set `Timeout: 300` (5 minutes) on the PreToolUse HookMatcher so the CLI waits long enough for the user to review and approve/reject the plan, instead of timing out and auto-allowing ExitPlanMode
- Suppress auto-transition in plan mode (3 paths: single-target, force-completion, error fallback) so the task stays at `waitForUserResponse` instead of silently transitioning to Develop
- Add 3 tests verifying plan-mode auto-transition blocking, non-plan-mode preservation, and explicit NEXT_STATUS still working in plan mode

## Test plan
- [x] `go build ./cmd/taskguild-agent/` passes
- [x] `go test ./cmd/taskguild-agent/ -run TestRunTask` — all 13 tests pass
- [x] New test: `TestRunTask_PlanMode_AutoTransitionBlocked` — plan mode blocks auto-transition
- [x] New test: `TestRunTask_NonPlanMode_AutoTransitionUnchanged` — non-plan auto-transition still works
- [x] New test: `TestRunTask_PlanMode_ExplicitNextStatusAllowed` — explicit NEXT_STATUS honored in plan mode
- [ ] Manual test: Plan status task shows approval screen and does NOT auto-transition to Develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)