### PR TITLE
fix: Support YAML block scalar notation in skill/agent MD parser

### DIFF
--- a/cmd/taskguild-agent/sync.go
+++ b/cmd/taskguild-agent/sync.go
@@ -92,7 +92,7 @@ func buildAgentMDContent(ag *v1.AgentDefinition) string {
 		sb.WriteString(fmt.Sprintf("name: %s\n", ag.GetName()))
 	}
 	if ag.GetDescription() != "" {
-		sb.WriteString(fmt.Sprintf("description: %s\n", ag.GetDescription()))
+		writeYAMLStringField(&sb, "description", ag.GetDescription())
 	}
 	if len(ag.GetTools()) > 0 {
 		sb.WriteString(fmt.Sprintf("tools: %s\n", strings.Join(ag.GetTools(), ", ")))
@@ -125,6 +125,23 @@ func buildAgentMDContent(ag *v1.AgentDefinition) string {
 	}
 
 	return sb.String()
+}
+
+// writeYAMLStringField writes a YAML key-value pair to the builder.
+// If the value contains newlines, it uses YAML block scalar (|) notation.
+func writeYAMLStringField(sb *strings.Builder, key, value string) {
+	if strings.Contains(value, "\n") {
+		sb.WriteString(fmt.Sprintf("%s: |\n", key))
+		for _, line := range strings.Split(value, "\n") {
+			if line == "" {
+				sb.WriteString("\n")
+			} else {
+				sb.WriteString(fmt.Sprintf("  %s\n", line))
+			}
+		}
+	} else {
+		sb.WriteString(fmt.Sprintf("%s: %s\n", key, value))
+	}
 }
 
 // cleanupStaleAgentFiles removes .md files from the agents directory

--- a/cmd/taskguild-agent/sync_skills.go
+++ b/cmd/taskguild-agent/sync_skills.go
@@ -99,7 +99,7 @@ func buildSkillMDContent(sk *v1.SkillDefinition) string {
 		sb.WriteString(fmt.Sprintf("name: %s\n", sk.GetName()))
 	}
 	if sk.GetDescription() != "" {
-		sb.WriteString(fmt.Sprintf("description: %s\n", sk.GetDescription()))
+		writeYAMLStringField(&sb, "description", sk.GetDescription())
 	}
 	if sk.GetDisableModelInvocation() {
 		sb.WriteString("disable-model-invocation: true\n")

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -327,11 +327,58 @@ func parseAgentMDFile(filePath string) (*parsedAgent, error) {
 	}
 
 	// Parse frontmatter as simple key: value pairs.
-	// Also supports YAML list format (  - item) for list fields like skills.
+	// Also supports YAML list format (  - item) for list fields like skills,
+	// and YAML block scalar indicators (| and >) for multi-line string values.
 	var currentListKey string
+	var blockScalarKey string
+	var blockScalarLines []string
+	var blockIndent int
+
+	assignAgentBlockScalar := func(key string, lines []string) {
+		value := strings.TrimRight(strings.Join(lines, "\n"), "\n ")
+		switch key {
+		case "name":
+			result.Name = value
+		case "description":
+			result.Description = value
+		case "model":
+			result.Model = value
+		case "permissionMode":
+			result.PermissionMode = value
+		case "memory":
+			result.Memory = value
+		}
+	}
+
 	for _, line := range frontmatterLines {
-		// Check for YAML list item (e.g. "  - skill-name").
 		trimmed := strings.TrimSpace(line)
+
+		// If collecting a block scalar, check if this line continues it.
+		if blockScalarKey != "" {
+			if len(line) > 0 && (line[0] == ' ' || line[0] == '\t') {
+				// Indented line: part of the block scalar.
+				if len(blockScalarLines) == 0 {
+					blockIndent = len(line) - len(strings.TrimLeft(line, " \t"))
+				}
+				stripped := line
+				if len(line) >= blockIndent {
+					stripped = line[blockIndent:]
+				}
+				blockScalarLines = append(blockScalarLines, stripped)
+				continue
+			}
+			if trimmed == "" {
+				// Blank line within block scalar.
+				blockScalarLines = append(blockScalarLines, "")
+				continue
+			}
+			// Non-indented line: finalize block scalar and fall through.
+			assignAgentBlockScalar(blockScalarKey, blockScalarLines)
+			blockScalarKey = ""
+			blockScalarLines = nil
+		}
+
+		// Check for YAML list item (e.g. "  - skill-name").
 		if strings.HasPrefix(trimmed, "- ") && currentListKey != "" {
 			item := strings.TrimSpace(strings.TrimPrefix(trimmed, "- "))
 			if item != "" {
@@ -351,6 +398,14 @@ func parseAgentMDFile(filePath string) (*parsedAgent, error) {
 			key := strings.TrimSpace(line[:idx])
 			value := strings.TrimSpace(line[idx+1:])
 			currentListKey = "" // Reset list context.
+
+			// Detect block scalar indicator.
+			if value == "|" || value == ">" {
+				blockScalarKey = key
+				blockScalarLines = nil
+				blockIndent = 0
+				continue
+			}
 
 			switch key {
 			case "name":
@@ -401,6 +456,11 @@ func parseAgentMDFile(filePath string) (*parsedAgent, error) {
 				result.Memory = value
 			}
 		}
+	}
+
+	// Finalize any trailing block scalar.
+	if blockScalarKey != "" {
+		assignAgentBlockScalar(blockScalarKey, blockScalarLines)
 	}
 
 	// The body is the system prompt.

--- a/internal/agent/server_parse_test.go
+++ b/internal/agent/server_parse_test.go
@@ -1,0 +1,154 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTempAgentMD(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "test-agent.md")
+	if err := os.WriteFile(fp, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return fp
+}
+
+func TestParseAgentMDFile_BlockScalarLiteral(t *testing.T) {
+	content := `---
+name: gopls-agent
+description: |
+  Use gopls for precise Go code exploration.
+  Prefer gopls over grep/glob for Go code.
+---
+
+Agent prompt here.
+`
+	fp := writeTempAgentMD(t, content)
+	parsed, err := parseAgentMDFile(fp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "Use gopls for precise Go code exploration.\nPrefer gopls over grep/glob for Go code."
+	if parsed.Description != expected {
+		t.Errorf("description mismatch\ngot:  %q\nwant: %q", parsed.Description, expected)
+	}
+	if parsed.Name != "gopls-agent" {
+		t.Errorf("name = %q, want %q", parsed.Name, "gopls-agent")
+	}
+	if parsed.Prompt != "Agent prompt here." {
+		t.Errorf("prompt = %q, want %q", parsed.Prompt, "Agent prompt here.")
+	}
+}
+
+func TestParseAgentMDFile_BlockScalarFollowedByOtherFields(t *testing.T) {
+	content := `---
+name: my-agent
+description: |
+  Line one.
+  Line two.
+model: sonnet
+---
+`
+	fp := writeTempAgentMD(t, content)
+	parsed, err := parseAgentMDFile(fp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "Line one.\nLine two."
+	if parsed.Description != expected {
+		t.Errorf("description mismatch\ngot:  %q\nwant: %q", parsed.Description, expected)
+	}
+	if parsed.Model != "sonnet" {
+		t.Errorf("model = %q, want %q", parsed.Model, "sonnet")
+	}
+}
+
+func TestParseAgentMDFile_BlockScalarAsLastField(t *testing.T) {
+	content := `---
+name: my-agent
+description: |
+  This is the last field.
+  Parsed correctly.
+---
+`
+	fp := writeTempAgentMD(t, content)
+	parsed, err := parseAgentMDFile(fp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "This is the last field.\nParsed correctly."
+	if parsed.Description != expected {
+		t.Errorf("description mismatch\ngot:  %q\nwant: %q", parsed.Description, expected)
+	}
+}
+
+func TestParseAgentMDFile_SingleLineDescription(t *testing.T) {
+	content := `---
+name: simple-agent
+description: A simple one-line description
+model: opus
+---
+`
+	fp := writeTempAgentMD(t, content)
+	parsed, err := parseAgentMDFile(fp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if parsed.Description != "A simple one-line description" {
+		t.Errorf("description = %q, want %q", parsed.Description, "A simple one-line description")
+	}
+}
+
+func TestParseAgentMDFile_BlockScalarThenList(t *testing.T) {
+	content := `---
+name: my-agent
+description: |
+  Multi-line desc.
+  Second line.
+skills:
+  - skill-a
+  - skill-b
+---
+`
+	fp := writeTempAgentMD(t, content)
+	parsed, err := parseAgentMDFile(fp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "Multi-line desc.\nSecond line."
+	if parsed.Description != expected {
+		t.Errorf("description mismatch\ngot:  %q\nwant: %q", parsed.Description, expected)
+	}
+	if len(parsed.Skills) != 2 || parsed.Skills[0] != "skill-a" || parsed.Skills[1] != "skill-b" {
+		t.Errorf("skills = %v, want [skill-a, skill-b]", parsed.Skills)
+	}
+}
+
+func TestParseAgentMDFile_EmptyBlockScalar(t *testing.T) {
+	content := `---
+name: my-agent
+description: |
+model: sonnet
+---
+`
+	fp := writeTempAgentMD(t, content)
+	parsed, err := parseAgentMDFile(fp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if parsed.Description != "" {
+		t.Errorf("description = %q, want empty string", parsed.Description)
+	}
+	if parsed.Model != "sonnet" {
+		t.Errorf("model = %q, want %q", parsed.Model, "sonnet")
+	}
+}

--- a/internal/skill/server.go
+++ b/internal/skill/server.go
@@ -323,11 +323,60 @@ func parseSkillMDFile(filePath string, dirName string) (*parsedSkill, error) {
 	}
 
 	// Parse frontmatter as simple key: value pairs.
-	// Also supports YAML list format (  - item) for list fields like allowed-tools.
+	// Also supports YAML list format (  - item) for list fields like allowed-tools,
+	// and YAML block scalar indicators (| and >) for multi-line string values.
 	var currentListKey string
+	var blockScalarKey string
+	var blockScalarLines []string
+	var blockIndent int
+
+	assignSkillBlockScalar := func(key string, lines []string) {
+		value := strings.TrimRight(strings.Join(lines, "\n"), "\n ")
+		switch key {
+		case "name":
+			result.Name = value
+		case "description":
+			result.Description = value
+		case "model":
+			result.Model = value
+		case "context":
+			result.Context = value
+		case "agent":
+			result.Agent = value
+		case "argument-hint":
+			result.ArgumentHint = value
+		}
+	}
+
 	for _, line := range frontmatterLines {
-		// Check for YAML list item (e.g. "  - Read").
 		trimmed := strings.TrimSpace(line)
+
+		// If collecting a block scalar, check if this line continues it.
+		if blockScalarKey != "" {
+			if len(line) > 0 && (line[0] == ' ' || line[0] == '\t') {
+				// Indented line: part of the block scalar.
+				if len(blockScalarLines) == 0 {
+					blockIndent = len(line) - len(strings.TrimLeft(line, " \t"))
+				}
+				stripped := line
+				if len(line) >= blockIndent {
+					stripped = line[blockIndent:]
+				}
+				blockScalarLines = append(blockScalarLines, stripped)
+				continue
+			}
+			if trimmed == "" {
+				// Blank line within block scalar.
+				blockScalarLines = append(blockScalarLines, "")
+				continue
+			}
+			// Non-indented line: finalize block scalar and fall through.
+			assignSkillBlockScalar(blockScalarKey, blockScalarLines)
+			blockScalarKey = ""
+			blockScalarLines = nil
+		}
+
+		// Check for YAML list item (e.g. "  - Read").
 		if strings.HasPrefix(trimmed, "- ") && currentListKey != "" {
 			item := strings.TrimSpace(strings.TrimPrefix(trimmed, "- "))
 			if item != "" {
@@ -343,6 +392,14 @@ func parseSkillMDFile(filePath string, dirName string) (*parsedSkill, error) {
 			key := strings.TrimSpace(line[:idx])
 			value := strings.TrimSpace(line[idx+1:])
 			currentListKey = "" // Reset list context.
+
+			// Detect block scalar indicator.
+			if value == "|" || value == ">" {
+				blockScalarKey = key
+				blockScalarLines = nil
+				blockIndent = 0
+				continue
+			}
 
 			switch key {
 			case "name":
@@ -375,6 +432,11 @@ func parseSkillMDFile(filePath string, dirName string) (*parsedSkill, error) {
 				result.ArgumentHint = value
 			}
 		}
+	}
+
+	// Finalize any trailing block scalar.
+	if blockScalarKey != "" {
+		assignSkillBlockScalar(blockScalarKey, blockScalarLines)
 	}
 
 	// The body is the skill content.

--- a/internal/skill/server_parse_test.go
+++ b/internal/skill/server_parse_test.go
@@ -1,0 +1,185 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTempSkillMD(t *testing.T, content string) (filePath string, dirName string) {
+	t.Helper()
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "test-skill")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	fp := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(fp, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return fp, "test-skill"
+}
+
+func TestParseSkillMDFile_BlockScalarLiteral(t *testing.T) {
+	content := `---
+name: gopls-explorer
+description: |
+  Use gopls for precise Go code exploration.
+  Prefer gopls over grep/glob for Go code.
+---
+
+Body content here.
+`
+	fp, dirName := writeTempSkillMD(t, content)
+	parsed, err := parseSkillMDFile(fp, dirName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "Use gopls for precise Go code exploration.\nPrefer gopls over grep/glob for Go code."
+	if parsed.Description != expected {
+		t.Errorf("description mismatch\ngot:  %q\nwant: %q", parsed.Description, expected)
+	}
+	if parsed.Name != "gopls-explorer" {
+		t.Errorf("name = %q, want %q", parsed.Name, "gopls-explorer")
+	}
+	if parsed.Content != "Body content here." {
+		t.Errorf("content = %q, want %q", parsed.Content, "Body content here.")
+	}
+}
+
+func TestParseSkillMDFile_BlockScalarFollowedByOtherFields(t *testing.T) {
+	content := `---
+name: my-skill
+description: |
+  Line one.
+  Line two.
+  Line three.
+model: sonnet
+---
+`
+	fp, dirName := writeTempSkillMD(t, content)
+	parsed, err := parseSkillMDFile(fp, dirName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "Line one.\nLine two.\nLine three."
+	if parsed.Description != expected {
+		t.Errorf("description mismatch\ngot:  %q\nwant: %q", parsed.Description, expected)
+	}
+	if parsed.Model != "sonnet" {
+		t.Errorf("model = %q, want %q", parsed.Model, "sonnet")
+	}
+}
+
+func TestParseSkillMDFile_BlockScalarAsLastField(t *testing.T) {
+	content := `---
+name: my-skill
+description: |
+  This is the last field.
+  It should be parsed correctly.
+---
+`
+	fp, dirName := writeTempSkillMD(t, content)
+	parsed, err := parseSkillMDFile(fp, dirName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "This is the last field.\nIt should be parsed correctly."
+	if parsed.Description != expected {
+		t.Errorf("description mismatch\ngot:  %q\nwant: %q", parsed.Description, expected)
+	}
+}
+
+func TestParseSkillMDFile_SingleLineDescription(t *testing.T) {
+	content := `---
+name: simple-skill
+description: A simple one-line description
+model: opus
+---
+
+Some body.
+`
+	fp, dirName := writeTempSkillMD(t, content)
+	parsed, err := parseSkillMDFile(fp, dirName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if parsed.Description != "A simple one-line description" {
+		t.Errorf("description = %q, want %q", parsed.Description, "A simple one-line description")
+	}
+	if parsed.Model != "opus" {
+		t.Errorf("model = %q, want %q", parsed.Model, "opus")
+	}
+}
+
+func TestParseSkillMDFile_BlockScalarThenList(t *testing.T) {
+	content := `---
+name: my-skill
+description: |
+  Multi-line desc.
+  Second line.
+allowed-tools:
+  - Read
+  - Write
+---
+`
+	fp, dirName := writeTempSkillMD(t, content)
+	parsed, err := parseSkillMDFile(fp, dirName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "Multi-line desc.\nSecond line."
+	if parsed.Description != expected {
+		t.Errorf("description mismatch\ngot:  %q\nwant: %q", parsed.Description, expected)
+	}
+	if len(parsed.AllowedTools) != 2 || parsed.AllowedTools[0] != "Read" || parsed.AllowedTools[1] != "Write" {
+		t.Errorf("allowed-tools = %v, want [Read, Write]", parsed.AllowedTools)
+	}
+}
+
+func TestParseSkillMDFile_EmptyBlockScalar(t *testing.T) {
+	content := `---
+name: my-skill
+description: |
+model: sonnet
+---
+`
+	fp, dirName := writeTempSkillMD(t, content)
+	parsed, err := parseSkillMDFile(fp, dirName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if parsed.Description != "" {
+		t.Errorf("description = %q, want empty string", parsed.Description)
+	}
+	if parsed.Model != "sonnet" {
+		t.Errorf("model = %q, want %q", parsed.Model, "sonnet")
+	}
+}
+
+func TestParseSkillMDFile_BlockScalarWithBlankLines(t *testing.T) {
+	content := `---
+name: my-skill
+description: |
+  First paragraph.
+
+  Second paragraph.
+---
+`
+	fp, dirName := writeTempSkillMD(t, content)
+	parsed, err := parseSkillMDFile(fp, dirName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "First paragraph.\n\nSecond paragraph."
+	if parsed.Description != expected {
+		t.Errorf("description mismatch\ngot:  %q\nwant: %q", parsed.Description, expected)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix `parseSkillMDFile` and `parseAgentMDFile` to correctly handle YAML block scalar indicators (`|` and `>`) for multi-line field values like `description`
- Previously, `description: |` followed by indented lines would only capture `|` as the value, discarding the actual multi-line content
- Add `writeYAMLStringField` helper so the writer emits `|` block scalar notation for multi-line values, ensuring correct round-trip
- Add 13 test cases covering block scalar literal, followed-by-other-fields, last-field, single-line regression, with-list, empty, and blank-line scenarios

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/skill/ ./internal/agent/` — all 13 new parser tests pass
- [ ] Manual: create a skill MD with `description: |` block scalar, Sync From Repo, verify full description is captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)