### PR TITLE
feat: Add image attachment support for tasks

### DIFF
--- a/cmd/taskguild-agent/cmdlog.go
+++ b/cmd/taskguild-agent/cmdlog.go
@@ -26,7 +26,7 @@ type userInputMsg struct {
 
 type userInputBody struct {
 	Role    string `json:"role"`
-	Content string `json:"content"`
+	Content any    `json:"content"` // string or []map[string]any for image content blocks
 }
 
 // turnLog writes log entries to a single file per turn in real-time.
@@ -216,7 +216,7 @@ func (tl *turnLog) LogResult(result *claudeagent.ResultMessage, queryErr error) 
 // result to a single file per turn in real-time.
 func runQuerySyncWithLog(
 	ctx context.Context,
-	prompt string,
+	prompt any, // string or []map[string]any for image content blocks
 	options *claudeagent.ClaudeAgentOptions,
 	workDir, projectID, taskID, label string,
 ) (*claudeagent.QueryResult, error) {

--- a/cmd/taskguild-agent/prompt.go
+++ b/cmd/taskguild-agent/prompt.go
@@ -1,9 +1,17 @@
 package main
 
 import (
+	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
+
+	"connectrpc.com/connect"
+
+	v1 "github.com/kazz187/taskguild/proto/gen/go/taskguild/v1"
+	"github.com/kazz187/taskguild/proto/gen/go/taskguild/v1/taskguildv1connect"
 )
 
 // resultHistoryEntry represents a single entry in the task result history
@@ -50,6 +58,95 @@ func buildUserPrompt(metadata map[string]string, workDir string) string {
 	}
 
 	return sb.String()
+}
+
+var imageRefPattern = regexp.MustCompile(`\[Image#(\d+)\]`)
+
+// buildUserPromptWithImages builds the user prompt, replacing [Image#N] references
+// with actual image content blocks for the Claude API.
+// Returns string if no images, or []map[string]any if images are present.
+func buildUserPromptWithImages(ctx context.Context, metadata map[string]string, workDir string, taskClient taskguildv1connect.TaskServiceClient, taskID string) (any, error) {
+	textPrompt := buildUserPrompt(metadata, workDir)
+
+	// Find all [Image#N] references in the description.
+	matches := imageRefPattern.FindAllStringIndex(textPrompt, -1)
+	if len(matches) == 0 {
+		return textPrompt, nil
+	}
+
+	// Fetch all images for this task.
+	listResp, err := taskClient.ListTaskImages(ctx, connect.NewRequest(&v1.ListTaskImagesRequest{
+		TaskId: taskID,
+	}))
+	if err != nil {
+		return nil, fmt.Errorf("list task images: %w", err)
+	}
+
+	// Build a map of image ID -> image proto for quick lookup.
+	imageMap := make(map[string]*v1.TaskImage)
+	for _, img := range listResp.Msg.Images {
+		imageMap[img.Id] = img
+	}
+
+	// Split the text by [Image#N] references and interleave with image blocks.
+	var blocks []map[string]any
+	lastEnd := 0
+
+	for _, match := range imageRefPattern.FindAllStringSubmatchIndex(textPrompt, -1) {
+		// match[0:1] = full match start/end, match[2:3] = capture group (number)
+		fullStart, fullEnd := match[0], match[1]
+		imageID := textPrompt[match[2]:match[3]]
+
+		// Add text before this image reference.
+		if fullStart > lastEnd {
+			textBefore := textPrompt[lastEnd:fullStart]
+			if strings.TrimSpace(textBefore) != "" {
+				blocks = append(blocks, map[string]any{
+					"type": "text",
+					"text": textBefore,
+				})
+			}
+		}
+
+		// Check if this image exists.
+		if _, exists := imageMap[imageID]; exists {
+			// Fetch image data.
+			imgResp, err := taskClient.GetTaskImage(ctx, connect.NewRequest(&v1.GetTaskImageRequest{
+				TaskId:  taskID,
+				ImageId: imageID,
+			}))
+			if err == nil {
+				blocks = append(blocks, map[string]any{
+					"type": "image",
+					"source": map[string]any{
+						"type":       "base64",
+						"media_type": imgResp.Msg.Image.MediaType,
+						"data":       base64.StdEncoding.EncodeToString(imgResp.Msg.Data),
+					},
+				})
+			}
+		}
+
+		lastEnd = fullEnd
+	}
+
+	// Add remaining text after the last image reference.
+	if lastEnd < len(textPrompt) {
+		remaining := textPrompt[lastEnd:]
+		if strings.TrimSpace(remaining) != "" {
+			blocks = append(blocks, map[string]any{
+				"type": "text",
+				"text": remaining,
+			})
+		}
+	}
+
+	// If no image blocks were actually added, fall back to plain text.
+	if len(blocks) == 0 {
+		return textPrompt, nil
+	}
+
+	return blocks, nil
 }
 
 // buildWorkflowContext builds the workflow context block for the system prompt

--- a/cmd/taskguild-agent/prompt.go
+++ b/cmd/taskguild-agent/prompt.go
@@ -108,9 +108,8 @@ func buildUserPromptWithImages(ctx context.Context, metadata map[string]string, 
 			}
 		}
 
-		// Check if this image exists.
+		// Check if this image exists and fetch it.
 		if _, exists := imageMap[imageID]; exists {
-			// Fetch image data.
 			imgResp, err := taskClient.GetTaskImage(ctx, connect.NewRequest(&v1.GetTaskImageRequest{
 				TaskId:  taskID,
 				ImageId: imageID,
@@ -124,7 +123,19 @@ func buildUserPromptWithImages(ctx context.Context, metadata map[string]string, 
 						"data":       base64.StdEncoding.EncodeToString(imgResp.Msg.Data),
 					},
 				})
+			} else {
+				// Keep the reference as text if fetch fails.
+				blocks = append(blocks, map[string]any{
+					"type": "text",
+					"text": textPrompt[fullStart:fullEnd],
+				})
 			}
+		} else {
+			// Image not found — keep the reference as text.
+			blocks = append(blocks, map[string]any{
+				"type": "text",
+				"text": textPrompt[fullStart:fullEnd],
+			})
 		}
 
 		lastEnd = fullEnd

--- a/cmd/taskguild-agent/query_runner.go
+++ b/cmd/taskguild-agent/query_runner.go
@@ -11,7 +11,7 @@ import (
 type QueryRunner interface {
 	RunQuerySync(
 		ctx context.Context,
-		prompt string,
+		prompt any, // string or []map[string]any for image content blocks
 		options *claudeagent.ClaudeAgentOptions,
 		workDir, taskID, label string,
 	) (*claudeagent.QueryResult, error)
@@ -26,7 +26,7 @@ type subprocessQueryRunner struct {
 
 func (r subprocessQueryRunner) RunQuerySync(
 	ctx context.Context,
-	prompt string,
+	prompt any,
 	options *claudeagent.ClaudeAgentOptions,
 	workDir, taskID, label string,
 ) (*claudeagent.QueryResult, error) {

--- a/cmd/taskguild-agent/recording_query_runner.go
+++ b/cmd/taskguild-agent/recording_query_runner.go
@@ -12,7 +12,7 @@ import (
 
 // RecordedEntry represents a single recorded QueryRunner call and its result.
 type RecordedEntry struct {
-	Prompt    string `json:"prompt"`
+	Prompt    any    `json:"prompt"` // string or []map[string]any for image content blocks
 	Label     string `json:"label"`
 	TaskID    string `json:"task_id"`
 	Result    string `json:"result"`
@@ -31,7 +31,7 @@ type RecordingQueryRunner struct {
 // RunQuerySync delegates to the inner QueryRunner and records the call.
 func (r *RecordingQueryRunner) RunQuerySync(
 	ctx context.Context,
-	prompt string,
+	prompt any,
 	options *claudeagent.ClaudeAgentOptions,
 	workDir, taskID, label string,
 ) (*claudeagent.QueryResult, error) {
@@ -108,7 +108,7 @@ func LoadReplayQueryRunner(path string) (*ReplayQueryRunner, error) {
 // RunQuerySync returns the next recorded entry as a QueryResult.
 func (r *ReplayQueryRunner) RunQuerySync(
 	ctx context.Context,
-	prompt string,
+	prompt any,
 	options *claudeagent.ClaudeAgentOptions,
 	workDir, taskID, label string,
 ) (*claudeagent.QueryResult, error) {

--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -169,7 +169,11 @@ func runTask(
 	listenerWg.Go(func() {
 		runInteractionListener(ctx, interClient, taskID, waiter)
 	})
-	prompt := buildUserPrompt(metadata, workDir)
+	prompt, err := buildUserPromptWithImages(ctx, metadata, workDir, taskClient, taskID)
+	if err != nil {
+		logger.Error("failed to build prompt with images, falling back to text-only", "error", err)
+		prompt = buildUserPrompt(metadata, workDir)
+	}
 	hasTransitions := metadata["_available_transitions"] != ""
 	logger.Info("task setup complete, entering turn loop", "has_session", sessionID != "", "has_transitions", hasTransitions)
 

--- a/cmd/taskguild-agent/testutil_test.go
+++ b/cmd/taskguild-agent/testutil_test.go
@@ -17,7 +17,7 @@ import (
 // ---------------------------------------------------------------------------
 
 type mockQueryRunnerCall struct {
-	Prompt  string
+	Prompt  any
 	Label   string
 	TaskID  string
 	WorkDir string
@@ -38,7 +38,7 @@ type mockQueryRunner struct {
 
 func (m *mockQueryRunner) RunQuerySync(
 	ctx context.Context,
-	prompt string,
+	prompt any,
 	options *claudeagent.ClaudeAgentOptions,
 	workDir, taskID, label string,
 ) (*claudeagent.QueryResult, error) {

--- a/cmd/taskguild-server/run.go
+++ b/cmd/taskguild-server/run.go
@@ -243,6 +243,7 @@ func runServer() {
 	agentManagerServer := agentmanager.NewServer(agentManagerRegistry, taskRepo, workflowRepo, agentRepo, interactionRepo, projectRepo, skillRepo, scriptRepo, taskLogRepo, permissionRepo, scpRepo, claudeSettingsRepo, bus, scriptBroker)
 	descLogger := tasklog.NewDescriptionLoggerAdapter(taskLogRepo, bus)
 	taskServer := task.NewServer(taskRepo, workflowRepo, bus, agentManagerServer, agentManagerServer, []task.CascadeArchiver{interactionRepo}, descLogger, taskLogRepo, interactionRepo)
+	taskServer.SetImageStore(task.NewImageStore(store))
 	interactionServer := interaction.NewServer(interactionRepo, taskRepo, bus)
 	agentChangeNotifier := &agentChangeNotifier{
 		registry:    agentManagerRegistry,

--- a/frontend/src/components/molecules/ImageUploadTextarea.tsx
+++ b/frontend/src/components/molecules/ImageUploadTextarea.tsx
@@ -1,0 +1,303 @@
+import { useState, useRef, useCallback, useEffect, type DragEvent, type ChangeEvent } from 'react'
+import { useMutation, useQuery } from '@connectrpc/connect-query'
+import { uploadTaskImage, listTaskImages, getTaskImage } from '@taskguild/proto/taskguild/v1/task-TaskService_connectquery.ts'
+import { ImagePlus, X, Loader } from 'lucide-react'
+import { Textarea } from '../atoms/index.ts'
+
+const ACCEPTED_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp']
+const MAX_SIZE_BYTES = 10 * 1024 * 1024 // 10MB
+
+export interface PendingImage {
+  file: File
+  /** Sequential number used in [Image#N] reference */
+  num: number
+  /** Object URL for preview */
+  previewUrl: string
+}
+
+export interface ImageUploadTextareaProps {
+  value: string
+  onChange: (value: string) => void
+  /** When set, images are uploaded immediately via RPC */
+  taskId?: string
+  /** For create flow: pending images held in parent state */
+  pendingImages?: PendingImage[]
+  onPendingImagesChange?: (images: PendingImage[]) => void
+  placeholder?: string
+  textareaSize?: 'sm' | 'md'
+  disabled?: boolean
+}
+
+export function ImageUploadTextarea({
+  value,
+  onChange,
+  taskId,
+  pendingImages,
+  onPendingImagesChange,
+  placeholder,
+  textareaSize = 'md',
+  disabled,
+}: ImageUploadTextareaProps) {
+  const [isDragging, setIsDragging] = useState(false)
+  const [uploading, setUploading] = useState(false)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const dragCounterRef = useRef(0)
+  const uploadMut = useMutation(uploadTaskImage)
+
+  // Fetch existing images when taskId is available
+  const { data: imagesData } = useQuery(listTaskImages, { taskId: taskId ?? '' }, {
+    enabled: !!taskId,
+  })
+
+  // Track uploaded image previews (for edit mode)
+  const [uploadedPreviews, setUploadedPreviews] = useState<Map<string, string>>(new Map())
+
+  // Load previews for existing images
+  useEffect(() => {
+    if (!taskId || !imagesData?.images?.length) return
+
+    const loadPreviews = async () => {
+      // We'll load previews lazily when needed
+    }
+    loadPreviews()
+  }, [taskId, imagesData])
+
+  const getNextImageNum = useCallback((): number => {
+    // Find the highest [Image#N] reference in the text
+    const matches = value.matchAll(/\[Image#(\d+)\]/g)
+    let maxNum = 0
+    for (const match of matches) {
+      const num = parseInt(match[1], 10)
+      if (num > maxNum) maxNum = num
+    }
+    return maxNum + 1
+  }, [value])
+
+  const insertImageRef = useCallback((num: number) => {
+    const ref = `[Image#${num}]`
+    const textarea = textareaRef.current
+    if (textarea) {
+      const start = textarea.selectionStart
+      const end = textarea.selectionEnd
+      const newValue = value.substring(0, start) + ref + value.substring(end)
+      onChange(newValue)
+      // Move cursor after the inserted reference
+      requestAnimationFrame(() => {
+        textarea.selectionStart = textarea.selectionEnd = start + ref.length
+        textarea.focus()
+      })
+    } else {
+      onChange(value + ref)
+    }
+  }, [value, onChange])
+
+  const handleFiles = useCallback(async (files: FileList | File[]) => {
+    const validFiles = Array.from(files).filter(f => {
+      if (!ACCEPTED_TYPES.includes(f.type)) return false
+      if (f.size > MAX_SIZE_BYTES) return false
+      return true
+    })
+
+    if (validFiles.length === 0) return
+
+    if (taskId) {
+      // Edit mode: upload immediately
+      setUploading(true)
+      for (const file of validFiles) {
+        try {
+          const arrayBuffer = await file.arrayBuffer()
+          const data = new Uint8Array(arrayBuffer)
+          const resp = await uploadMut.mutateAsync({
+            taskId,
+            filename: file.name,
+            mediaType: file.type,
+            data,
+          })
+          if (resp.image) {
+            const num = parseInt(resp.image.id, 10)
+            insertImageRef(num)
+            // Store preview
+            const url = URL.createObjectURL(file)
+            setUploadedPreviews(prev => new Map(prev).set(resp.image!.id, url))
+          }
+        } catch (err) {
+          console.error('Failed to upload image:', err)
+        }
+      }
+      setUploading(false)
+    } else {
+      // Create mode: hold in pending state
+      if (!onPendingImagesChange) return
+      const current = pendingImages ?? []
+      let nextNum = getNextImageNum()
+      const newPending: PendingImage[] = []
+
+      for (const file of validFiles) {
+        const num = nextNum++
+        newPending.push({
+          file,
+          num,
+          previewUrl: URL.createObjectURL(file),
+        })
+        insertImageRef(num)
+      }
+
+      onPendingImagesChange([...current, ...newPending])
+    }
+  }, [taskId, uploadMut, insertImageRef, getNextImageNum, pendingImages, onPendingImagesChange])
+
+  const handleDragEnter = useCallback((e: DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    dragCounterRef.current++
+    if (dragCounterRef.current === 1) {
+      setIsDragging(true)
+    }
+  }, [])
+
+  const handleDragLeave = useCallback((e: DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    dragCounterRef.current--
+    if (dragCounterRef.current === 0) {
+      setIsDragging(false)
+    }
+  }, [])
+
+  const handleDragOver = useCallback((e: DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+  }, [])
+
+  const handleDrop = useCallback((e: DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    dragCounterRef.current = 0
+    setIsDragging(false)
+    if (e.dataTransfer.files.length > 0) {
+      handleFiles(e.dataTransfer.files)
+    }
+  }, [handleFiles])
+
+  const handleFileSelect = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      handleFiles(e.target.files)
+    }
+    // Reset input so the same file can be selected again
+    e.target.value = ''
+  }, [handleFiles])
+
+  const handleRemovePending = useCallback((num: number) => {
+    if (!onPendingImagesChange || !pendingImages) return
+    const img = pendingImages.find(p => p.num === num)
+    if (img) {
+      URL.revokeObjectURL(img.previewUrl)
+    }
+    onPendingImagesChange(pendingImages.filter(p => p.num !== num))
+    // Remove the [Image#N] reference from text
+    onChange(value.replace(`[Image#${num}]`, ''))
+  }, [pendingImages, onPendingImagesChange, value, onChange])
+
+  // Collect all image references in the text for preview display
+  const imageRefs = Array.from(value.matchAll(/\[Image#(\d+)\]/g)).map(m => parseInt(m[1], 10))
+
+  // Build preview data: merge pending images and uploaded images
+  const previewItems = imageRefs.map(num => {
+    const id = String(num)
+    // Check pending images first
+    const pending = pendingImages?.find(p => p.num === num)
+    if (pending) {
+      return { num, url: pending.previewUrl, isPending: true }
+    }
+    // Check uploaded previews
+    const uploadedUrl = uploadedPreviews.get(id)
+    if (uploadedUrl) {
+      return { num, url: uploadedUrl, isPending: false }
+    }
+    return { num, url: null, isPending: false }
+  })
+
+  return (
+    <div className="relative">
+      {/* Drag overlay */}
+      <div
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+        className="relative"
+      >
+        {isDragging && (
+          <div className="absolute inset-0 z-10 bg-cyan-500/10 border-2 border-dashed border-cyan-500 rounded-lg flex items-center justify-center pointer-events-none">
+            <span className="text-cyan-400 text-sm font-medium">Drop image here</span>
+          </div>
+        )}
+
+        <Textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          textareaSize={textareaSize}
+          placeholder={placeholder}
+          disabled={disabled}
+        />
+      </div>
+
+      {/* Toolbar */}
+      <div className="flex items-center gap-2 mt-1">
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={disabled || uploading}
+          className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-300 transition-colors disabled:opacity-50"
+          title="Add image"
+        >
+          {uploading ? (
+            <Loader className="w-3.5 h-3.5 animate-spin" />
+          ) : (
+            <ImagePlus className="w-3.5 h-3.5" />
+          )}
+          <span>Add image</span>
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={ACCEPTED_TYPES.join(',')}
+          multiple
+          onChange={handleFileSelect}
+          className="hidden"
+        />
+      </div>
+
+      {/* Image previews */}
+      {previewItems.length > 0 && (
+        <div className="flex flex-wrap gap-2 mt-2">
+          {previewItems.map(({ num, url, isPending }) => (
+            <div key={num} className="relative group">
+              <div className="w-16 h-16 rounded border border-slate-700 overflow-hidden bg-slate-800 flex items-center justify-center">
+                {url ? (
+                  <img src={url} alt={`Image #${num}`} className="w-full h-full object-cover" />
+                ) : (
+                  <span className="text-[10px] text-gray-600">#{num}</span>
+                )}
+              </div>
+              <span className="absolute bottom-0 left-0 right-0 text-center text-[9px] text-gray-400 bg-slate-900/80 leading-4">
+                #{num}
+              </span>
+              {isPending && (
+                <button
+                  type="button"
+                  onClick={() => handleRemovePending(num)}
+                  className="absolute -top-1 -right-1 w-4 h-4 bg-red-600 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                >
+                  <X className="w-2.5 h-2.5 text-white" />
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/molecules/ImageUploadTextarea.tsx
+++ b/frontend/src/components/molecules/ImageUploadTextarea.tsx
@@ -1,6 +1,6 @@
-import { useState, useRef, useCallback, useEffect, type DragEvent, type ChangeEvent } from 'react'
-import { useMutation, useQuery } from '@connectrpc/connect-query'
-import { uploadTaskImage, listTaskImages, getTaskImage } from '@taskguild/proto/taskguild/v1/task-TaskService_connectquery.ts'
+import { useState, useRef, useCallback, type DragEvent, type ChangeEvent } from 'react'
+import { useMutation } from '@connectrpc/connect-query'
+import { uploadTaskImage } from '@taskguild/proto/taskguild/v1/task-TaskService_connectquery.ts'
 import { ImagePlus, X, Loader } from 'lucide-react'
 import { Textarea } from '../atoms/index.ts'
 
@@ -45,23 +45,8 @@ export function ImageUploadTextarea({
   const dragCounterRef = useRef(0)
   const uploadMut = useMutation(uploadTaskImage)
 
-  // Fetch existing images when taskId is available
-  const { data: imagesData } = useQuery(listTaskImages, { taskId: taskId ?? '' }, {
-    enabled: !!taskId,
-  })
-
   // Track uploaded image previews (for edit mode)
   const [uploadedPreviews, setUploadedPreviews] = useState<Map<string, string>>(new Map())
-
-  // Load previews for existing images
-  useEffect(() => {
-    if (!taskId || !imagesData?.images?.length) return
-
-    const loadPreviews = async () => {
-      // We'll load previews lazily when needed
-    }
-    loadPreviews()
-  }, [taskId, imagesData])
 
   const getNextImageNum = useCallback((): number => {
     // Find the highest [Image#N] reference in the text

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -5,3 +5,4 @@ export { DropdownMenu, type DropdownMenuProps, type DropdownMenuItemProps } from
 export { PageHeading, type PageHeadingProps } from './PageHeading.tsx'
 export { EmptyState, type EmptyStateProps } from './EmptyState.tsx'
 export { SyncButton, type SyncButtonProps } from './SyncButton.tsx'
+export { ImageUploadTextarea, type ImageUploadTextareaProps, type PendingImage } from './ImageUploadTextarea.tsx'

--- a/frontend/src/components/organisms/ChildTaskCreateModal.tsx
+++ b/frontend/src/components/organisms/ChildTaskCreateModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useMutation, useQuery } from '@connectrpc/connect-query'
-import { createTask } from '@taskguild/proto/taskguild/v1/task-TaskService_connectquery.ts'
+import { createTask, uploadTaskImage } from '@taskguild/proto/taskguild/v1/task-TaskService_connectquery.ts'
 import { requestWorktreeList, getWorktreeList } from '@taskguild/proto/taskguild/v1/agent_manager-AgentManagerService_connectquery.ts'
 import { EventType } from '@taskguild/proto/taskguild/v1/event_pb.ts'
 import type { Task } from '@taskguild/proto/taskguild/v1/task_pb.ts'
@@ -8,8 +8,8 @@ import { TaskAssignmentStatus } from '@taskguild/proto/taskguild/v1/task_pb.ts'
 import { useEventSubscription } from '@/hooks/useEventSubscription'
 import { X, GitBranch, RefreshCw, AlertTriangle, ArrowUpRight } from 'lucide-react'
 import { shortId } from '@/lib/id'
-import { Button, Input, Textarea, Select, Checkbox, Badge } from '../atoms/index.ts'
-import { Modal, Card } from '../molecules/index.ts'
+import { Button, Input, Select, Checkbox, Badge } from '../atoms/index.ts'
+import { Modal, Card, ImageUploadTextarea, type PendingImage } from '../molecules/index.ts'
 
 interface ChildTaskCreateModalProps {
   parentTask: Task
@@ -33,8 +33,10 @@ export function ChildTaskCreateModal({
   const [useWorktree, setUseWorktree] = useState(parentTask.useWorktree ?? false)
   const [selectedWorktree, setSelectedWorktree] = useState(parentTask.metadata?.['worktree'] ?? '')
   const [inheritSession, setInheritSession] = useState(false)
+  const [pendingImages, setPendingImages] = useState<PendingImage[]>([])
 
   const createMut = useMutation(createTask)
+  const uploadMut = useMutation(uploadTaskImage)
   const requestWtMut = useMutation(requestWorktreeList)
 
   const isParentAgentRunning = parentTask.assignmentStatus === TaskAssignmentStatus.ASSIGNED
@@ -64,7 +66,7 @@ export function ChildTaskCreateModal({
 
   const worktrees = wtData?.worktrees ?? []
 
-  const handleCreate = () => {
+  const handleCreate = async () => {
     if (!title.trim()) return
     const metadata: Record<string, string> = {
       source_task_id: parentTask.id,
@@ -75,22 +77,41 @@ export function ChildTaskCreateModal({
     if (inheritSession && parentSessionId && parentSessionKey) {
       metadata[parentSessionKey] = parentSessionId
     }
-    createMut.mutate(
-      {
+    try {
+      const res = await createMut.mutateAsync({
         projectId,
         workflowId,
         title: title.trim(),
         description,
         metadata,
         useWorktree,
-      },
-      {
-        onSuccess: (res) => {
-          onCreated(res.task?.id ?? '')
-          onClose()
-        },
-      },
-    )
+      })
+
+      // Upload pending images after task creation
+      if (res.task && pendingImages.length > 0) {
+        const taskId = res.task.id
+        for (const img of pendingImages) {
+          try {
+            const arrayBuffer = await img.file.arrayBuffer()
+            const data = new Uint8Array(arrayBuffer)
+            await uploadMut.mutateAsync({
+              taskId,
+              filename: img.file.name,
+              mediaType: img.file.type,
+              data,
+            })
+          } catch (err) {
+            console.error('Failed to upload pending image:', err)
+          }
+        }
+        pendingImages.forEach(img => URL.revokeObjectURL(img.previewUrl))
+      }
+
+      onCreated(res.task?.id ?? '')
+      onClose()
+    } catch {
+      // error handled by mutation state
+    }
   }
 
   return (
@@ -127,9 +148,11 @@ export function ChildTaskCreateModal({
           </div>
         </Card>
 
-        <Textarea
+        <ImageUploadTextarea
           value={description}
-          onChange={(e) => setDescription(e.target.value)}
+          onChange={setDescription}
+          pendingImages={pendingImages}
+          onPendingImagesChange={setPendingImages}
           textareaSize="md"
           placeholder="Add description..."
         />

--- a/frontend/src/components/organisms/MarkdownDescription.tsx
+++ b/frontend/src/components/organisms/MarkdownDescription.tsx
@@ -1,4 +1,42 @@
+import { useState, useEffect } from 'react'
+import { useQuery } from '@connectrpc/connect-query'
+import { getTaskImage } from '@taskguild/proto/taskguild/v1/task-TaskService_connectquery.ts'
 import { parseWorktreePaths } from '../../lib/worktreePath.ts'
+
+/** Inline image component that fetches and displays an image by task ID and image number. */
+function ImageRefInline({ imageNum, taskId }: { imageNum: string; taskId?: string }) {
+  const { data } = useQuery(getTaskImage, { taskId: taskId ?? '', imageId: imageNum }, {
+    enabled: !!taskId,
+  })
+  const [objectUrl, setObjectUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (data?.data && data.image?.mediaType) {
+      const blob = new Blob([data.data], { type: data.image.mediaType })
+      const url = URL.createObjectURL(blob)
+      setObjectUrl(url)
+      return () => URL.revokeObjectURL(url)
+    }
+  }, [data])
+
+  if (!taskId) {
+    return <span className="text-cyan-400 text-[10px] bg-slate-800 px-1 rounded">[Image#{imageNum}]</span>
+  }
+
+  if (!objectUrl) {
+    return <span className="text-gray-600 text-[10px]">[Image#{imageNum}]</span>
+  }
+
+  return (
+    <span className="inline-block my-1">
+      <img
+        src={objectUrl}
+        alt={`Image #${imageNum}`}
+        className="max-w-xs max-h-48 rounded border border-slate-700"
+      />
+    </span>
+  )
+}
 
 type Segment =
   | { type: 'code'; language: string; content: string }
@@ -66,10 +104,10 @@ function renderWorktreeSegments(text: string, keyPrefix: string): React.ReactNod
   )
 }
 
-/** Render inline markdown: **bold**, `code`, and [link](url). */
-function renderInline(text: string): React.ReactNode[] {
+/** Render inline markdown: **bold**, `code`, [link](url), and [Image#N]. */
+function renderInline(text: string, taskId?: string): React.ReactNode[] {
   const parts: React.ReactNode[] = []
-  const re = /(\*\*(.+?)\*\*|`([^`]+)`|\[([^\]]+)\]\(([^)]+)\))/g
+  const re = /(\*\*(.+?)\*\*|`([^`]+)`|\[([^\]]+)\]\(([^)]+)\)|\[Image#(\d+)\])/g
   let last = 0
   let match: RegExpExecArray | null
 
@@ -104,6 +142,11 @@ function renderInline(text: string): React.ReactNode[] {
         <a key={match.index} href={match[5]} target="_blank" rel="noopener noreferrer" className="text-cyan-400 hover:text-cyan-300 underline">
           {match[4]}
         </a>,
+      )
+    } else if (match[6] !== undefined) {
+      // [Image#N] reference
+      parts.push(
+        <ImageRefInline key={match.index} imageNum={match[6]} taskId={taskId} />,
       )
     }
     last = match.index + match[0].length
@@ -223,7 +266,7 @@ function parseBlocks(text: string): BlockElement[] {
 
 /* ─── Block renderers ─── */
 
-function HeaderBlock({ level, content }: { level: number; content: string }) {
+function HeaderBlock({ level, content, taskId }: { level: number; content: string; taskId?: string }) {
   const styles: Record<number, string> = {
     1: 'text-base font-bold text-gray-200 mt-3 mb-1.5',
     2: 'text-sm font-bold text-gray-200 mt-2.5 mb-1',
@@ -233,36 +276,36 @@ function HeaderBlock({ level, content }: { level: number; content: string }) {
     6: 'text-xs font-medium text-gray-400 mt-1 mb-0.5',
   }
   const cn = styles[level] ?? styles[3]
-  return <div className={cn}>{renderInline(content)}</div>
+  return <div className={cn}>{renderInline(content, taskId)}</div>
 }
 
-function UnorderedListBlock({ items }: { items: string[] }) {
+function UnorderedListBlock({ items, taskId }: { items: string[]; taskId?: string }) {
   return (
     <ul className="list-disc list-inside space-y-0.5 my-1 ml-2">
       {items.map((item, i) => (
-        <li key={i}>{renderInline(item)}</li>
+        <li key={i}>{renderInline(item, taskId)}</li>
       ))}
     </ul>
   )
 }
 
-function OrderedListBlock({ items }: { items: string[] }) {
+function OrderedListBlock({ items, taskId }: { items: string[]; taskId?: string }) {
   return (
     <ol className="list-decimal list-inside space-y-0.5 my-1 ml-2">
       {items.map((item, i) => (
-        <li key={i}>{renderInline(item)}</li>
+        <li key={i}>{renderInline(item, taskId)}</li>
       ))}
     </ol>
   )
 }
 
-function BlockquoteBlock({ lines }: { lines: string[] }) {
+function BlockquoteBlock({ lines, taskId }: { lines: string[]; taskId?: string }) {
   return (
     <blockquote className="border-l-2 border-slate-600 pl-3 my-1.5 text-gray-500 italic">
       {lines.map((line, i) => (
         <span key={i}>
           {i > 0 && '\n'}
-          {renderInline(line)}
+          {renderInline(line, taskId)}
         </span>
       ))}
     </blockquote>
@@ -273,37 +316,37 @@ function HorizontalRule() {
   return <hr className="border-slate-700 my-2" />
 }
 
-function ParagraphBlock({ lines }: { lines: string[] }) {
+function ParagraphBlock({ lines, taskId }: { lines: string[]; taskId?: string }) {
   return (
     <div className="whitespace-pre-wrap my-0.5">
       {lines.map((line, j) => (
         <span key={j}>
           {j > 0 && '\n'}
-          {renderInline(line)}
+          {renderInline(line, taskId)}
         </span>
       ))}
     </div>
   )
 }
 
-function TextSegment({ content }: { content: string }) {
+function TextSegment({ content, taskId }: { content: string; taskId?: string }) {
   const blocks = parseBlocks(content)
   return (
     <>
       {blocks.map((block, i) => {
         switch (block.type) {
           case 'header':
-            return <HeaderBlock key={i} level={block.level} content={block.content} />
+            return <HeaderBlock key={i} level={block.level} content={block.content} taskId={taskId} />
           case 'ul':
-            return <UnorderedListBlock key={i} items={block.items} />
+            return <UnorderedListBlock key={i} items={block.items} taskId={taskId} />
           case 'ol':
-            return <OrderedListBlock key={i} items={block.items} />
+            return <OrderedListBlock key={i} items={block.items} taskId={taskId} />
           case 'blockquote':
-            return <BlockquoteBlock key={i} lines={block.lines} />
+            return <BlockquoteBlock key={i} lines={block.lines} taskId={taskId} />
           case 'hr':
             return <HorizontalRule key={i} />
           case 'paragraph':
-            return <ParagraphBlock key={i} lines={block.lines} />
+            return <ParagraphBlock key={i} lines={block.lines} taskId={taskId} />
         }
       })}
     </>
@@ -619,9 +662,11 @@ function CodeBlock({ language, content }: { language: string; content: string })
 export function MarkdownDescription({
   content,
   className = '',
+  taskId,
 }: {
   content: string
   className?: string
+  taskId?: string
 }) {
   const segments = parse(content)
 
@@ -631,7 +676,7 @@ export function MarkdownDescription({
         if (seg.type === 'code') {
           return <CodeBlock key={i} language={seg.language} content={seg.content} />
         }
-        return <TextSegment key={i} content={seg.content} />
+        return <TextSegment key={i} content={seg.content} taskId={taskId} />
       })}
     </div>
   )

--- a/frontend/src/components/organisms/TaskCreateModal.tsx
+++ b/frontend/src/components/organisms/TaskCreateModal.tsx
@@ -1,12 +1,12 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useMutation, useQuery } from '@connectrpc/connect-query'
-import { createTask } from '@taskguild/proto/taskguild/v1/task-TaskService_connectquery.ts'
+import { createTask, uploadTaskImage } from '@taskguild/proto/taskguild/v1/task-TaskService_connectquery.ts'
 import { requestWorktreeList, getWorktreeList } from '@taskguild/proto/taskguild/v1/agent_manager-AgentManagerService_connectquery.ts'
 import { EventType } from '@taskguild/proto/taskguild/v1/event_pb.ts'
 import { useEventSubscription } from '@/hooks/useEventSubscription'
 import { X, GitBranch, RefreshCw } from 'lucide-react'
-import { Button, Input, Textarea, Select, Checkbox } from '../atoms/index.ts'
-import { Modal } from '../molecules/index.ts'
+import { Button, Input, Select, Checkbox } from '../atoms/index.ts'
+import { Modal, ImageUploadTextarea, type PendingImage } from '../molecules/index.ts'
 
 interface TaskCreateModalProps {
   projectId: string
@@ -21,7 +21,9 @@ export function TaskCreateModal({ projectId, workflowId, defaultUseWorktree, onC
   const [description, setDescription] = useState('')
   const [useWorktree, setUseWorktree] = useState(defaultUseWorktree ?? false)
   const [selectedWorktree, setSelectedWorktree] = useState('')
+  const [pendingImages, setPendingImages] = useState<PendingImage[]>([])
   const createMut = useMutation(createTask)
+  const uploadMut = useMutation(uploadTaskImage)
   const requestWtMut = useMutation(requestWorktreeList)
 
   // Query cached worktree list
@@ -45,21 +47,44 @@ export function TaskCreateModal({ projectId, workflowId, defaultUseWorktree, onC
 
   const worktrees = wtData?.worktrees ?? []
 
-  const handleCreate = () => {
+  const handleCreate = async () => {
     if (!title.trim()) return
     const metadata: Record<string, string> = {}
     if (selectedWorktree) {
       metadata['worktree'] = selectedWorktree
     }
-    createMut.mutate(
-      { projectId, workflowId, title: title.trim(), description, metadata, useWorktree },
-      {
-        onSuccess: () => {
-          onCreated()
-          onClose()
-        },
-      },
-    )
+
+    try {
+      const resp = await createMut.mutateAsync(
+        { projectId, workflowId, title: title.trim(), description, metadata, useWorktree },
+      )
+
+      // Upload pending images after task creation
+      if (resp.task && pendingImages.length > 0) {
+        const taskId = resp.task.id
+        for (const img of pendingImages) {
+          try {
+            const arrayBuffer = await img.file.arrayBuffer()
+            const data = new Uint8Array(arrayBuffer)
+            await uploadMut.mutateAsync({
+              taskId,
+              filename: img.file.name,
+              mediaType: img.file.type,
+              data,
+            })
+          } catch (err) {
+            console.error('Failed to upload pending image:', err)
+          }
+        }
+        // Clean up preview URLs
+        pendingImages.forEach(img => URL.revokeObjectURL(img.previewUrl))
+      }
+
+      onCreated()
+      onClose()
+    } catch {
+      // createMut error state will show via isPending
+    }
   }
 
   return (
@@ -83,9 +108,11 @@ export function TaskCreateModal({ projectId, workflowId, defaultUseWorktree, onC
 
       {/* Body */}
       <Modal.Body>
-        <Textarea
+        <ImageUploadTextarea
           value={description}
-          onChange={(e) => setDescription(e.target.value)}
+          onChange={setDescription}
+          pendingImages={pendingImages}
+          onPendingImagesChange={setPendingImages}
           textareaSize="md"
           placeholder="Add description..."
         />
@@ -134,9 +161,9 @@ export function TaskCreateModal({ projectId, workflowId, defaultUseWorktree, onC
             variant="primary"
             size="sm"
             onClick={handleCreate}
-            disabled={createMut.isPending || !title.trim()}
+            disabled={createMut.isPending || uploadMut.isPending || !title.trim()}
           >
-            {createMut.isPending ? 'Creating...' : 'Create'}
+            {createMut.isPending || uploadMut.isPending ? 'Creating...' : 'Create'}
           </Button>
         </div>
       </Modal.Body>

--- a/frontend/src/components/organisms/TaskDetailModal.tsx
+++ b/frontend/src/components/organisms/TaskDetailModal.tsx
@@ -10,9 +10,9 @@ import { useEventSubscription } from '@/hooks/useEventSubscription'
 import { X, Bot, Clock, GitBranch, Loader, Trash2, ArrowRight, AlertTriangle, RefreshCw, CopyPlus, ArrowUpRight, Layers } from 'lucide-react'
 import { ForceTransitionDialog } from './ForceTransitionDialog'
 import { shortId } from '@/lib/id'
-import { Button, Input, Textarea, Select, Checkbox, Badge, Tooltip } from '../atoms/index.ts'
+import { Button, Input, Select, Checkbox, Badge, Tooltip } from '../atoms/index.ts'
 import { pendingReasonText } from '@/lib/pendingReason'
-import { Modal, Card } from '../molecules/index.ts'
+import { Modal, Card, ImageUploadTextarea } from '../molecules/index.ts'
 
 const TASK_DETAIL_EVENT_TYPES = [
   EventType.TASK_UPDATED,
@@ -236,11 +236,13 @@ export function TaskDetailModal({
           </Card>
         )}
 
-        <Textarea
+        <ImageUploadTextarea
           value={descDraft}
-          onChange={(e) => setDescDraft(e.target.value)}
+          onChange={setDescDraft}
+          taskId={task?.id}
           textareaSize="md"
           placeholder="Add description..."
+          disabled={isTaskLocked}
         />
 
         {/* Agent settings */}

--- a/frontend/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/frontend/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -454,7 +454,7 @@ function TaskDetailPage() {
                   onClose={() => setShowDescHistory(false)}
                 />
               ) : (
-                <MarkdownDescription content={task.description} />
+                <MarkdownDescription content={task.description} taskId={task.id} />
               )}
             </div>
           )}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/fatih/color v1.15.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-chi/chi/v5 v5.2.2
-	github.com/kazz187/claude-agent-sdk-go v0.0.16
+	github.com/kazz187/claude-agent-sdk-go v0.0.17
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbc
 github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/kazz187/claude-agent-sdk-go v0.0.16 h1:DIePzIZ0tpzncOCvZ3r/R5BJOenOlefmlLELiQCgdJY=
 github.com/kazz187/claude-agent-sdk-go v0.0.16/go.mod h1:avEQx0oBuhHXKd3LYfnFfT5DXrBOmTK0iEFyUzRlQss=
+github.com/kazz187/claude-agent-sdk-go v0.0.17 h1:HjcTUply9xWQeMoiEn+NZ6m9R+gOzyF9wgl7HdYjveE=
+github.com/kazz187/claude-agent-sdk-go v0.0.17/go.mod h1:avEQx0oBuhHXKd3LYfnFfT5DXrBOmTK0iEFyUzRlQss=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/internal/task/image_store.go
+++ b/internal/task/image_store.go
@@ -154,8 +154,12 @@ func (s *storageImageStore) List(ctx context.Context, projectID, taskID string) 
 }
 
 func (s *storageImageStore) Delete(ctx context.Context, projectID, taskID, imageID string) error {
-	// Delete both data and meta files. Ignore individual errors.
-	_ = s.store.Delete(ctx, imageDataPath(projectID, taskID, imageID))
-	_ = s.store.Delete(ctx, imageMetaPath(projectID, taskID, imageID))
-	return nil
+	var firstErr error
+	if err := s.store.Delete(ctx, imageDataPath(projectID, taskID, imageID)); err != nil {
+		firstErr = fmt.Errorf("delete image data: %w", err)
+	}
+	if err := s.store.Delete(ctx, imageMetaPath(projectID, taskID, imageID)); err != nil && firstErr == nil {
+		firstErr = fmt.Errorf("delete image meta: %w", err)
+	}
+	return firstErr
 }

--- a/internal/task/image_store.go
+++ b/internal/task/image_store.go
@@ -1,0 +1,161 @@
+package task
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/kazz187/taskguild/pkg/storage"
+)
+
+// ImageMeta is the metadata for a stored image.
+type ImageMeta struct {
+	ID        string    `yaml:"id"`
+	Filename  string    `yaml:"filename"`
+	MediaType string    `yaml:"media_type"`
+	SizeBytes int64     `yaml:"size_bytes"`
+	CreatedAt time.Time `yaml:"created_at"`
+}
+
+// ImageStore provides CRUD operations for task images.
+type ImageStore interface {
+	Upload(ctx context.Context, projectID, taskID string, filename, mediaType string, data []byte) (*ImageMeta, error)
+	Get(ctx context.Context, projectID, taskID, imageID string) (*ImageMeta, []byte, error)
+	List(ctx context.Context, projectID, taskID string) ([]*ImageMeta, error)
+	Delete(ctx context.Context, projectID, taskID, imageID string) error
+}
+
+// storageImageStore implements ImageStore using the storage.Storage interface.
+type storageImageStore struct {
+	store storage.Storage
+}
+
+// NewImageStore creates an ImageStore backed by the given storage.
+func NewImageStore(store storage.Storage) ImageStore {
+	return &storageImageStore{store: store}
+}
+
+func imageDataPath(projectID, taskID, imageID string) string {
+	return fmt.Sprintf("projects/%s/%s/images/%s.dat", projectID, taskID, imageID)
+}
+
+func imageMetaPath(projectID, taskID, imageID string) string {
+	return fmt.Sprintf("projects/%s/%s/images/%s.meta.yaml", projectID, taskID, imageID)
+}
+
+func imagesPrefix(projectID, taskID string) string {
+	return fmt.Sprintf("projects/%s/%s/images/", projectID, taskID)
+}
+
+// ValidImageMediaTypes is the set of accepted image media types.
+var ValidImageMediaTypes = map[string]bool{
+	"image/png":  true,
+	"image/jpeg": true,
+	"image/gif":  true,
+	"image/webp": true,
+}
+
+const MaxImageSizeBytes = 10 * 1024 * 1024 // 10MB
+
+func (s *storageImageStore) Upload(ctx context.Context, projectID, taskID string, filename, mediaType string, data []byte) (*ImageMeta, error) {
+	// Determine next image ID by listing existing images.
+	existing, err := s.List(ctx, projectID, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("list existing images: %w", err)
+	}
+
+	nextID := 1
+	for _, img := range existing {
+		n, _ := strconv.Atoi(img.ID)
+		if n >= nextID {
+			nextID = n + 1
+		}
+	}
+
+	id := strconv.Itoa(nextID)
+	meta := &ImageMeta{
+		ID:        id,
+		Filename:  filename,
+		MediaType: mediaType,
+		SizeBytes: int64(len(data)),
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Write image data.
+	if err := s.store.Write(ctx, imageDataPath(projectID, taskID, id), data); err != nil {
+		return nil, fmt.Errorf("write image data: %w", err)
+	}
+
+	// Write metadata.
+	metaBytes, err := yaml.Marshal(meta)
+	if err != nil {
+		return nil, fmt.Errorf("marshal image meta: %w", err)
+	}
+	if err := s.store.Write(ctx, imageMetaPath(projectID, taskID, id), metaBytes); err != nil {
+		return nil, fmt.Errorf("write image meta: %w", err)
+	}
+
+	return meta, nil
+}
+
+func (s *storageImageStore) Get(ctx context.Context, projectID, taskID, imageID string) (*ImageMeta, []byte, error) {
+	metaBytes, err := s.store.Read(ctx, imageMetaPath(projectID, taskID, imageID))
+	if err != nil {
+		return nil, nil, fmt.Errorf("read image meta: %w", err)
+	}
+
+	var meta ImageMeta
+	if err := yaml.Unmarshal(metaBytes, &meta); err != nil {
+		return nil, nil, fmt.Errorf("unmarshal image meta: %w", err)
+	}
+
+	data, err := s.store.Read(ctx, imageDataPath(projectID, taskID, imageID))
+	if err != nil {
+		return nil, nil, fmt.Errorf("read image data: %w", err)
+	}
+
+	return &meta, data, nil
+}
+
+func (s *storageImageStore) List(ctx context.Context, projectID, taskID string) ([]*ImageMeta, error) {
+	files, err := s.store.List(ctx, imagesPrefix(projectID, taskID))
+	if err != nil {
+		// Empty directory is not an error — just no images.
+		return nil, nil
+	}
+
+	var metas []*ImageMeta
+	for _, f := range files {
+		if !strings.HasSuffix(f, ".meta.yaml") {
+			continue
+		}
+		metaBytes, err := s.store.Read(ctx, f)
+		if err != nil {
+			continue
+		}
+		var meta ImageMeta
+		if yaml.Unmarshal(metaBytes, &meta) == nil {
+			metas = append(metas, &meta)
+		}
+	}
+
+	sort.Slice(metas, func(i, j int) bool {
+		ni, _ := strconv.Atoi(metas[i].ID)
+		nj, _ := strconv.Atoi(metas[j].ID)
+		return ni < nj
+	})
+
+	return metas, nil
+}
+
+func (s *storageImageStore) Delete(ctx context.Context, projectID, taskID, imageID string) error {
+	// Delete both data and meta files. Ignore individual errors.
+	_ = s.store.Delete(ctx, imageDataPath(projectID, taskID, imageID))
+	_ = s.store.Delete(ctx, imageMetaPath(projectID, taskID, imageID))
+	return nil
+}

--- a/internal/task/server.go
+++ b/internal/task/server.go
@@ -56,6 +56,7 @@ type Server struct {
 	stopper          TaskStopper
 	resumer          TaskResumer
 	descLogger       DescriptionLogger
+	imageStore       ImageStore
 }
 
 func NewServer(repo Repository, workflowRepo workflow.Repository, eventBus *eventbus.Bus, stopper TaskStopper, resumer TaskResumer, cascadeArchivers []CascadeArchiver, descLogger DescriptionLogger, cascadeDeleters ...CascadeDeleter) *Server {
@@ -69,6 +70,11 @@ func NewServer(repo Repository, workflowRepo workflow.Repository, eventBus *even
 		descLogger:       descLogger,
 		cascadeDeleters:  cascadeDeleters,
 	}
+}
+
+// SetImageStore sets the image store for the server. Must be called before handling image RPCs.
+func (s *Server) SetImageStore(store ImageStore) {
+	s.imageStore = store
 }
 
 func (s *Server) CreateTask(ctx context.Context, req *connect.Request[taskguildv1.CreateTaskRequest]) (*connect.Response[taskguildv1.CreateTaskResponse], error) {

--- a/internal/task/server_image.go
+++ b/internal/task/server_image.go
@@ -1,0 +1,117 @@
+package task
+
+import (
+	"context"
+	"fmt"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	taskguildv1 "github.com/kazz187/taskguild/proto/gen/go/taskguild/v1"
+)
+
+func (s *Server) UploadTaskImage(ctx context.Context, req *connect.Request[taskguildv1.UploadTaskImageRequest]) (*connect.Response[taskguildv1.UploadTaskImageResponse], error) {
+	if s.imageStore == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("image storage not configured"))
+	}
+
+	msg := req.Msg
+
+	// Validate media type.
+	if !ValidImageMediaTypes[msg.MediaType] {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("unsupported media type: %s", msg.MediaType))
+	}
+
+	// Validate size.
+	if len(msg.Data) > MaxImageSizeBytes {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("image too large: %d bytes (max %d)", len(msg.Data), MaxImageSizeBytes))
+	}
+
+	// Look up task to get project ID.
+	t, err := s.repo.Get(ctx, msg.TaskId)
+	if err != nil {
+		return nil, err
+	}
+
+	meta, err := s.imageStore.Upload(ctx, t.ProjectID, t.ID, msg.Filename, msg.MediaType, msg.Data)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("upload image: %w", err))
+	}
+
+	return connect.NewResponse(&taskguildv1.UploadTaskImageResponse{
+		Image: imageMetaToProto(meta),
+	}), nil
+}
+
+func (s *Server) GetTaskImage(ctx context.Context, req *connect.Request[taskguildv1.GetTaskImageRequest]) (*connect.Response[taskguildv1.GetTaskImageResponse], error) {
+	if s.imageStore == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("image storage not configured"))
+	}
+
+	t, err := s.repo.Get(ctx, req.Msg.TaskId)
+	if err != nil {
+		return nil, err
+	}
+
+	meta, data, err := s.imageStore.Get(ctx, t.ProjectID, t.ID, req.Msg.ImageId)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("image not found: %w", err))
+	}
+
+	return connect.NewResponse(&taskguildv1.GetTaskImageResponse{
+		Image: imageMetaToProto(meta),
+		Data:  data,
+	}), nil
+}
+
+func (s *Server) ListTaskImages(ctx context.Context, req *connect.Request[taskguildv1.ListTaskImagesRequest]) (*connect.Response[taskguildv1.ListTaskImagesResponse], error) {
+	if s.imageStore == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("image storage not configured"))
+	}
+
+	t, err := s.repo.Get(ctx, req.Msg.TaskId)
+	if err != nil {
+		return nil, err
+	}
+
+	metas, err := s.imageStore.List(ctx, t.ProjectID, t.ID)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("list images: %w", err))
+	}
+
+	images := make([]*taskguildv1.TaskImage, len(metas))
+	for i, m := range metas {
+		images[i] = imageMetaToProto(m)
+	}
+
+	return connect.NewResponse(&taskguildv1.ListTaskImagesResponse{
+		Images: images,
+	}), nil
+}
+
+func (s *Server) DeleteTaskImage(ctx context.Context, req *connect.Request[taskguildv1.DeleteTaskImageRequest]) (*connect.Response[taskguildv1.DeleteTaskImageResponse], error) {
+	if s.imageStore == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("image storage not configured"))
+	}
+
+	t, err := s.repo.Get(ctx, req.Msg.TaskId)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.imageStore.Delete(ctx, t.ProjectID, t.ID, req.Msg.ImageId); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("delete image: %w", err))
+	}
+
+	return connect.NewResponse(&taskguildv1.DeleteTaskImageResponse{}), nil
+}
+
+func imageMetaToProto(m *ImageMeta) *taskguildv1.TaskImage {
+	return &taskguildv1.TaskImage{
+		Id:        m.ID,
+		Filename:  m.Filename,
+		MediaType: m.MediaType,
+		SizeBytes: m.SizeBytes,
+		CreatedAt: timestamppb.New(m.CreatedAt),
+	}
+}

--- a/proto/gen/go/taskguild/v1/task.pb.go
+++ b/proto/gen/go/taskguild/v1/task.pb.go
@@ -1438,6 +1438,474 @@ func (x *ListArchivedTasksResponse) GetPagination() *PaginationResponse {
 	return nil
 }
 
+type TaskImage struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Filename      string                 `protobuf:"bytes,2,opt,name=filename,proto3" json:"filename,omitempty"`
+	MediaType     string                 `protobuf:"bytes,3,opt,name=media_type,json=mediaType,proto3" json:"media_type,omitempty"`
+	SizeBytes     int64                  `protobuf:"varint,4,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TaskImage) Reset() {
+	*x = TaskImage{}
+	mi := &file_taskguild_v1_task_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TaskImage) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TaskImage) ProtoMessage() {}
+
+func (x *TaskImage) ProtoReflect() protoreflect.Message {
+	mi := &file_taskguild_v1_task_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TaskImage.ProtoReflect.Descriptor instead.
+func (*TaskImage) Descriptor() ([]byte, []int) {
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *TaskImage) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *TaskImage) GetFilename() string {
+	if x != nil {
+		return x.Filename
+	}
+	return ""
+}
+
+func (x *TaskImage) GetMediaType() string {
+	if x != nil {
+		return x.MediaType
+	}
+	return ""
+}
+
+func (x *TaskImage) GetSizeBytes() int64 {
+	if x != nil {
+		return x.SizeBytes
+	}
+	return 0
+}
+
+func (x *TaskImage) GetCreatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
+}
+
+type UploadTaskImageRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TaskId        string                 `protobuf:"bytes,1,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
+	Filename      string                 `protobuf:"bytes,2,opt,name=filename,proto3" json:"filename,omitempty"`
+	MediaType     string                 `protobuf:"bytes,3,opt,name=media_type,json=mediaType,proto3" json:"media_type,omitempty"`
+	Data          []byte                 `protobuf:"bytes,4,opt,name=data,proto3" json:"data,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UploadTaskImageRequest) Reset() {
+	*x = UploadTaskImageRequest{}
+	mi := &file_taskguild_v1_task_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UploadTaskImageRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UploadTaskImageRequest) ProtoMessage() {}
+
+func (x *UploadTaskImageRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_taskguild_v1_task_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UploadTaskImageRequest.ProtoReflect.Descriptor instead.
+func (*UploadTaskImageRequest) Descriptor() ([]byte, []int) {
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *UploadTaskImageRequest) GetTaskId() string {
+	if x != nil {
+		return x.TaskId
+	}
+	return ""
+}
+
+func (x *UploadTaskImageRequest) GetFilename() string {
+	if x != nil {
+		return x.Filename
+	}
+	return ""
+}
+
+func (x *UploadTaskImageRequest) GetMediaType() string {
+	if x != nil {
+		return x.MediaType
+	}
+	return ""
+}
+
+func (x *UploadTaskImageRequest) GetData() []byte {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+type UploadTaskImageResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Image         *TaskImage             `protobuf:"bytes,1,opt,name=image,proto3" json:"image,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UploadTaskImageResponse) Reset() {
+	*x = UploadTaskImageResponse{}
+	mi := &file_taskguild_v1_task_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UploadTaskImageResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UploadTaskImageResponse) ProtoMessage() {}
+
+func (x *UploadTaskImageResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_taskguild_v1_task_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UploadTaskImageResponse.ProtoReflect.Descriptor instead.
+func (*UploadTaskImageResponse) Descriptor() ([]byte, []int) {
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *UploadTaskImageResponse) GetImage() *TaskImage {
+	if x != nil {
+		return x.Image
+	}
+	return nil
+}
+
+type GetTaskImageRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TaskId        string                 `protobuf:"bytes,1,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
+	ImageId       string                 `protobuf:"bytes,2,opt,name=image_id,json=imageId,proto3" json:"image_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetTaskImageRequest) Reset() {
+	*x = GetTaskImageRequest{}
+	mi := &file_taskguild_v1_task_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetTaskImageRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetTaskImageRequest) ProtoMessage() {}
+
+func (x *GetTaskImageRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_taskguild_v1_task_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetTaskImageRequest.ProtoReflect.Descriptor instead.
+func (*GetTaskImageRequest) Descriptor() ([]byte, []int) {
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *GetTaskImageRequest) GetTaskId() string {
+	if x != nil {
+		return x.TaskId
+	}
+	return ""
+}
+
+func (x *GetTaskImageRequest) GetImageId() string {
+	if x != nil {
+		return x.ImageId
+	}
+	return ""
+}
+
+type GetTaskImageResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Image         *TaskImage             `protobuf:"bytes,1,opt,name=image,proto3" json:"image,omitempty"`
+	Data          []byte                 `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetTaskImageResponse) Reset() {
+	*x = GetTaskImageResponse{}
+	mi := &file_taskguild_v1_task_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetTaskImageResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetTaskImageResponse) ProtoMessage() {}
+
+func (x *GetTaskImageResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_taskguild_v1_task_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetTaskImageResponse.ProtoReflect.Descriptor instead.
+func (*GetTaskImageResponse) Descriptor() ([]byte, []int) {
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *GetTaskImageResponse) GetImage() *TaskImage {
+	if x != nil {
+		return x.Image
+	}
+	return nil
+}
+
+func (x *GetTaskImageResponse) GetData() []byte {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+type ListTaskImagesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TaskId        string                 `protobuf:"bytes,1,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTaskImagesRequest) Reset() {
+	*x = ListTaskImagesRequest{}
+	mi := &file_taskguild_v1_task_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTaskImagesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTaskImagesRequest) ProtoMessage() {}
+
+func (x *ListTaskImagesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_taskguild_v1_task_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTaskImagesRequest.ProtoReflect.Descriptor instead.
+func (*ListTaskImagesRequest) Descriptor() ([]byte, []int) {
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *ListTaskImagesRequest) GetTaskId() string {
+	if x != nil {
+		return x.TaskId
+	}
+	return ""
+}
+
+type ListTaskImagesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Images        []*TaskImage           `protobuf:"bytes,1,rep,name=images,proto3" json:"images,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTaskImagesResponse) Reset() {
+	*x = ListTaskImagesResponse{}
+	mi := &file_taskguild_v1_task_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTaskImagesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTaskImagesResponse) ProtoMessage() {}
+
+func (x *ListTaskImagesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_taskguild_v1_task_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTaskImagesResponse.ProtoReflect.Descriptor instead.
+func (*ListTaskImagesResponse) Descriptor() ([]byte, []int) {
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *ListTaskImagesResponse) GetImages() []*TaskImage {
+	if x != nil {
+		return x.Images
+	}
+	return nil
+}
+
+type DeleteTaskImageRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TaskId        string                 `protobuf:"bytes,1,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
+	ImageId       string                 `protobuf:"bytes,2,opt,name=image_id,json=imageId,proto3" json:"image_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteTaskImageRequest) Reset() {
+	*x = DeleteTaskImageRequest{}
+	mi := &file_taskguild_v1_task_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteTaskImageRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteTaskImageRequest) ProtoMessage() {}
+
+func (x *DeleteTaskImageRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_taskguild_v1_task_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteTaskImageRequest.ProtoReflect.Descriptor instead.
+func (*DeleteTaskImageRequest) Descriptor() ([]byte, []int) {
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *DeleteTaskImageRequest) GetTaskId() string {
+	if x != nil {
+		return x.TaskId
+	}
+	return ""
+}
+
+func (x *DeleteTaskImageRequest) GetImageId() string {
+	if x != nil {
+		return x.ImageId
+	}
+	return ""
+}
+
+type DeleteTaskImageResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteTaskImageResponse) Reset() {
+	*x = DeleteTaskImageResponse{}
+	mi := &file_taskguild_v1_task_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteTaskImageResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteTaskImageResponse) ProtoMessage() {}
+
+func (x *DeleteTaskImageResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_taskguild_v1_task_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteTaskImageResponse.ProtoReflect.Descriptor instead.
+func (*DeleteTaskImageResponse) Descriptor() ([]byte, []int) {
+	return file_taskguild_v1_task_proto_rawDescGZIP(), []int{33}
+}
+
 var File_taskguild_v1_task_proto protoreflect.FileDescriptor
 
 const file_taskguild_v1_task_proto_rawDesc = "" +
@@ -1556,12 +2024,43 @@ const file_taskguild_v1_task_proto_rawDesc = "" +
 	"\x05tasks\x18\x01 \x03(\v2\x12.taskguild.v1.TaskR\x05tasks\x12@\n" +
 	"\n" +
 	"pagination\x18\x02 \x01(\v2 .taskguild.v1.PaginationResponseR\n" +
-	"pagination*\xae\x01\n" +
+	"pagination\"\xb0\x01\n" +
+	"\tTaskImage\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1a\n" +
+	"\bfilename\x18\x02 \x01(\tR\bfilename\x12\x1d\n" +
+	"\n" +
+	"media_type\x18\x03 \x01(\tR\tmediaType\x12\x1d\n" +
+	"\n" +
+	"size_bytes\x18\x04 \x01(\x03R\tsizeBytes\x129\n" +
+	"\n" +
+	"created_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"\x80\x01\n" +
+	"\x16UploadTaskImageRequest\x12\x17\n" +
+	"\atask_id\x18\x01 \x01(\tR\x06taskId\x12\x1a\n" +
+	"\bfilename\x18\x02 \x01(\tR\bfilename\x12\x1d\n" +
+	"\n" +
+	"media_type\x18\x03 \x01(\tR\tmediaType\x12\x12\n" +
+	"\x04data\x18\x04 \x01(\fR\x04data\"H\n" +
+	"\x17UploadTaskImageResponse\x12-\n" +
+	"\x05image\x18\x01 \x01(\v2\x17.taskguild.v1.TaskImageR\x05image\"I\n" +
+	"\x13GetTaskImageRequest\x12\x17\n" +
+	"\atask_id\x18\x01 \x01(\tR\x06taskId\x12\x19\n" +
+	"\bimage_id\x18\x02 \x01(\tR\aimageId\"Y\n" +
+	"\x14GetTaskImageResponse\x12-\n" +
+	"\x05image\x18\x01 \x01(\v2\x17.taskguild.v1.TaskImageR\x05image\x12\x12\n" +
+	"\x04data\x18\x02 \x01(\fR\x04data\"0\n" +
+	"\x15ListTaskImagesRequest\x12\x17\n" +
+	"\atask_id\x18\x01 \x01(\tR\x06taskId\"I\n" +
+	"\x16ListTaskImagesResponse\x12/\n" +
+	"\x06images\x18\x01 \x03(\v2\x17.taskguild.v1.TaskImageR\x06images\"L\n" +
+	"\x16DeleteTaskImageRequest\x12\x17\n" +
+	"\atask_id\x18\x01 \x01(\tR\x06taskId\x12\x19\n" +
+	"\bimage_id\x18\x02 \x01(\tR\aimageId\"\x19\n" +
+	"\x17DeleteTaskImageResponse*\xae\x01\n" +
 	"\x14TaskAssignmentStatus\x12&\n" +
 	"\"TASK_ASSIGNMENT_STATUS_UNSPECIFIED\x10\x00\x12%\n" +
 	"!TASK_ASSIGNMENT_STATUS_UNASSIGNED\x10\x01\x12\"\n" +
 	"\x1eTASK_ASSIGNMENT_STATUS_PENDING\x10\x02\x12#\n" +
-	"\x1fTASK_ASSIGNMENT_STATUS_ASSIGNED\x10\x032\x98\b\n" +
+	"\x1fTASK_ASSIGNMENT_STATUS_ASSIGNED\x10\x032\x8c\v\n" +
 	"\vTaskService\x12O\n" +
 	"\n" +
 	"CreateTask\x12\x1f.taskguild.v1.CreateTaskRequest\x1a .taskguild.v1.CreateTaskResponse\x12F\n" +
@@ -1578,7 +2077,11 @@ const file_taskguild_v1_task_proto_rawDesc = "" +
 	"\vArchiveTask\x12 .taskguild.v1.ArchiveTaskRequest\x1a!.taskguild.v1.ArchiveTaskResponse\x12m\n" +
 	"\x14ArchiveTerminalTasks\x12).taskguild.v1.ArchiveTerminalTasksRequest\x1a*.taskguild.v1.ArchiveTerminalTasksResponse\x12X\n" +
 	"\rUnarchiveTask\x12\".taskguild.v1.UnarchiveTaskRequest\x1a#.taskguild.v1.UnarchiveTaskResponse\x12d\n" +
-	"\x11ListArchivedTasks\x12&.taskguild.v1.ListArchivedTasksRequest\x1a'.taskguild.v1.ListArchivedTasksResponseB\xb2\x01\n" +
+	"\x11ListArchivedTasks\x12&.taskguild.v1.ListArchivedTasksRequest\x1a'.taskguild.v1.ListArchivedTasksResponse\x12^\n" +
+	"\x0fUploadTaskImage\x12$.taskguild.v1.UploadTaskImageRequest\x1a%.taskguild.v1.UploadTaskImageResponse\x12U\n" +
+	"\fGetTaskImage\x12!.taskguild.v1.GetTaskImageRequest\x1a\".taskguild.v1.GetTaskImageResponse\x12[\n" +
+	"\x0eListTaskImages\x12#.taskguild.v1.ListTaskImagesRequest\x1a$.taskguild.v1.ListTaskImagesResponse\x12^\n" +
+	"\x0fDeleteTaskImage\x12$.taskguild.v1.DeleteTaskImageRequest\x1a%.taskguild.v1.DeleteTaskImageResponseB\xb2\x01\n" +
 	"\x10com.taskguild.v1B\tTaskProtoP\x01ZBgithub.com/kazz187/taskguild/proto/gen/go/taskguild/v1;taskguildv1\xa2\x02\x03TXX\xaa\x02\fTaskguild.V1\xca\x02\fTaskguild\\V1\xe2\x02\x18Taskguild\\V1\\GPBMetadata\xea\x02\rTaskguild::V1b\x06proto3"
 
 var (
@@ -1594,7 +2097,7 @@ func file_taskguild_v1_task_proto_rawDescGZIP() []byte {
 }
 
 var file_taskguild_v1_task_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_taskguild_v1_task_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_taskguild_v1_task_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
 var file_taskguild_v1_task_proto_goTypes = []any{
 	(TaskAssignmentStatus)(0),            // 0: taskguild.v1.TaskAssignmentStatus
 	(*Task)(nil),                         // 1: taskguild.v1.Task
@@ -1622,25 +2125,34 @@ var file_taskguild_v1_task_proto_goTypes = []any{
 	(*UnarchiveTaskResponse)(nil),        // 23: taskguild.v1.UnarchiveTaskResponse
 	(*ListArchivedTasksRequest)(nil),     // 24: taskguild.v1.ListArchivedTasksRequest
 	(*ListArchivedTasksResponse)(nil),    // 25: taskguild.v1.ListArchivedTasksResponse
-	nil,                                  // 26: taskguild.v1.Task.MetadataEntry
-	nil,                                  // 27: taskguild.v1.CreateTaskRequest.MetadataEntry
-	nil,                                  // 28: taskguild.v1.UpdateTaskRequest.MetadataEntry
-	(*timestamppb.Timestamp)(nil),        // 29: google.protobuf.Timestamp
-	(*PaginationRequest)(nil),            // 30: taskguild.v1.PaginationRequest
-	(*PaginationResponse)(nil),           // 31: taskguild.v1.PaginationResponse
+	(*TaskImage)(nil),                    // 26: taskguild.v1.TaskImage
+	(*UploadTaskImageRequest)(nil),       // 27: taskguild.v1.UploadTaskImageRequest
+	(*UploadTaskImageResponse)(nil),      // 28: taskguild.v1.UploadTaskImageResponse
+	(*GetTaskImageRequest)(nil),          // 29: taskguild.v1.GetTaskImageRequest
+	(*GetTaskImageResponse)(nil),         // 30: taskguild.v1.GetTaskImageResponse
+	(*ListTaskImagesRequest)(nil),        // 31: taskguild.v1.ListTaskImagesRequest
+	(*ListTaskImagesResponse)(nil),       // 32: taskguild.v1.ListTaskImagesResponse
+	(*DeleteTaskImageRequest)(nil),       // 33: taskguild.v1.DeleteTaskImageRequest
+	(*DeleteTaskImageResponse)(nil),      // 34: taskguild.v1.DeleteTaskImageResponse
+	nil,                                  // 35: taskguild.v1.Task.MetadataEntry
+	nil,                                  // 36: taskguild.v1.CreateTaskRequest.MetadataEntry
+	nil,                                  // 37: taskguild.v1.UpdateTaskRequest.MetadataEntry
+	(*timestamppb.Timestamp)(nil),        // 38: google.protobuf.Timestamp
+	(*PaginationRequest)(nil),            // 39: taskguild.v1.PaginationRequest
+	(*PaginationResponse)(nil),           // 40: taskguild.v1.PaginationResponse
 }
 var file_taskguild_v1_task_proto_depIdxs = []int32{
 	0,  // 0: taskguild.v1.Task.assignment_status:type_name -> taskguild.v1.TaskAssignmentStatus
-	26, // 1: taskguild.v1.Task.metadata:type_name -> taskguild.v1.Task.MetadataEntry
-	29, // 2: taskguild.v1.Task.created_at:type_name -> google.protobuf.Timestamp
-	29, // 3: taskguild.v1.Task.updated_at:type_name -> google.protobuf.Timestamp
-	27, // 4: taskguild.v1.CreateTaskRequest.metadata:type_name -> taskguild.v1.CreateTaskRequest.MetadataEntry
+	35, // 1: taskguild.v1.Task.metadata:type_name -> taskguild.v1.Task.MetadataEntry
+	38, // 2: taskguild.v1.Task.created_at:type_name -> google.protobuf.Timestamp
+	38, // 3: taskguild.v1.Task.updated_at:type_name -> google.protobuf.Timestamp
+	36, // 4: taskguild.v1.CreateTaskRequest.metadata:type_name -> taskguild.v1.CreateTaskRequest.MetadataEntry
 	1,  // 5: taskguild.v1.CreateTaskResponse.task:type_name -> taskguild.v1.Task
 	1,  // 6: taskguild.v1.GetTaskResponse.task:type_name -> taskguild.v1.Task
-	30, // 7: taskguild.v1.ListTasksRequest.pagination:type_name -> taskguild.v1.PaginationRequest
+	39, // 7: taskguild.v1.ListTasksRequest.pagination:type_name -> taskguild.v1.PaginationRequest
 	1,  // 8: taskguild.v1.ListTasksResponse.tasks:type_name -> taskguild.v1.Task
-	31, // 9: taskguild.v1.ListTasksResponse.pagination:type_name -> taskguild.v1.PaginationResponse
-	28, // 10: taskguild.v1.UpdateTaskRequest.metadata:type_name -> taskguild.v1.UpdateTaskRequest.MetadataEntry
+	40, // 9: taskguild.v1.ListTasksResponse.pagination:type_name -> taskguild.v1.PaginationResponse
+	37, // 10: taskguild.v1.UpdateTaskRequest.metadata:type_name -> taskguild.v1.UpdateTaskRequest.MetadataEntry
 	1,  // 11: taskguild.v1.UpdateTaskResponse.task:type_name -> taskguild.v1.Task
 	1,  // 12: taskguild.v1.UpdateTaskStatusResponse.task:type_name -> taskguild.v1.Task
 	1,  // 13: taskguild.v1.StopTaskResponse.task:type_name -> taskguild.v1.Task
@@ -1649,38 +2161,50 @@ var file_taskguild_v1_task_proto_depIdxs = []int32{
 	1,  // 16: taskguild.v1.ArchiveTerminalTasksResponse.archived_tasks:type_name -> taskguild.v1.Task
 	1,  // 17: taskguild.v1.ArchiveTerminalTasksResponse.skipped_tasks:type_name -> taskguild.v1.Task
 	1,  // 18: taskguild.v1.UnarchiveTaskResponse.task:type_name -> taskguild.v1.Task
-	30, // 19: taskguild.v1.ListArchivedTasksRequest.pagination:type_name -> taskguild.v1.PaginationRequest
+	39, // 19: taskguild.v1.ListArchivedTasksRequest.pagination:type_name -> taskguild.v1.PaginationRequest
 	1,  // 20: taskguild.v1.ListArchivedTasksResponse.tasks:type_name -> taskguild.v1.Task
-	31, // 21: taskguild.v1.ListArchivedTasksResponse.pagination:type_name -> taskguild.v1.PaginationResponse
-	2,  // 22: taskguild.v1.TaskService.CreateTask:input_type -> taskguild.v1.CreateTaskRequest
-	4,  // 23: taskguild.v1.TaskService.GetTask:input_type -> taskguild.v1.GetTaskRequest
-	6,  // 24: taskguild.v1.TaskService.ListTasks:input_type -> taskguild.v1.ListTasksRequest
-	8,  // 25: taskguild.v1.TaskService.UpdateTask:input_type -> taskguild.v1.UpdateTaskRequest
-	10, // 26: taskguild.v1.TaskService.DeleteTask:input_type -> taskguild.v1.DeleteTaskRequest
-	12, // 27: taskguild.v1.TaskService.UpdateTaskStatus:input_type -> taskguild.v1.UpdateTaskStatusRequest
-	14, // 28: taskguild.v1.TaskService.StopTask:input_type -> taskguild.v1.StopTaskRequest
-	16, // 29: taskguild.v1.TaskService.ResumeTask:input_type -> taskguild.v1.ResumeTaskRequest
-	18, // 30: taskguild.v1.TaskService.ArchiveTask:input_type -> taskguild.v1.ArchiveTaskRequest
-	20, // 31: taskguild.v1.TaskService.ArchiveTerminalTasks:input_type -> taskguild.v1.ArchiveTerminalTasksRequest
-	22, // 32: taskguild.v1.TaskService.UnarchiveTask:input_type -> taskguild.v1.UnarchiveTaskRequest
-	24, // 33: taskguild.v1.TaskService.ListArchivedTasks:input_type -> taskguild.v1.ListArchivedTasksRequest
-	3,  // 34: taskguild.v1.TaskService.CreateTask:output_type -> taskguild.v1.CreateTaskResponse
-	5,  // 35: taskguild.v1.TaskService.GetTask:output_type -> taskguild.v1.GetTaskResponse
-	7,  // 36: taskguild.v1.TaskService.ListTasks:output_type -> taskguild.v1.ListTasksResponse
-	9,  // 37: taskguild.v1.TaskService.UpdateTask:output_type -> taskguild.v1.UpdateTaskResponse
-	11, // 38: taskguild.v1.TaskService.DeleteTask:output_type -> taskguild.v1.DeleteTaskResponse
-	13, // 39: taskguild.v1.TaskService.UpdateTaskStatus:output_type -> taskguild.v1.UpdateTaskStatusResponse
-	15, // 40: taskguild.v1.TaskService.StopTask:output_type -> taskguild.v1.StopTaskResponse
-	17, // 41: taskguild.v1.TaskService.ResumeTask:output_type -> taskguild.v1.ResumeTaskResponse
-	19, // 42: taskguild.v1.TaskService.ArchiveTask:output_type -> taskguild.v1.ArchiveTaskResponse
-	21, // 43: taskguild.v1.TaskService.ArchiveTerminalTasks:output_type -> taskguild.v1.ArchiveTerminalTasksResponse
-	23, // 44: taskguild.v1.TaskService.UnarchiveTask:output_type -> taskguild.v1.UnarchiveTaskResponse
-	25, // 45: taskguild.v1.TaskService.ListArchivedTasks:output_type -> taskguild.v1.ListArchivedTasksResponse
-	34, // [34:46] is the sub-list for method output_type
-	22, // [22:34] is the sub-list for method input_type
-	22, // [22:22] is the sub-list for extension type_name
-	22, // [22:22] is the sub-list for extension extendee
-	0,  // [0:22] is the sub-list for field type_name
+	40, // 21: taskguild.v1.ListArchivedTasksResponse.pagination:type_name -> taskguild.v1.PaginationResponse
+	38, // 22: taskguild.v1.TaskImage.created_at:type_name -> google.protobuf.Timestamp
+	26, // 23: taskguild.v1.UploadTaskImageResponse.image:type_name -> taskguild.v1.TaskImage
+	26, // 24: taskguild.v1.GetTaskImageResponse.image:type_name -> taskguild.v1.TaskImage
+	26, // 25: taskguild.v1.ListTaskImagesResponse.images:type_name -> taskguild.v1.TaskImage
+	2,  // 26: taskguild.v1.TaskService.CreateTask:input_type -> taskguild.v1.CreateTaskRequest
+	4,  // 27: taskguild.v1.TaskService.GetTask:input_type -> taskguild.v1.GetTaskRequest
+	6,  // 28: taskguild.v1.TaskService.ListTasks:input_type -> taskguild.v1.ListTasksRequest
+	8,  // 29: taskguild.v1.TaskService.UpdateTask:input_type -> taskguild.v1.UpdateTaskRequest
+	10, // 30: taskguild.v1.TaskService.DeleteTask:input_type -> taskguild.v1.DeleteTaskRequest
+	12, // 31: taskguild.v1.TaskService.UpdateTaskStatus:input_type -> taskguild.v1.UpdateTaskStatusRequest
+	14, // 32: taskguild.v1.TaskService.StopTask:input_type -> taskguild.v1.StopTaskRequest
+	16, // 33: taskguild.v1.TaskService.ResumeTask:input_type -> taskguild.v1.ResumeTaskRequest
+	18, // 34: taskguild.v1.TaskService.ArchiveTask:input_type -> taskguild.v1.ArchiveTaskRequest
+	20, // 35: taskguild.v1.TaskService.ArchiveTerminalTasks:input_type -> taskguild.v1.ArchiveTerminalTasksRequest
+	22, // 36: taskguild.v1.TaskService.UnarchiveTask:input_type -> taskguild.v1.UnarchiveTaskRequest
+	24, // 37: taskguild.v1.TaskService.ListArchivedTasks:input_type -> taskguild.v1.ListArchivedTasksRequest
+	27, // 38: taskguild.v1.TaskService.UploadTaskImage:input_type -> taskguild.v1.UploadTaskImageRequest
+	29, // 39: taskguild.v1.TaskService.GetTaskImage:input_type -> taskguild.v1.GetTaskImageRequest
+	31, // 40: taskguild.v1.TaskService.ListTaskImages:input_type -> taskguild.v1.ListTaskImagesRequest
+	33, // 41: taskguild.v1.TaskService.DeleteTaskImage:input_type -> taskguild.v1.DeleteTaskImageRequest
+	3,  // 42: taskguild.v1.TaskService.CreateTask:output_type -> taskguild.v1.CreateTaskResponse
+	5,  // 43: taskguild.v1.TaskService.GetTask:output_type -> taskguild.v1.GetTaskResponse
+	7,  // 44: taskguild.v1.TaskService.ListTasks:output_type -> taskguild.v1.ListTasksResponse
+	9,  // 45: taskguild.v1.TaskService.UpdateTask:output_type -> taskguild.v1.UpdateTaskResponse
+	11, // 46: taskguild.v1.TaskService.DeleteTask:output_type -> taskguild.v1.DeleteTaskResponse
+	13, // 47: taskguild.v1.TaskService.UpdateTaskStatus:output_type -> taskguild.v1.UpdateTaskStatusResponse
+	15, // 48: taskguild.v1.TaskService.StopTask:output_type -> taskguild.v1.StopTaskResponse
+	17, // 49: taskguild.v1.TaskService.ResumeTask:output_type -> taskguild.v1.ResumeTaskResponse
+	19, // 50: taskguild.v1.TaskService.ArchiveTask:output_type -> taskguild.v1.ArchiveTaskResponse
+	21, // 51: taskguild.v1.TaskService.ArchiveTerminalTasks:output_type -> taskguild.v1.ArchiveTerminalTasksResponse
+	23, // 52: taskguild.v1.TaskService.UnarchiveTask:output_type -> taskguild.v1.UnarchiveTaskResponse
+	25, // 53: taskguild.v1.TaskService.ListArchivedTasks:output_type -> taskguild.v1.ListArchivedTasksResponse
+	28, // 54: taskguild.v1.TaskService.UploadTaskImage:output_type -> taskguild.v1.UploadTaskImageResponse
+	30, // 55: taskguild.v1.TaskService.GetTaskImage:output_type -> taskguild.v1.GetTaskImageResponse
+	32, // 56: taskguild.v1.TaskService.ListTaskImages:output_type -> taskguild.v1.ListTaskImagesResponse
+	34, // 57: taskguild.v1.TaskService.DeleteTaskImage:output_type -> taskguild.v1.DeleteTaskImageResponse
+	42, // [42:58] is the sub-list for method output_type
+	26, // [26:42] is the sub-list for method input_type
+	26, // [26:26] is the sub-list for extension type_name
+	26, // [26:26] is the sub-list for extension extendee
+	0,  // [0:26] is the sub-list for field type_name
 }
 
 func init() { file_taskguild_v1_task_proto_init() }
@@ -1697,7 +2221,7 @@ func file_taskguild_v1_task_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_taskguild_v1_task_proto_rawDesc), len(file_taskguild_v1_task_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   28,
+			NumMessages:   37,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/gen/go/taskguild/v1/taskguildv1connect/task.connect.go
+++ b/proto/gen/go/taskguild/v1/taskguildv1connect/task.connect.go
@@ -61,6 +61,18 @@ const (
 	// TaskServiceListArchivedTasksProcedure is the fully-qualified name of the TaskService's
 	// ListArchivedTasks RPC.
 	TaskServiceListArchivedTasksProcedure = "/taskguild.v1.TaskService/ListArchivedTasks"
+	// TaskServiceUploadTaskImageProcedure is the fully-qualified name of the TaskService's
+	// UploadTaskImage RPC.
+	TaskServiceUploadTaskImageProcedure = "/taskguild.v1.TaskService/UploadTaskImage"
+	// TaskServiceGetTaskImageProcedure is the fully-qualified name of the TaskService's GetTaskImage
+	// RPC.
+	TaskServiceGetTaskImageProcedure = "/taskguild.v1.TaskService/GetTaskImage"
+	// TaskServiceListTaskImagesProcedure is the fully-qualified name of the TaskService's
+	// ListTaskImages RPC.
+	TaskServiceListTaskImagesProcedure = "/taskguild.v1.TaskService/ListTaskImages"
+	// TaskServiceDeleteTaskImageProcedure is the fully-qualified name of the TaskService's
+	// DeleteTaskImage RPC.
+	TaskServiceDeleteTaskImageProcedure = "/taskguild.v1.TaskService/DeleteTaskImage"
 )
 
 // TaskServiceClient is a client for the taskguild.v1.TaskService service.
@@ -79,6 +91,11 @@ type TaskServiceClient interface {
 	ArchiveTerminalTasks(context.Context, *connect.Request[v1.ArchiveTerminalTasksRequest]) (*connect.Response[v1.ArchiveTerminalTasksResponse], error)
 	UnarchiveTask(context.Context, *connect.Request[v1.UnarchiveTaskRequest]) (*connect.Response[v1.UnarchiveTaskResponse], error)
 	ListArchivedTasks(context.Context, *connect.Request[v1.ListArchivedTasksRequest]) (*connect.Response[v1.ListArchivedTasksResponse], error)
+	// Task image operations
+	UploadTaskImage(context.Context, *connect.Request[v1.UploadTaskImageRequest]) (*connect.Response[v1.UploadTaskImageResponse], error)
+	GetTaskImage(context.Context, *connect.Request[v1.GetTaskImageRequest]) (*connect.Response[v1.GetTaskImageResponse], error)
+	ListTaskImages(context.Context, *connect.Request[v1.ListTaskImagesRequest]) (*connect.Response[v1.ListTaskImagesResponse], error)
+	DeleteTaskImage(context.Context, *connect.Request[v1.DeleteTaskImageRequest]) (*connect.Response[v1.DeleteTaskImageResponse], error)
 }
 
 // NewTaskServiceClient constructs a client for the taskguild.v1.TaskService service. By default, it
@@ -164,6 +181,30 @@ func NewTaskServiceClient(httpClient connect.HTTPClient, baseURL string, opts ..
 			connect.WithSchema(taskServiceMethods.ByName("ListArchivedTasks")),
 			connect.WithClientOptions(opts...),
 		),
+		uploadTaskImage: connect.NewClient[v1.UploadTaskImageRequest, v1.UploadTaskImageResponse](
+			httpClient,
+			baseURL+TaskServiceUploadTaskImageProcedure,
+			connect.WithSchema(taskServiceMethods.ByName("UploadTaskImage")),
+			connect.WithClientOptions(opts...),
+		),
+		getTaskImage: connect.NewClient[v1.GetTaskImageRequest, v1.GetTaskImageResponse](
+			httpClient,
+			baseURL+TaskServiceGetTaskImageProcedure,
+			connect.WithSchema(taskServiceMethods.ByName("GetTaskImage")),
+			connect.WithClientOptions(opts...),
+		),
+		listTaskImages: connect.NewClient[v1.ListTaskImagesRequest, v1.ListTaskImagesResponse](
+			httpClient,
+			baseURL+TaskServiceListTaskImagesProcedure,
+			connect.WithSchema(taskServiceMethods.ByName("ListTaskImages")),
+			connect.WithClientOptions(opts...),
+		),
+		deleteTaskImage: connect.NewClient[v1.DeleteTaskImageRequest, v1.DeleteTaskImageResponse](
+			httpClient,
+			baseURL+TaskServiceDeleteTaskImageProcedure,
+			connect.WithSchema(taskServiceMethods.ByName("DeleteTaskImage")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -181,6 +222,10 @@ type taskServiceClient struct {
 	archiveTerminalTasks *connect.Client[v1.ArchiveTerminalTasksRequest, v1.ArchiveTerminalTasksResponse]
 	unarchiveTask        *connect.Client[v1.UnarchiveTaskRequest, v1.UnarchiveTaskResponse]
 	listArchivedTasks    *connect.Client[v1.ListArchivedTasksRequest, v1.ListArchivedTasksResponse]
+	uploadTaskImage      *connect.Client[v1.UploadTaskImageRequest, v1.UploadTaskImageResponse]
+	getTaskImage         *connect.Client[v1.GetTaskImageRequest, v1.GetTaskImageResponse]
+	listTaskImages       *connect.Client[v1.ListTaskImagesRequest, v1.ListTaskImagesResponse]
+	deleteTaskImage      *connect.Client[v1.DeleteTaskImageRequest, v1.DeleteTaskImageResponse]
 }
 
 // CreateTask calls taskguild.v1.TaskService.CreateTask.
@@ -243,6 +288,26 @@ func (c *taskServiceClient) ListArchivedTasks(ctx context.Context, req *connect.
 	return c.listArchivedTasks.CallUnary(ctx, req)
 }
 
+// UploadTaskImage calls taskguild.v1.TaskService.UploadTaskImage.
+func (c *taskServiceClient) UploadTaskImage(ctx context.Context, req *connect.Request[v1.UploadTaskImageRequest]) (*connect.Response[v1.UploadTaskImageResponse], error) {
+	return c.uploadTaskImage.CallUnary(ctx, req)
+}
+
+// GetTaskImage calls taskguild.v1.TaskService.GetTaskImage.
+func (c *taskServiceClient) GetTaskImage(ctx context.Context, req *connect.Request[v1.GetTaskImageRequest]) (*connect.Response[v1.GetTaskImageResponse], error) {
+	return c.getTaskImage.CallUnary(ctx, req)
+}
+
+// ListTaskImages calls taskguild.v1.TaskService.ListTaskImages.
+func (c *taskServiceClient) ListTaskImages(ctx context.Context, req *connect.Request[v1.ListTaskImagesRequest]) (*connect.Response[v1.ListTaskImagesResponse], error) {
+	return c.listTaskImages.CallUnary(ctx, req)
+}
+
+// DeleteTaskImage calls taskguild.v1.TaskService.DeleteTaskImage.
+func (c *taskServiceClient) DeleteTaskImage(ctx context.Context, req *connect.Request[v1.DeleteTaskImageRequest]) (*connect.Response[v1.DeleteTaskImageResponse], error) {
+	return c.deleteTaskImage.CallUnary(ctx, req)
+}
+
 // TaskServiceHandler is an implementation of the taskguild.v1.TaskService service.
 type TaskServiceHandler interface {
 	CreateTask(context.Context, *connect.Request[v1.CreateTaskRequest]) (*connect.Response[v1.CreateTaskResponse], error)
@@ -259,6 +324,11 @@ type TaskServiceHandler interface {
 	ArchiveTerminalTasks(context.Context, *connect.Request[v1.ArchiveTerminalTasksRequest]) (*connect.Response[v1.ArchiveTerminalTasksResponse], error)
 	UnarchiveTask(context.Context, *connect.Request[v1.UnarchiveTaskRequest]) (*connect.Response[v1.UnarchiveTaskResponse], error)
 	ListArchivedTasks(context.Context, *connect.Request[v1.ListArchivedTasksRequest]) (*connect.Response[v1.ListArchivedTasksResponse], error)
+	// Task image operations
+	UploadTaskImage(context.Context, *connect.Request[v1.UploadTaskImageRequest]) (*connect.Response[v1.UploadTaskImageResponse], error)
+	GetTaskImage(context.Context, *connect.Request[v1.GetTaskImageRequest]) (*connect.Response[v1.GetTaskImageResponse], error)
+	ListTaskImages(context.Context, *connect.Request[v1.ListTaskImagesRequest]) (*connect.Response[v1.ListTaskImagesResponse], error)
+	DeleteTaskImage(context.Context, *connect.Request[v1.DeleteTaskImageRequest]) (*connect.Response[v1.DeleteTaskImageResponse], error)
 }
 
 // NewTaskServiceHandler builds an HTTP handler from the service implementation. It returns the path
@@ -340,6 +410,30 @@ func NewTaskServiceHandler(svc TaskServiceHandler, opts ...connect.HandlerOption
 		connect.WithSchema(taskServiceMethods.ByName("ListArchivedTasks")),
 		connect.WithHandlerOptions(opts...),
 	)
+	taskServiceUploadTaskImageHandler := connect.NewUnaryHandler(
+		TaskServiceUploadTaskImageProcedure,
+		svc.UploadTaskImage,
+		connect.WithSchema(taskServiceMethods.ByName("UploadTaskImage")),
+		connect.WithHandlerOptions(opts...),
+	)
+	taskServiceGetTaskImageHandler := connect.NewUnaryHandler(
+		TaskServiceGetTaskImageProcedure,
+		svc.GetTaskImage,
+		connect.WithSchema(taskServiceMethods.ByName("GetTaskImage")),
+		connect.WithHandlerOptions(opts...),
+	)
+	taskServiceListTaskImagesHandler := connect.NewUnaryHandler(
+		TaskServiceListTaskImagesProcedure,
+		svc.ListTaskImages,
+		connect.WithSchema(taskServiceMethods.ByName("ListTaskImages")),
+		connect.WithHandlerOptions(opts...),
+	)
+	taskServiceDeleteTaskImageHandler := connect.NewUnaryHandler(
+		TaskServiceDeleteTaskImageProcedure,
+		svc.DeleteTaskImage,
+		connect.WithSchema(taskServiceMethods.ByName("DeleteTaskImage")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/taskguild.v1.TaskService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case TaskServiceCreateTaskProcedure:
@@ -366,6 +460,14 @@ func NewTaskServiceHandler(svc TaskServiceHandler, opts ...connect.HandlerOption
 			taskServiceUnarchiveTaskHandler.ServeHTTP(w, r)
 		case TaskServiceListArchivedTasksProcedure:
 			taskServiceListArchivedTasksHandler.ServeHTTP(w, r)
+		case TaskServiceUploadTaskImageProcedure:
+			taskServiceUploadTaskImageHandler.ServeHTTP(w, r)
+		case TaskServiceGetTaskImageProcedure:
+			taskServiceGetTaskImageHandler.ServeHTTP(w, r)
+		case TaskServiceListTaskImagesProcedure:
+			taskServiceListTaskImagesHandler.ServeHTTP(w, r)
+		case TaskServiceDeleteTaskImageProcedure:
+			taskServiceDeleteTaskImageHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -421,4 +523,20 @@ func (UnimplementedTaskServiceHandler) UnarchiveTask(context.Context, *connect.R
 
 func (UnimplementedTaskServiceHandler) ListArchivedTasks(context.Context, *connect.Request[v1.ListArchivedTasksRequest]) (*connect.Response[v1.ListArchivedTasksResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("taskguild.v1.TaskService.ListArchivedTasks is not implemented"))
+}
+
+func (UnimplementedTaskServiceHandler) UploadTaskImage(context.Context, *connect.Request[v1.UploadTaskImageRequest]) (*connect.Response[v1.UploadTaskImageResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("taskguild.v1.TaskService.UploadTaskImage is not implemented"))
+}
+
+func (UnimplementedTaskServiceHandler) GetTaskImage(context.Context, *connect.Request[v1.GetTaskImageRequest]) (*connect.Response[v1.GetTaskImageResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("taskguild.v1.TaskService.GetTaskImage is not implemented"))
+}
+
+func (UnimplementedTaskServiceHandler) ListTaskImages(context.Context, *connect.Request[v1.ListTaskImagesRequest]) (*connect.Response[v1.ListTaskImagesResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("taskguild.v1.TaskService.ListTaskImages is not implemented"))
+}
+
+func (UnimplementedTaskServiceHandler) DeleteTaskImage(context.Context, *connect.Request[v1.DeleteTaskImageRequest]) (*connect.Response[v1.DeleteTaskImageResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("taskguild.v1.TaskService.DeleteTaskImage is not implemented"))
 }

--- a/proto/gen/go/taskguild/v1/workflow.pb.go
+++ b/proto/gen/go/taskguild/v1/workflow.pb.go
@@ -364,7 +364,7 @@ type WorkflowStatus struct {
 	AgentId       string   `protobuf:"bytes,7,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`                   // ID of the AgentDefinition assigned to this status
 	// hooks
 	Hooks []*StatusHook `protobuf:"bytes,8,rep,name=hooks,proto3" json:"hooks,omitempty"`
-	// harness: when true, a background agent reviews and updates AGENT.md
+	// harness: when true, a background agent reviews and updates agent markdown
 	// with lessons learned upon status exit. Defaults to true when not set.
 	EnableAgentMdHarness bool `protobuf:"varint,9,opt,name=enable_agent_md_harness,json=enableAgentMdHarness,proto3" json:"enable_agent_md_harness,omitempty"`
 	// Explicitly tracks whether enable_agent_md_harness was set by the user.

--- a/proto/gen/ts/taskguild/v1/task-TaskService_connectquery.ts
+++ b/proto/gen/ts/taskguild/v1/task-TaskService_connectquery.ts
@@ -67,3 +67,25 @@ export const unarchiveTask = TaskService.method.unarchiveTask;
  * @generated from rpc taskguild.v1.TaskService.ListArchivedTasks
  */
 export const listArchivedTasks = TaskService.method.listArchivedTasks;
+
+/**
+ * Task image operations
+ *
+ * @generated from rpc taskguild.v1.TaskService.UploadTaskImage
+ */
+export const uploadTaskImage = TaskService.method.uploadTaskImage;
+
+/**
+ * @generated from rpc taskguild.v1.TaskService.GetTaskImage
+ */
+export const getTaskImage = TaskService.method.getTaskImage;
+
+/**
+ * @generated from rpc taskguild.v1.TaskService.ListTaskImages
+ */
+export const listTaskImages = TaskService.method.listTaskImages;
+
+/**
+ * @generated from rpc taskguild.v1.TaskService.DeleteTaskImage
+ */
+export const deleteTaskImage = TaskService.method.deleteTaskImage;

--- a/proto/gen/ts/taskguild/v1/task_pb.ts
+++ b/proto/gen/ts/taskguild/v1/task_pb.ts
@@ -14,7 +14,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file taskguild/v1/task.proto.
  */
 export const file_taskguild_v1_task: GenFile = /*@__PURE__*/
-  fileDesc("Chd0YXNrZ3VpbGQvdjEvdGFzay5wcm90bxIMdGFza2d1aWxkLnYxIr4DCgRUYXNrEgoKAmlkGAEgASgJEhIKCnByb2plY3RfaWQYAiABKAkSEwoLd29ya2Zsb3dfaWQYAyABKAkSDQoFdGl0bGUYBCABKAkSEwoLZGVzY3JpcHRpb24YBSABKAkSEQoJc3RhdHVzX2lkGAYgASgJEj0KEWFzc2lnbm1lbnRfc3RhdHVzGAcgASgOMiIudGFza2d1aWxkLnYxLlRhc2tBc3NpZ25tZW50U3RhdHVzEhkKEWFzc2lnbmVkX2FnZW50X2lkGAggASgJEhQKDHVzZV93b3JrdHJlZRgJIAEoCBIyCghtZXRhZGF0YRgLIAMoCzIgLnRhc2tndWlsZC52MS5UYXNrLk1ldGFkYXRhRW50cnkSLgoKY3JlYXRlZF9hdBgMIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLgoKdXBkYXRlZF9hdBgNIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAaLwoNTWV0YWRhdGFFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBSgQIChALUg9wZXJtaXNzaW9uX21vZGUipQIKEUNyZWF0ZVRhc2tSZXF1ZXN0EhIKCnByb2plY3RfaWQYASABKAkSEwoLd29ya2Zsb3dfaWQYAiABKAkSDQoFdGl0bGUYAyABKAkSEwoLZGVzY3JpcHRpb24YBCABKAkSFAoMdXNlX3dvcmt0cmVlGAUgASgIEj8KCG1ldGFkYXRhGAcgAygLMi0udGFza2d1aWxkLnYxLkNyZWF0ZVRhc2tSZXF1ZXN0Lk1ldGFkYXRhRW50cnkSFgoJc3RhdHVzX2lkGAggASgJSACIAQEaLwoNTWV0YWRhdGFFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBQgwKCl9zdGF0dXNfaWRKBAgGEAdSD3Blcm1pc3Npb25fbW9kZSI2ChJDcmVhdGVUYXNrUmVzcG9uc2USIAoEdGFzaxgBIAEoCzISLnRhc2tndWlsZC52MS5UYXNrIhwKDkdldFRhc2tSZXF1ZXN0EgoKAmlkGAEgASgJIjMKD0dldFRhc2tSZXNwb25zZRIgCgR0YXNrGAEgASgLMhIudGFza2d1aWxkLnYxLlRhc2sigwEKEExpc3RUYXNrc1JlcXVlc3QSEgoKcHJvamVjdF9pZBgBIAEoCRITCgt3b3JrZmxvd19pZBgCIAEoCRIRCglzdGF0dXNfaWQYAyABKAkSMwoKcGFnaW5hdGlvbhgEIAEoCzIfLnRhc2tndWlsZC52MS5QYWdpbmF0aW9uUmVxdWVzdCJsChFMaXN0VGFza3NSZXNwb25zZRIhCgV0YXNrcxgBIAMoCzISLnRhc2tndWlsZC52MS5UYXNrEjQKCnBhZ2luYXRpb24YAiABKAsyIC50YXNrZ3VpbGQudjEuUGFnaW5hdGlvblJlc3BvbnNlIvgBChFVcGRhdGVUYXNrUmVxdWVzdBIKCgJpZBgBIAEoCRINCgV0aXRsZRgCIAEoCRITCgtkZXNjcmlwdGlvbhgDIAEoCRIZCgx1c2Vfd29ya3RyZWUYBCABKAhIAIgBARI/CghtZXRhZGF0YRgGIAMoCzItLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrUmVxdWVzdC5NZXRhZGF0YUVudHJ5Gi8KDU1ldGFkYXRhRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4AUIPCg1fdXNlX3dvcmt0cmVlSgQIBRAGUg9wZXJtaXNzaW9uX21vZGUiNgoSVXBkYXRlVGFza1Jlc3BvbnNlEiAKBHRhc2sYASABKAsyEi50YXNrZ3VpbGQudjEuVGFzayIfChFEZWxldGVUYXNrUmVxdWVzdBIKCgJpZBgBIAEoCSIUChJEZWxldGVUYXNrUmVzcG9uc2UiRwoXVXBkYXRlVGFza1N0YXR1c1JlcXVlc3QSCgoCaWQYASABKAkSEQoJc3RhdHVzX2lkGAIgASgJEg0KBWZvcmNlGAMgASgIIjwKGFVwZGF0ZVRhc2tTdGF0dXNSZXNwb25zZRIgCgR0YXNrGAEgASgLMhIudGFza2d1aWxkLnYxLlRhc2siHQoPU3RvcFRhc2tSZXF1ZXN0EgoKAmlkGAEgASgJIjQKEFN0b3BUYXNrUmVzcG9uc2USIAoEdGFzaxgBIAEoCzISLnRhc2tndWlsZC52MS5UYXNrIh8KEVJlc3VtZVRhc2tSZXF1ZXN0EgoKAmlkGAEgASgJIjYKElJlc3VtZVRhc2tSZXNwb25zZRIgCgR0YXNrGAEgASgLMhIudGFza2d1aWxkLnYxLlRhc2siIAoSQXJjaGl2ZVRhc2tSZXF1ZXN0EgoKAmlkGAEgASgJIjcKE0FyY2hpdmVUYXNrUmVzcG9uc2USIAoEdGFzaxgBIAEoCzISLnRhc2tndWlsZC52MS5UYXNrIkYKG0FyY2hpdmVUZXJtaW5hbFRhc2tzUmVxdWVzdBISCgpwcm9qZWN0X2lkGAEgASgJEhMKC3dvcmtmbG93X2lkGAIgASgJInUKHEFyY2hpdmVUZXJtaW5hbFRhc2tzUmVzcG9uc2USKgoOYXJjaGl2ZWRfdGFza3MYASADKAsyEi50YXNrZ3VpbGQudjEuVGFzaxIpCg1za2lwcGVkX3Rhc2tzGAIgAygLMhIudGFza2d1aWxkLnYxLlRhc2siIgoUVW5hcmNoaXZlVGFza1JlcXVlc3QSCgoCaWQYASABKAkiOQoVVW5hcmNoaXZlVGFza1Jlc3BvbnNlEiAKBHRhc2sYASABKAsyEi50YXNrZ3VpbGQudjEuVGFzayJ4ChhMaXN0QXJjaGl2ZWRUYXNrc1JlcXVlc3QSEgoKcHJvamVjdF9pZBgBIAEoCRITCgt3b3JrZmxvd19pZBgCIAEoCRIzCgpwYWdpbmF0aW9uGAMgASgLMh8udGFza2d1aWxkLnYxLlBhZ2luYXRpb25SZXF1ZXN0InQKGUxpc3RBcmNoaXZlZFRhc2tzUmVzcG9uc2USIQoFdGFza3MYASADKAsyEi50YXNrZ3VpbGQudjEuVGFzaxI0CgpwYWdpbmF0aW9uGAIgASgLMiAudGFza2d1aWxkLnYxLlBhZ2luYXRpb25SZXNwb25zZSquAQoUVGFza0Fzc2lnbm1lbnRTdGF0dXMSJgoiVEFTS19BU1NJR05NRU5UX1NUQVRVU19VTlNQRUNJRklFRBAAEiUKIVRBU0tfQVNTSUdOTUVOVF9TVEFUVVNfVU5BU1NJR05FRBABEiIKHlRBU0tfQVNTSUdOTUVOVF9TVEFUVVNfUEVORElORxACEiMKH1RBU0tfQVNTSUdOTUVOVF9TVEFUVVNfQVNTSUdORUQQAzKYCAoLVGFza1NlcnZpY2USTwoKQ3JlYXRlVGFzaxIfLnRhc2tndWlsZC52MS5DcmVhdGVUYXNrUmVxdWVzdBogLnRhc2tndWlsZC52MS5DcmVhdGVUYXNrUmVzcG9uc2USRgoHR2V0VGFzaxIcLnRhc2tndWlsZC52MS5HZXRUYXNrUmVxdWVzdBodLnRhc2tndWlsZC52MS5HZXRUYXNrUmVzcG9uc2USTAoJTGlzdFRhc2tzEh4udGFza2d1aWxkLnYxLkxpc3RUYXNrc1JlcXVlc3QaHy50YXNrZ3VpbGQudjEuTGlzdFRhc2tzUmVzcG9uc2USTwoKVXBkYXRlVGFzaxIfLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrUmVxdWVzdBogLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrUmVzcG9uc2USTwoKRGVsZXRlVGFzaxIfLnRhc2tndWlsZC52MS5EZWxldGVUYXNrUmVxdWVzdBogLnRhc2tndWlsZC52MS5EZWxldGVUYXNrUmVzcG9uc2USYQoQVXBkYXRlVGFza1N0YXR1cxIlLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrU3RhdHVzUmVxdWVzdBomLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrU3RhdHVzUmVzcG9uc2USSQoIU3RvcFRhc2sSHS50YXNrZ3VpbGQudjEuU3RvcFRhc2tSZXF1ZXN0Gh4udGFza2d1aWxkLnYxLlN0b3BUYXNrUmVzcG9uc2USTwoKUmVzdW1lVGFzaxIfLnRhc2tndWlsZC52MS5SZXN1bWVUYXNrUmVxdWVzdBogLnRhc2tndWlsZC52MS5SZXN1bWVUYXNrUmVzcG9uc2USUgoLQXJjaGl2ZVRhc2sSIC50YXNrZ3VpbGQudjEuQXJjaGl2ZVRhc2tSZXF1ZXN0GiEudGFza2d1aWxkLnYxLkFyY2hpdmVUYXNrUmVzcG9uc2USbQoUQXJjaGl2ZVRlcm1pbmFsVGFza3MSKS50YXNrZ3VpbGQudjEuQXJjaGl2ZVRlcm1pbmFsVGFza3NSZXF1ZXN0GioudGFza2d1aWxkLnYxLkFyY2hpdmVUZXJtaW5hbFRhc2tzUmVzcG9uc2USWAoNVW5hcmNoaXZlVGFzaxIiLnRhc2tndWlsZC52MS5VbmFyY2hpdmVUYXNrUmVxdWVzdBojLnRhc2tndWlsZC52MS5VbmFyY2hpdmVUYXNrUmVzcG9uc2USZAoRTGlzdEFyY2hpdmVkVGFza3MSJi50YXNrZ3VpbGQudjEuTGlzdEFyY2hpdmVkVGFza3NSZXF1ZXN0GicudGFza2d1aWxkLnYxLkxpc3RBcmNoaXZlZFRhc2tzUmVzcG9uc2VCsgEKEGNvbS50YXNrZ3VpbGQudjFCCVRhc2tQcm90b1ABWkJnaXRodWIuY29tL2thenoxODcvdGFza2d1aWxkL3Byb3RvL2dlbi9nby90YXNrZ3VpbGQvdjE7dGFza2d1aWxkdjGiAgNUWFiqAgxUYXNrZ3VpbGQuVjHKAgxUYXNrZ3VpbGRcVjHiAhhUYXNrZ3VpbGRcVjFcR1BCTWV0YWRhdGHqAg1UYXNrZ3VpbGQ6OlYxYgZwcm90bzM", [file_google_protobuf_timestamp, file_taskguild_v1_common]);
+  fileDesc("Chd0YXNrZ3VpbGQvdjEvdGFzay5wcm90bxIMdGFza2d1aWxkLnYxIr4DCgRUYXNrEgoKAmlkGAEgASgJEhIKCnByb2plY3RfaWQYAiABKAkSEwoLd29ya2Zsb3dfaWQYAyABKAkSDQoFdGl0bGUYBCABKAkSEwoLZGVzY3JpcHRpb24YBSABKAkSEQoJc3RhdHVzX2lkGAYgASgJEj0KEWFzc2lnbm1lbnRfc3RhdHVzGAcgASgOMiIudGFza2d1aWxkLnYxLlRhc2tBc3NpZ25tZW50U3RhdHVzEhkKEWFzc2lnbmVkX2FnZW50X2lkGAggASgJEhQKDHVzZV93b3JrdHJlZRgJIAEoCBIyCghtZXRhZGF0YRgLIAMoCzIgLnRhc2tndWlsZC52MS5UYXNrLk1ldGFkYXRhRW50cnkSLgoKY3JlYXRlZF9hdBgMIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLgoKdXBkYXRlZF9hdBgNIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAaLwoNTWV0YWRhdGFFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBSgQIChALUg9wZXJtaXNzaW9uX21vZGUipQIKEUNyZWF0ZVRhc2tSZXF1ZXN0EhIKCnByb2plY3RfaWQYASABKAkSEwoLd29ya2Zsb3dfaWQYAiABKAkSDQoFdGl0bGUYAyABKAkSEwoLZGVzY3JpcHRpb24YBCABKAkSFAoMdXNlX3dvcmt0cmVlGAUgASgIEj8KCG1ldGFkYXRhGAcgAygLMi0udGFza2d1aWxkLnYxLkNyZWF0ZVRhc2tSZXF1ZXN0Lk1ldGFkYXRhRW50cnkSFgoJc3RhdHVzX2lkGAggASgJSACIAQEaLwoNTWV0YWRhdGFFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBQgwKCl9zdGF0dXNfaWRKBAgGEAdSD3Blcm1pc3Npb25fbW9kZSI2ChJDcmVhdGVUYXNrUmVzcG9uc2USIAoEdGFzaxgBIAEoCzISLnRhc2tndWlsZC52MS5UYXNrIhwKDkdldFRhc2tSZXF1ZXN0EgoKAmlkGAEgASgJIjMKD0dldFRhc2tSZXNwb25zZRIgCgR0YXNrGAEgASgLMhIudGFza2d1aWxkLnYxLlRhc2sigwEKEExpc3RUYXNrc1JlcXVlc3QSEgoKcHJvamVjdF9pZBgBIAEoCRITCgt3b3JrZmxvd19pZBgCIAEoCRIRCglzdGF0dXNfaWQYAyABKAkSMwoKcGFnaW5hdGlvbhgEIAEoCzIfLnRhc2tndWlsZC52MS5QYWdpbmF0aW9uUmVxdWVzdCJsChFMaXN0VGFza3NSZXNwb25zZRIhCgV0YXNrcxgBIAMoCzISLnRhc2tndWlsZC52MS5UYXNrEjQKCnBhZ2luYXRpb24YAiABKAsyIC50YXNrZ3VpbGQudjEuUGFnaW5hdGlvblJlc3BvbnNlIvgBChFVcGRhdGVUYXNrUmVxdWVzdBIKCgJpZBgBIAEoCRINCgV0aXRsZRgCIAEoCRITCgtkZXNjcmlwdGlvbhgDIAEoCRIZCgx1c2Vfd29ya3RyZWUYBCABKAhIAIgBARI/CghtZXRhZGF0YRgGIAMoCzItLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrUmVxdWVzdC5NZXRhZGF0YUVudHJ5Gi8KDU1ldGFkYXRhRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4AUIPCg1fdXNlX3dvcmt0cmVlSgQIBRAGUg9wZXJtaXNzaW9uX21vZGUiNgoSVXBkYXRlVGFza1Jlc3BvbnNlEiAKBHRhc2sYASABKAsyEi50YXNrZ3VpbGQudjEuVGFzayIfChFEZWxldGVUYXNrUmVxdWVzdBIKCgJpZBgBIAEoCSIUChJEZWxldGVUYXNrUmVzcG9uc2UiRwoXVXBkYXRlVGFza1N0YXR1c1JlcXVlc3QSCgoCaWQYASABKAkSEQoJc3RhdHVzX2lkGAIgASgJEg0KBWZvcmNlGAMgASgIIjwKGFVwZGF0ZVRhc2tTdGF0dXNSZXNwb25zZRIgCgR0YXNrGAEgASgLMhIudGFza2d1aWxkLnYxLlRhc2siHQoPU3RvcFRhc2tSZXF1ZXN0EgoKAmlkGAEgASgJIjQKEFN0b3BUYXNrUmVzcG9uc2USIAoEdGFzaxgBIAEoCzISLnRhc2tndWlsZC52MS5UYXNrIh8KEVJlc3VtZVRhc2tSZXF1ZXN0EgoKAmlkGAEgASgJIjYKElJlc3VtZVRhc2tSZXNwb25zZRIgCgR0YXNrGAEgASgLMhIudGFza2d1aWxkLnYxLlRhc2siIAoSQXJjaGl2ZVRhc2tSZXF1ZXN0EgoKAmlkGAEgASgJIjcKE0FyY2hpdmVUYXNrUmVzcG9uc2USIAoEdGFzaxgBIAEoCzISLnRhc2tndWlsZC52MS5UYXNrIkYKG0FyY2hpdmVUZXJtaW5hbFRhc2tzUmVxdWVzdBISCgpwcm9qZWN0X2lkGAEgASgJEhMKC3dvcmtmbG93X2lkGAIgASgJInUKHEFyY2hpdmVUZXJtaW5hbFRhc2tzUmVzcG9uc2USKgoOYXJjaGl2ZWRfdGFza3MYASADKAsyEi50YXNrZ3VpbGQudjEuVGFzaxIpCg1za2lwcGVkX3Rhc2tzGAIgAygLMhIudGFza2d1aWxkLnYxLlRhc2siIgoUVW5hcmNoaXZlVGFza1JlcXVlc3QSCgoCaWQYASABKAkiOQoVVW5hcmNoaXZlVGFza1Jlc3BvbnNlEiAKBHRhc2sYASABKAsyEi50YXNrZ3VpbGQudjEuVGFzayJ4ChhMaXN0QXJjaGl2ZWRUYXNrc1JlcXVlc3QSEgoKcHJvamVjdF9pZBgBIAEoCRITCgt3b3JrZmxvd19pZBgCIAEoCRIzCgpwYWdpbmF0aW9uGAMgASgLMh8udGFza2d1aWxkLnYxLlBhZ2luYXRpb25SZXF1ZXN0InQKGUxpc3RBcmNoaXZlZFRhc2tzUmVzcG9uc2USIQoFdGFza3MYASADKAsyEi50YXNrZ3VpbGQudjEuVGFzaxI0CgpwYWdpbmF0aW9uGAIgASgLMiAudGFza2d1aWxkLnYxLlBhZ2luYXRpb25SZXNwb25zZSKBAQoJVGFza0ltYWdlEgoKAmlkGAEgASgJEhAKCGZpbGVuYW1lGAIgASgJEhIKCm1lZGlhX3R5cGUYAyABKAkSEgoKc2l6ZV9ieXRlcxgEIAEoAxIuCgpjcmVhdGVkX2F0GAUgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCJdChZVcGxvYWRUYXNrSW1hZ2VSZXF1ZXN0Eg8KB3Rhc2tfaWQYASABKAkSEAoIZmlsZW5hbWUYAiABKAkSEgoKbWVkaWFfdHlwZRgDIAEoCRIMCgRkYXRhGAQgASgMIkEKF1VwbG9hZFRhc2tJbWFnZVJlc3BvbnNlEiYKBWltYWdlGAEgASgLMhcudGFza2d1aWxkLnYxLlRhc2tJbWFnZSI4ChNHZXRUYXNrSW1hZ2VSZXF1ZXN0Eg8KB3Rhc2tfaWQYASABKAkSEAoIaW1hZ2VfaWQYAiABKAkiTAoUR2V0VGFza0ltYWdlUmVzcG9uc2USJgoFaW1hZ2UYASABKAsyFy50YXNrZ3VpbGQudjEuVGFza0ltYWdlEgwKBGRhdGEYAiABKAwiKAoVTGlzdFRhc2tJbWFnZXNSZXF1ZXN0Eg8KB3Rhc2tfaWQYASABKAkiQQoWTGlzdFRhc2tJbWFnZXNSZXNwb25zZRInCgZpbWFnZXMYASADKAsyFy50YXNrZ3VpbGQudjEuVGFza0ltYWdlIjsKFkRlbGV0ZVRhc2tJbWFnZVJlcXVlc3QSDwoHdGFza19pZBgBIAEoCRIQCghpbWFnZV9pZBgCIAEoCSIZChdEZWxldGVUYXNrSW1hZ2VSZXNwb25zZSquAQoUVGFza0Fzc2lnbm1lbnRTdGF0dXMSJgoiVEFTS19BU1NJR05NRU5UX1NUQVRVU19VTlNQRUNJRklFRBAAEiUKIVRBU0tfQVNTSUdOTUVOVF9TVEFUVVNfVU5BU1NJR05FRBABEiIKHlRBU0tfQVNTSUdOTUVOVF9TVEFUVVNfUEVORElORxACEiMKH1RBU0tfQVNTSUdOTUVOVF9TVEFUVVNfQVNTSUdORUQQAzKMCwoLVGFza1NlcnZpY2USTwoKQ3JlYXRlVGFzaxIfLnRhc2tndWlsZC52MS5DcmVhdGVUYXNrUmVxdWVzdBogLnRhc2tndWlsZC52MS5DcmVhdGVUYXNrUmVzcG9uc2USRgoHR2V0VGFzaxIcLnRhc2tndWlsZC52MS5HZXRUYXNrUmVxdWVzdBodLnRhc2tndWlsZC52MS5HZXRUYXNrUmVzcG9uc2USTAoJTGlzdFRhc2tzEh4udGFza2d1aWxkLnYxLkxpc3RUYXNrc1JlcXVlc3QaHy50YXNrZ3VpbGQudjEuTGlzdFRhc2tzUmVzcG9uc2USTwoKVXBkYXRlVGFzaxIfLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrUmVxdWVzdBogLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrUmVzcG9uc2USTwoKRGVsZXRlVGFzaxIfLnRhc2tndWlsZC52MS5EZWxldGVUYXNrUmVxdWVzdBogLnRhc2tndWlsZC52MS5EZWxldGVUYXNrUmVzcG9uc2USYQoQVXBkYXRlVGFza1N0YXR1cxIlLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrU3RhdHVzUmVxdWVzdBomLnRhc2tndWlsZC52MS5VcGRhdGVUYXNrU3RhdHVzUmVzcG9uc2USSQoIU3RvcFRhc2sSHS50YXNrZ3VpbGQudjEuU3RvcFRhc2tSZXF1ZXN0Gh4udGFza2d1aWxkLnYxLlN0b3BUYXNrUmVzcG9uc2USTwoKUmVzdW1lVGFzaxIfLnRhc2tndWlsZC52MS5SZXN1bWVUYXNrUmVxdWVzdBogLnRhc2tndWlsZC52MS5SZXN1bWVUYXNrUmVzcG9uc2USUgoLQXJjaGl2ZVRhc2sSIC50YXNrZ3VpbGQudjEuQXJjaGl2ZVRhc2tSZXF1ZXN0GiEudGFza2d1aWxkLnYxLkFyY2hpdmVUYXNrUmVzcG9uc2USbQoUQXJjaGl2ZVRlcm1pbmFsVGFza3MSKS50YXNrZ3VpbGQudjEuQXJjaGl2ZVRlcm1pbmFsVGFza3NSZXF1ZXN0GioudGFza2d1aWxkLnYxLkFyY2hpdmVUZXJtaW5hbFRhc2tzUmVzcG9uc2USWAoNVW5hcmNoaXZlVGFzaxIiLnRhc2tndWlsZC52MS5VbmFyY2hpdmVUYXNrUmVxdWVzdBojLnRhc2tndWlsZC52MS5VbmFyY2hpdmVUYXNrUmVzcG9uc2USZAoRTGlzdEFyY2hpdmVkVGFza3MSJi50YXNrZ3VpbGQudjEuTGlzdEFyY2hpdmVkVGFza3NSZXF1ZXN0GicudGFza2d1aWxkLnYxLkxpc3RBcmNoaXZlZFRhc2tzUmVzcG9uc2USXgoPVXBsb2FkVGFza0ltYWdlEiQudGFza2d1aWxkLnYxLlVwbG9hZFRhc2tJbWFnZVJlcXVlc3QaJS50YXNrZ3VpbGQudjEuVXBsb2FkVGFza0ltYWdlUmVzcG9uc2USVQoMR2V0VGFza0ltYWdlEiEudGFza2d1aWxkLnYxLkdldFRhc2tJbWFnZVJlcXVlc3QaIi50YXNrZ3VpbGQudjEuR2V0VGFza0ltYWdlUmVzcG9uc2USWwoOTGlzdFRhc2tJbWFnZXMSIy50YXNrZ3VpbGQudjEuTGlzdFRhc2tJbWFnZXNSZXF1ZXN0GiQudGFza2d1aWxkLnYxLkxpc3RUYXNrSW1hZ2VzUmVzcG9uc2USXgoPRGVsZXRlVGFza0ltYWdlEiQudGFza2d1aWxkLnYxLkRlbGV0ZVRhc2tJbWFnZVJlcXVlc3QaJS50YXNrZ3VpbGQudjEuRGVsZXRlVGFza0ltYWdlUmVzcG9uc2VCsgEKEGNvbS50YXNrZ3VpbGQudjFCCVRhc2tQcm90b1ABWkJnaXRodWIuY29tL2thenoxODcvdGFza2d1aWxkL3Byb3RvL2dlbi9nby90YXNrZ3VpbGQvdjE7dGFza2d1aWxkdjGiAgNUWFiqAgxUYXNrZ3VpbGQuVjHKAgxUYXNrZ3VpbGRcVjHiAhhUYXNrZ3VpbGRcVjFcR1BCTWV0YWRhdGHqAg1UYXNrZ3VpbGQ6OlYxYgZwcm90bzM", [file_google_protobuf_timestamp, file_taskguild_v1_common]);
 
 /**
  * @generated from message taskguild.v1.Task
@@ -637,6 +637,205 @@ export const ListArchivedTasksResponseSchema: GenMessage<ListArchivedTasksRespon
   messageDesc(file_taskguild_v1_task, 24);
 
 /**
+ * @generated from message taskguild.v1.TaskImage
+ */
+export type TaskImage = Message<"taskguild.v1.TaskImage"> & {
+  /**
+   * @generated from field: string id = 1;
+   */
+  id: string;
+
+  /**
+   * @generated from field: string filename = 2;
+   */
+  filename: string;
+
+  /**
+   * @generated from field: string media_type = 3;
+   */
+  mediaType: string;
+
+  /**
+   * @generated from field: int64 size_bytes = 4;
+   */
+  sizeBytes: bigint;
+
+  /**
+   * @generated from field: google.protobuf.Timestamp created_at = 5;
+   */
+  createdAt?: Timestamp;
+};
+
+/**
+ * Describes the message taskguild.v1.TaskImage.
+ * Use `create(TaskImageSchema)` to create a new message.
+ */
+export const TaskImageSchema: GenMessage<TaskImage> = /*@__PURE__*/
+  messageDesc(file_taskguild_v1_task, 25);
+
+/**
+ * @generated from message taskguild.v1.UploadTaskImageRequest
+ */
+export type UploadTaskImageRequest = Message<"taskguild.v1.UploadTaskImageRequest"> & {
+  /**
+   * @generated from field: string task_id = 1;
+   */
+  taskId: string;
+
+  /**
+   * @generated from field: string filename = 2;
+   */
+  filename: string;
+
+  /**
+   * @generated from field: string media_type = 3;
+   */
+  mediaType: string;
+
+  /**
+   * @generated from field: bytes data = 4;
+   */
+  data: Uint8Array;
+};
+
+/**
+ * Describes the message taskguild.v1.UploadTaskImageRequest.
+ * Use `create(UploadTaskImageRequestSchema)` to create a new message.
+ */
+export const UploadTaskImageRequestSchema: GenMessage<UploadTaskImageRequest> = /*@__PURE__*/
+  messageDesc(file_taskguild_v1_task, 26);
+
+/**
+ * @generated from message taskguild.v1.UploadTaskImageResponse
+ */
+export type UploadTaskImageResponse = Message<"taskguild.v1.UploadTaskImageResponse"> & {
+  /**
+   * @generated from field: taskguild.v1.TaskImage image = 1;
+   */
+  image?: TaskImage;
+};
+
+/**
+ * Describes the message taskguild.v1.UploadTaskImageResponse.
+ * Use `create(UploadTaskImageResponseSchema)` to create a new message.
+ */
+export const UploadTaskImageResponseSchema: GenMessage<UploadTaskImageResponse> = /*@__PURE__*/
+  messageDesc(file_taskguild_v1_task, 27);
+
+/**
+ * @generated from message taskguild.v1.GetTaskImageRequest
+ */
+export type GetTaskImageRequest = Message<"taskguild.v1.GetTaskImageRequest"> & {
+  /**
+   * @generated from field: string task_id = 1;
+   */
+  taskId: string;
+
+  /**
+   * @generated from field: string image_id = 2;
+   */
+  imageId: string;
+};
+
+/**
+ * Describes the message taskguild.v1.GetTaskImageRequest.
+ * Use `create(GetTaskImageRequestSchema)` to create a new message.
+ */
+export const GetTaskImageRequestSchema: GenMessage<GetTaskImageRequest> = /*@__PURE__*/
+  messageDesc(file_taskguild_v1_task, 28);
+
+/**
+ * @generated from message taskguild.v1.GetTaskImageResponse
+ */
+export type GetTaskImageResponse = Message<"taskguild.v1.GetTaskImageResponse"> & {
+  /**
+   * @generated from field: taskguild.v1.TaskImage image = 1;
+   */
+  image?: TaskImage;
+
+  /**
+   * @generated from field: bytes data = 2;
+   */
+  data: Uint8Array;
+};
+
+/**
+ * Describes the message taskguild.v1.GetTaskImageResponse.
+ * Use `create(GetTaskImageResponseSchema)` to create a new message.
+ */
+export const GetTaskImageResponseSchema: GenMessage<GetTaskImageResponse> = /*@__PURE__*/
+  messageDesc(file_taskguild_v1_task, 29);
+
+/**
+ * @generated from message taskguild.v1.ListTaskImagesRequest
+ */
+export type ListTaskImagesRequest = Message<"taskguild.v1.ListTaskImagesRequest"> & {
+  /**
+   * @generated from field: string task_id = 1;
+   */
+  taskId: string;
+};
+
+/**
+ * Describes the message taskguild.v1.ListTaskImagesRequest.
+ * Use `create(ListTaskImagesRequestSchema)` to create a new message.
+ */
+export const ListTaskImagesRequestSchema: GenMessage<ListTaskImagesRequest> = /*@__PURE__*/
+  messageDesc(file_taskguild_v1_task, 30);
+
+/**
+ * @generated from message taskguild.v1.ListTaskImagesResponse
+ */
+export type ListTaskImagesResponse = Message<"taskguild.v1.ListTaskImagesResponse"> & {
+  /**
+   * @generated from field: repeated taskguild.v1.TaskImage images = 1;
+   */
+  images: TaskImage[];
+};
+
+/**
+ * Describes the message taskguild.v1.ListTaskImagesResponse.
+ * Use `create(ListTaskImagesResponseSchema)` to create a new message.
+ */
+export const ListTaskImagesResponseSchema: GenMessage<ListTaskImagesResponse> = /*@__PURE__*/
+  messageDesc(file_taskguild_v1_task, 31);
+
+/**
+ * @generated from message taskguild.v1.DeleteTaskImageRequest
+ */
+export type DeleteTaskImageRequest = Message<"taskguild.v1.DeleteTaskImageRequest"> & {
+  /**
+   * @generated from field: string task_id = 1;
+   */
+  taskId: string;
+
+  /**
+   * @generated from field: string image_id = 2;
+   */
+  imageId: string;
+};
+
+/**
+ * Describes the message taskguild.v1.DeleteTaskImageRequest.
+ * Use `create(DeleteTaskImageRequestSchema)` to create a new message.
+ */
+export const DeleteTaskImageRequestSchema: GenMessage<DeleteTaskImageRequest> = /*@__PURE__*/
+  messageDesc(file_taskguild_v1_task, 32);
+
+/**
+ * @generated from message taskguild.v1.DeleteTaskImageResponse
+ */
+export type DeleteTaskImageResponse = Message<"taskguild.v1.DeleteTaskImageResponse"> & {
+};
+
+/**
+ * Describes the message taskguild.v1.DeleteTaskImageResponse.
+ * Use `create(DeleteTaskImageResponseSchema)` to create a new message.
+ */
+export const DeleteTaskImageResponseSchema: GenMessage<DeleteTaskImageResponse> = /*@__PURE__*/
+  messageDesc(file_taskguild_v1_task, 33);
+
+/**
  * @generated from enum taskguild.v1.TaskAssignmentStatus
  */
 export enum TaskAssignmentStatus {
@@ -770,6 +969,40 @@ export const TaskService: GenService<{
     methodKind: "unary";
     input: typeof ListArchivedTasksRequestSchema;
     output: typeof ListArchivedTasksResponseSchema;
+  },
+  /**
+   * Task image operations
+   *
+   * @generated from rpc taskguild.v1.TaskService.UploadTaskImage
+   */
+  uploadTaskImage: {
+    methodKind: "unary";
+    input: typeof UploadTaskImageRequestSchema;
+    output: typeof UploadTaskImageResponseSchema;
+  },
+  /**
+   * @generated from rpc taskguild.v1.TaskService.GetTaskImage
+   */
+  getTaskImage: {
+    methodKind: "unary";
+    input: typeof GetTaskImageRequestSchema;
+    output: typeof GetTaskImageResponseSchema;
+  },
+  /**
+   * @generated from rpc taskguild.v1.TaskService.ListTaskImages
+   */
+  listTaskImages: {
+    methodKind: "unary";
+    input: typeof ListTaskImagesRequestSchema;
+    output: typeof ListTaskImagesResponseSchema;
+  },
+  /**
+   * @generated from rpc taskguild.v1.TaskService.DeleteTaskImage
+   */
+  deleteTaskImage: {
+    methodKind: "unary";
+    input: typeof DeleteTaskImageRequestSchema;
+    output: typeof DeleteTaskImageResponseSchema;
   },
 }> = /*@__PURE__*/
   serviceDesc(file_taskguild_v1_task, 0);

--- a/proto/gen/ts/taskguild/v1/workflow_pb.ts
+++ b/proto/gen/ts/taskguild/v1/workflow_pb.ts
@@ -214,7 +214,7 @@ export type WorkflowStatus = Message<"taskguild.v1.WorkflowStatus"> & {
   hooks: StatusHook[];
 
   /**
-   * harness: when true, a background agent reviews and updates AGENT.md
+   * harness: when true, a background agent reviews and updates agent markdown
    * with lessons learned upon status exit. Defaults to true when not set.
    *
    * @generated from field: bool enable_agent_md_harness = 9;

--- a/proto/taskguild/v1/task.proto
+++ b/proto/taskguild/v1/task.proto
@@ -29,6 +29,12 @@ service TaskService {
   rpc ArchiveTerminalTasks(ArchiveTerminalTasksRequest) returns (ArchiveTerminalTasksResponse);
   rpc UnarchiveTask(UnarchiveTaskRequest) returns (UnarchiveTaskResponse);
   rpc ListArchivedTasks(ListArchivedTasksRequest) returns (ListArchivedTasksResponse);
+
+  // Task image operations
+  rpc UploadTaskImage(UploadTaskImageRequest) returns (UploadTaskImageResponse);
+  rpc GetTaskImage(GetTaskImageRequest) returns (GetTaskImageResponse);
+  rpc ListTaskImages(ListTaskImagesRequest) returns (ListTaskImagesResponse);
+  rpc DeleteTaskImage(DeleteTaskImageRequest) returns (DeleteTaskImageResponse);
 }
 
 message Task {
@@ -186,3 +192,45 @@ message ListArchivedTasksResponse {
   repeated Task tasks = 1;
   PaginationResponse pagination = 2;
 }
+
+// Task image operations
+
+message TaskImage {
+  string id = 1;
+  string filename = 2;
+  string media_type = 3;
+  int64 size_bytes = 4;
+  google.protobuf.Timestamp created_at = 5;
+}
+
+message UploadTaskImageRequest {
+  string task_id = 1;
+  string filename = 2;
+  string media_type = 3;
+  bytes data = 4;
+}
+message UploadTaskImageResponse {
+  TaskImage image = 1;
+}
+
+message GetTaskImageRequest {
+  string task_id = 1;
+  string image_id = 2;
+}
+message GetTaskImageResponse {
+  TaskImage image = 1;
+  bytes data = 2;
+}
+
+message ListTaskImagesRequest {
+  string task_id = 1;
+}
+message ListTaskImagesResponse {
+  repeated TaskImage images = 1;
+}
+
+message DeleteTaskImageRequest {
+  string task_id = 1;
+  string image_id = 2;
+}
+message DeleteTaskImageResponse {}


### PR DESCRIPTION
## Summary
- Add `ImageBlock`/`ImageSource` types to `claude-agent-sdk-go` (v0.0.17) for base64-encoded image content blocks
- Add image CRUD RPCs (`UploadTaskImage`, `GetTaskImage`, `ListTaskImages`, `DeleteTaskImage`) to `TaskService` proto
- Implement `ImageStore` backed by the existing `Storage` interface (images stored as files in task directory)
- Update agent prompt builder to replace `[Image#N]` references with actual base64 image content blocks sent to Claude
- Add `ImageUploadTextarea` component with drag-and-drop, file picker, and image preview
- Integrate image upload into `TaskCreateModal`, `TaskDetailModal`, and `ChildTaskCreateModal`
- Render `[Image#N]` references as inline images in `MarkdownDescription`

## Test plan
- [ ] SDK tests pass (`cd claude-agent-sdk-go && go test ./...`)
- [ ] Go build passes (`go build ./...`)
- [ ] Go tests pass (`go test ./...`)
- [ ] Frontend build passes (`npx vite build`)
- [ ] Create a task, edit it, drag-and-drop an image → `[Image#1]` inserted, preview shown
- [ ] Create a task with images in the create modal → images uploaded after task creation
- [ ] View task detail page → `[Image#N]` rendered as inline images
- [ ] Run task with images → Claude receives image content blocks in prompt (check logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)