### PR TITLE
fix: skip status transitions at terminal statuses

### DIFF
--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -174,7 +174,7 @@ func runTask(
 		logger.Error("failed to build prompt with images, falling back to text-only", "error", err)
 		prompt = buildUserPrompt(metadata, workDir)
 	}
-	hasTransitions := metadata["_available_transitions"] != ""
+	hasTransitions := metadata["_available_transitions"] != "" && metadata["_available_transitions"] != "null"
 	logger.Info("task setup complete, entering turn loop", "has_session", sessionID != "", "has_transitions", hasTransitions)
 
 	const maxResumeRetries = 2 // after this many consecutive resume failures, start fresh

--- a/cmd/taskguild-agent/runner_test.go
+++ b/cmd/taskguild-agent/runner_test.go
@@ -201,37 +201,50 @@ func TestRunTask_AutoTransition_SingleTarget(t *testing.T) {
 
 // TestRunTask_TerminalStatus verifies that when the task is at a terminal
 // status (no transitions), it completes without attempting a transition.
+// The subtests cover both an empty string and "null" (what json.Marshal
+// produces for a nil Go slice) to guard against the bug where "null" was
+// treated as non-empty, causing hasTransitions to be incorrectly true.
 func TestRunTask_TerminalStatus(t *testing.T) {
-	tc := newTestClients()
-	defer tc.Close()
+	for _, tt := range []struct {
+		name        string
+		transitions string
+	}{
+		{"empty", ""},
+		{"null", "null"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := newTestClients()
+			defer tc.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
 
-	metadata := baseMetadata("Done", "")
+			metadata := baseMetadata("Done", tt.transitions)
 
-	qr := &mockQueryRunner{
-		results: []mockQueryRunnerResult{
-			{Result: makeResult("Task is complete.")},
-		},
+			qr := &mockQueryRunner{
+				results: []mockQueryRunnerResult{
+					{Result: makeResult("Task is complete.")},
+				},
+			}
+
+			permCache := newPermissionCache("test", tc.agentClient)
+			scpCache := newSingleCommandPermissionCache("test", tc.agentClient)
+
+			runTask(ctx, tc.agentClient, tc.taskClient, tc.interClient,
+				"agent-mgr-1", "task-terminal", "instructions", metadata,
+				t.TempDir(), permCache, scpCache, qr, func() bool { return false })
+
+			// No status transitions should have been attempted
+			tc.taskHandler.mu.Lock()
+			defer tc.taskHandler.mu.Unlock()
+			assert.Empty(t, tc.taskHandler.updateTaskStatusReqs, "no transitions expected at terminal status")
+
+			// But task result should have been reported
+			tc.agentHandler.mu.Lock()
+			defer tc.agentHandler.mu.Unlock()
+			assert.NotEmpty(t, tc.agentHandler.reportTaskResultReqs, "task result should be reported")
+		})
 	}
-
-	permCache := newPermissionCache("test", tc.agentClient)
-	scpCache := newSingleCommandPermissionCache("test", tc.agentClient)
-
-	runTask(ctx, tc.agentClient, tc.taskClient, tc.interClient,
-		"agent-mgr-1", "task-terminal", "instructions", metadata,
-		t.TempDir(), permCache, scpCache, qr, func() bool { return false })
-
-	// No status transitions should have been attempted
-	tc.taskHandler.mu.Lock()
-	defer tc.taskHandler.mu.Unlock()
-	assert.Empty(t, tc.taskHandler.updateTaskStatusReqs, "no transitions expected at terminal status")
-
-	// But task result should have been reported
-	tc.agentHandler.mu.Lock()
-	defer tc.agentHandler.mu.Unlock()
-	assert.NotEmpty(t, tc.agentHandler.reportTaskResultReqs, "task result should be reported")
 }
 
 // TestRunTask_CreateTask verifies that CREATE_TASK directives in agent output

--- a/internal/agentmanager/task_handler.go
+++ b/internal/agentmanager/task_handler.go
@@ -737,8 +737,10 @@ func (s *Server) ClaimTask(ctx context.Context, req *connect.Request[taskguildv1
 					Name: targetName,
 				})
 			}
-			if b, err := json.Marshal(transitions); err == nil {
-				enrichedMetadata["_available_transitions"] = string(b)
+			if len(transitions) > 0 {
+				if b, err := json.Marshal(transitions); err == nil {
+					enrichedMetadata["_available_transitions"] = string(b)
+				}
 			}
 			break
 		}


### PR DESCRIPTION
## Summary
- Fix infinite loop when an agent runs at a terminal status (e.g., Closed) triggered by user comments
- `task_handler.go`: Add `len(transitions) > 0` guard so `_available_transitions` metadata is only set when actual transitions exist (nil slice `json.Marshal` produced `"null"`, not `""`)
- `runner.go`: Add defensive check treating `"null"` as no-transitions for any existing tasks with stale metadata
- `runner_test.go`: Expand `TestRunTask_TerminalStatus` into table-driven test covering both `""` and `"null"` values

## Test plan
- [x] `go test ./cmd/taskguild-agent/... -run TestRunTask_TerminalStatus` — both subtests (empty, null) pass
- [x] `go test ./cmd/taskguild-agent/...` — all agent tests pass
- [x] `go test ./internal/agentmanager/...` — all agentmanager tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)