### PR TITLE
fix: pass taskId to DescriptionHistory for image rendering in previous versions

### DIFF
--- a/frontend/src/components/organisms/DescriptionHistory.tsx
+++ b/frontend/src/components/organisms/DescriptionHistory.tsx
@@ -7,10 +7,11 @@ interface DescriptionHistoryProps {
   /** Description RESULT logs sorted newest-first */
   versions: TaskLog[]
   currentDescription: string
+  taskId: string
   onClose: () => void
 }
 
-export function DescriptionHistory({ versions, currentDescription, onClose }: DescriptionHistoryProps) {
+export function DescriptionHistory({ versions, currentDescription, taskId, onClose }: DescriptionHistoryProps) {
   const [expandedId, setExpandedId] = useState<string | null>(null)
 
   return (
@@ -30,7 +31,7 @@ export function DescriptionHistory({ versions, currentDescription, onClose }: De
       {/* Current version */}
       <div className="border-l-2 border-cyan-500/30 pl-3 py-1">
         <span className="text-[10px] font-medium uppercase text-cyan-400">Current</span>
-        <MarkdownDescription content={currentDescription} className="text-sm text-gray-300 mt-1" />
+        <MarkdownDescription content={currentDescription} className="text-sm text-gray-300 mt-1" taskId={taskId} />
       </div>
 
       {/* Historical versions */}
@@ -57,7 +58,7 @@ export function DescriptionHistory({ versions, currentDescription, onClose }: De
               )}
             </button>
             {isExpanded && (
-              <MarkdownDescription content={fullText} className="text-sm text-gray-400 mt-1" />
+              <MarkdownDescription content={fullText} className="text-sm text-gray-400 mt-1" taskId={taskId} />
             )}
           </div>
         )

--- a/frontend/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/frontend/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -451,6 +451,7 @@ function TaskDetailPage() {
                 <DescriptionHistory
                   versions={descriptionLogs}
                   currentDescription={task.description}
+                  taskId={task.id}
                   onClose={() => setShowDescHistory(false)}
                 />
               ) : (


### PR DESCRIPTION
## Summary
- `DescriptionHistory` コンポーネントが `MarkdownDescription` に `taskId` を渡していなかったため、過去バージョンの説明文中の `[Image#N]` が画像として展開されずテキスト表示のままだった
- `DescriptionHistoryProps` に `taskId: string` を追加し、内部の2箇所の `MarkdownDescription` 呼び出しに伝播
- 呼び出し元の `$taskId.tsx` で `taskId={task.id}` を渡すように修正

## Test plan
- [ ] 画像を含むタスクの説明履歴を表示し、過去バージョンで `[Image#N]` が画像として展開されることを確認
- [ ] 現在バージョンの画像表示が引き続き正常であることを確認
- [ ] 画像がないタスクの説明履歴表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)