### PR TITLE
fix: Prevent duplicate interaction when exiting plan mode

### DIFF
--- a/cmd/taskguild-agent/interaction.go
+++ b/cmd/taskguild-agent/interaction.go
@@ -488,6 +488,13 @@ func handlePermissionRequest(
 		return claudeagent.PermissionResultAllow{}, nil
 	}
 
+	// Plan mode tools: ExitPlanMode approval is handled by PreToolUse hook,
+	// EnterPlanMode is a safe mode switch — both skip permission requests.
+	if toolName == "ExitPlanMode" || toolName == "EnterPlanMode" {
+		logger.Debug("auto-allowing plan mode tool", "tool", toolName)
+		return claudeagent.PermissionResultAllow{}, nil
+	}
+
 	// AskUserQuestion: present as QUESTION interactions instead of permission request
 	if toolName == "AskUserQuestion" {
 		return handleAskUserQuestion(ctx, client, taskID, agentID, input, waiter)


### PR DESCRIPTION
## Summary
- ExitPlanMode triggered two interactions: a plan approval (PreToolUse hook) and a redundant permission request (CanUseTool callback)
- Auto-allow `ExitPlanMode` and `EnterPlanMode` in `handlePermissionRequest` so only the PreToolUse hook's plan approval interaction runs
- `savePlanResult` in the PostToolUse hook continues to work unchanged

## Test plan
- [x] `go build ./cmd/taskguild-agent/` passes
- [x] `go test ./cmd/taskguild-agent/...` passes
- [ ] Manual: exit plan mode and verify only one approval interaction appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)