### PR TITLE
Convert Agent/Skill/Script edit forms to Modal dialogs

### DIFF
--- a/frontend/src/components/organisms/AgentFormModal.tsx
+++ b/frontend/src/components/organisms/AgentFormModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { X, Save } from 'lucide-react'
 import { Button, Input, Textarea, Select, Badge, MutationError } from '../atoms/index.ts'
-import { Card, FormField } from '../molecules/index.ts'
+import { Modal, FormField } from '../molecules/index.ts'
 import { AVAILABLE_TOOLS, MODEL_OPTIONS, PERMISSION_MODE_OPTIONS, MEMORY_OPTIONS } from '@/lib/constants.ts'
 import { toggleArrayItem } from '@/lib/arrays.ts'
 import type { AgentFormData } from './AgentListUtils.ts'
@@ -38,176 +38,173 @@ export function AgentFormModal({ formMode, form, setForm, onSubmit, onClose, isP
   }
 
   return (
-    <form onSubmit={onSubmit} className="mb-4 md:mb-6">
-      <Card className="md:p-5">
-        <div className="flex items-center justify-between mb-4">
-          <h3 className="text-lg font-semibold text-white">
-            {formMode === 'create' ? 'New Agent' : 'Edit Agent'}
-          </h3>
-          <button type="button" onClick={onClose} className="text-gray-500 hover:text-gray-300 transition-colors">
-            <X className="w-5 h-5" />
-          </button>
-        </div>
+    <Modal open={true} onClose={onClose} size="lg">
+      <Modal.Header onClose={onClose}>
+        <h3 className="text-lg font-semibold text-white">
+          {formMode === 'create' ? 'New Agent' : 'Edit Agent'}
+        </h3>
+      </Modal.Header>
+      <form onSubmit={onSubmit}>
+        <Modal.Body>
+          <div className="space-y-4">
+            {/* Name & Description row */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <FormField label="Name *" hint="Lowercase with hyphens. Used as filename in .claude/agents/">
+                <Input
+                  type="text"
+                  required
+                  value={form.name}
+                  onChange={e => setForm(prev => ({ ...prev, name: e.target.value }))}
+                  placeholder="e.g. code-reviewer"
+                />
+              </FormField>
+              <FormField label="Description *" hint="Claude uses this to decide when to delegate">
+                <Input
+                  type="text"
+                  required
+                  value={form.description}
+                  onChange={e => setForm(prev => ({ ...prev, description: e.target.value }))}
+                  placeholder="When to delegate to this agent"
+                />
+              </FormField>
+            </div>
 
-        <div className="space-y-4">
-          {/* Name & Description row */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <FormField label="Name *" hint="Lowercase with hyphens. Used as filename in .claude/agents/">
-              <Input
-                type="text"
+            {/* System Prompt */}
+            <FormField label="System Prompt *" hint="Body of the .md file. This becomes the agent's system prompt.">
+              <Textarea
                 required
-                value={form.name}
-                onChange={e => setForm(prev => ({ ...prev, name: e.target.value }))}
-                placeholder="e.g. code-reviewer"
+                value={form.prompt}
+                onChange={e => setForm(prev => ({ ...prev, prompt: e.target.value }))}
+                mono
+                placeholder="You are a code reviewer. Analyze code and provide specific, actionable feedback..."
               />
             </FormField>
-            <FormField label="Description *" hint="Claude uses this to decide when to delegate">
-              <Input
-                type="text"
-                required
-                value={form.description}
-                onChange={e => setForm(prev => ({ ...prev, description: e.target.value }))}
-                placeholder="When to delegate to this agent"
-              />
-            </FormField>
-          </div>
 
-          {/* System Prompt */}
-          <FormField label="System Prompt *" hint="Body of the .md file. This becomes the agent's system prompt.">
-            <Textarea
-              required
-              value={form.prompt}
-              onChange={e => setForm(prev => ({ ...prev, prompt: e.target.value }))}
-              mono
-              placeholder="You are a code reviewer. Analyze code and provide specific, actionable feedback..."
-            />
-          </FormField>
-
-          {/* Allowed Tools */}
-          <FormField label="Allowed Tools" hint="Leave empty to inherit all tools from parent">
-            <div className="flex flex-wrap gap-1.5">
-              {AVAILABLE_TOOLS.map(tool => (
-                <button
-                  key={tool}
-                  type="button"
-                  onClick={() => toggleTool(tool)}
-                  className={`px-2.5 py-1 text-xs rounded-lg transition-colors ${
-                    form.tools.includes(tool)
-                      ? 'bg-cyan-500/20 text-cyan-400 border border-cyan-500/30'
-                      : 'bg-slate-800 text-gray-500 border border-slate-700 hover:text-gray-300'
-                  }`}
-                >
-                  {tool}
-                </button>
-              ))}
-            </div>
-          </FormField>
-
-          {/* Disallowed Tools */}
-          <FormField label="Disallowed Tools" hint="Tools to deny, removed from inherited or specified list">
-            <div className="flex flex-wrap gap-1.5">
-              {AVAILABLE_TOOLS.map(tool => (
-                <button
-                  key={tool}
-                  type="button"
-                  onClick={() => toggleDisallowedTool(tool)}
-                  className={`px-2.5 py-1 text-xs rounded-lg transition-colors ${
-                    form.disallowedTools.includes(tool)
-                      ? 'bg-red-500/20 text-red-400 border border-red-500/30'
-                      : 'bg-slate-800 text-gray-500 border border-slate-700 hover:text-gray-300'
-                  }`}
-                >
-                  {tool}
-                </button>
-              ))}
-            </div>
-          </FormField>
-
-          {/* Model & Permission Mode row */}
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <FormField label="Model">
-              <Select
-                selectSize="xs"
-                value={form.model}
-                onChange={e => setForm(prev => ({ ...prev, model: e.target.value }))}
-                className="rounded"
-              >
-                {MODEL_OPTIONS.map(opt => (
-                  <option key={opt.value} value={opt.value}>{opt.label}</option>
-                ))}
-              </Select>
-            </FormField>
-            <FormField label="Permission Mode">
-              <Select
-                selectSize="xs"
-                value={form.permissionMode}
-                onChange={e => setForm(prev => ({ ...prev, permissionMode: e.target.value }))}
-                className="rounded"
-              >
-                {PERMISSION_MODE_OPTIONS.map(opt => (
-                  <option key={opt.value} value={opt.value}>{opt.label}</option>
-                ))}
-              </Select>
-            </FormField>
-            <FormField label="Memory">
-              <Select
-                selectSize="xs"
-                value={form.memory}
-                onChange={e => setForm(prev => ({ ...prev, memory: e.target.value }))}
-                className="rounded"
-              >
-                {MEMORY_OPTIONS.map(opt => (
-                  <option key={opt.value} value={opt.value}>{opt.label}</option>
-                ))}
-              </Select>
-            </FormField>
-          </div>
-
-          {/* Skills */}
-          <FormField label="Skills" hint="Skills to preload into the agent's context at startup">
-            <div className="flex gap-2">
-              <Input
-                inputSize="sm"
-                value={skillInput}
-                onChange={e => setSkillInput(e.target.value)}
-                onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addSkill() } }}
-                placeholder="e.g. api-conventions"
-                className="flex-1"
-              />
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={addSkill}
-                className="border border-slate-700 hover:border-slate-600"
-              >
-                Add
-              </Button>
-            </div>
-            {form.skills.length > 0 && (
-              <div className="flex flex-wrap gap-1.5 mt-2">
-                {form.skills.map(skill => (
-                  <Badge
-                    key={skill}
-                    color="purple"
-                    size="sm"
-                    variant="outline"
-                    className="border-purple-500/30 bg-purple-500/20"
+            {/* Allowed Tools */}
+            <FormField label="Allowed Tools" hint="Leave empty to inherit all tools from parent">
+              <div className="flex flex-wrap gap-1.5">
+                {AVAILABLE_TOOLS.map(tool => (
+                  <button
+                    key={tool}
+                    type="button"
+                    onClick={() => toggleTool(tool)}
+                    className={`px-2.5 py-1 text-xs rounded-lg transition-colors ${
+                      form.tools.includes(tool)
+                        ? 'bg-cyan-500/20 text-cyan-400 border border-cyan-500/30'
+                        : 'bg-slate-800 text-gray-500 border border-slate-700 hover:text-gray-300'
+                    }`}
                   >
-                    {skill}
-                    <button type="button" onClick={() => removeSkill(skill)} className="hover:text-purple-200">
-                      <X className="w-3 h-3" />
-                    </button>
-                  </Badge>
+                    {tool}
+                  </button>
                 ))}
               </div>
-            )}
-          </FormField>
-        </div>
+            </FormField>
 
-        <MutationError error={error} />
+            {/* Disallowed Tools */}
+            <FormField label="Disallowed Tools" hint="Tools to deny, removed from inherited or specified list">
+              <div className="flex flex-wrap gap-1.5">
+                {AVAILABLE_TOOLS.map(tool => (
+                  <button
+                    key={tool}
+                    type="button"
+                    onClick={() => toggleDisallowedTool(tool)}
+                    className={`px-2.5 py-1 text-xs rounded-lg transition-colors ${
+                      form.disallowedTools.includes(tool)
+                        ? 'bg-red-500/20 text-red-400 border border-red-500/30'
+                        : 'bg-slate-800 text-gray-500 border border-slate-700 hover:text-gray-300'
+                    }`}
+                  >
+                    {tool}
+                  </button>
+                ))}
+              </div>
+            </FormField>
 
-        <div className="flex justify-end gap-2 mt-4">
+            {/* Model & Permission Mode row */}
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <FormField label="Model">
+                <Select
+                  selectSize="xs"
+                  value={form.model}
+                  onChange={e => setForm(prev => ({ ...prev, model: e.target.value }))}
+                  className="rounded"
+                >
+                  {MODEL_OPTIONS.map(opt => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </Select>
+              </FormField>
+              <FormField label="Permission Mode">
+                <Select
+                  selectSize="xs"
+                  value={form.permissionMode}
+                  onChange={e => setForm(prev => ({ ...prev, permissionMode: e.target.value }))}
+                  className="rounded"
+                >
+                  {PERMISSION_MODE_OPTIONS.map(opt => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </Select>
+              </FormField>
+              <FormField label="Memory">
+                <Select
+                  selectSize="xs"
+                  value={form.memory}
+                  onChange={e => setForm(prev => ({ ...prev, memory: e.target.value }))}
+                  className="rounded"
+                >
+                  {MEMORY_OPTIONS.map(opt => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </Select>
+              </FormField>
+            </div>
+
+            {/* Skills */}
+            <FormField label="Skills" hint="Skills to preload into the agent's context at startup">
+              <div className="flex gap-2">
+                <Input
+                  inputSize="sm"
+                  value={skillInput}
+                  onChange={e => setSkillInput(e.target.value)}
+                  onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addSkill() } }}
+                  placeholder="e.g. api-conventions"
+                  className="flex-1"
+                />
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={addSkill}
+                  className="border border-slate-700 hover:border-slate-600"
+                >
+                  Add
+                </Button>
+              </div>
+              {form.skills.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 mt-2">
+                  {form.skills.map(skill => (
+                    <Badge
+                      key={skill}
+                      color="purple"
+                      size="sm"
+                      variant="outline"
+                      className="border-purple-500/30 bg-purple-500/20"
+                    >
+                      {skill}
+                      <button type="button" onClick={() => removeSkill(skill)} className="hover:text-purple-200">
+                        <X className="w-3 h-3" />
+                      </button>
+                    </Badge>
+                  ))}
+                </div>
+              )}
+            </FormField>
+          </div>
+
+          <MutationError error={error} />
+        </Modal.Body>
+        <Modal.Footer>
           <Button
             type="button"
             variant="secondary"
@@ -225,8 +222,8 @@ export function AgentFormModal({ formMode, form, setForm, onSubmit, onClose, isP
           >
             {isPending ? 'Saving...' : formMode === 'create' ? 'Create' : 'Save'}
           </Button>
-        </div>
-      </Card>
-    </form>
+        </Modal.Footer>
+      </form>
+    </Modal>
   )
 }

--- a/frontend/src/components/organisms/ScriptFormModal.tsx
+++ b/frontend/src/components/organisms/ScriptFormModal.tsx
@@ -1,0 +1,97 @@
+import { Save } from 'lucide-react'
+import { Button, Input, Textarea, MutationError } from '../atoms/index.ts'
+import { Modal, FormField } from '../molecules/index.ts'
+import type { ScriptFormData } from './ScriptListUtils.ts'
+
+export function ScriptFormModal({ formMode, form, setForm, onSubmit, onClose, isPending, error }: {
+  formMode: 'create' | 'edit'
+  form: ScriptFormData
+  setForm: React.Dispatch<React.SetStateAction<ScriptFormData>>
+  onSubmit: (e: React.FormEvent) => void
+  onClose: () => void
+  isPending: boolean
+  error?: Error | null
+}) {
+  return (
+    <Modal open={true} onClose={onClose} size="lg">
+      <Modal.Header onClose={onClose}>
+        <h3 className="text-lg font-semibold text-white">
+          {formMode === 'create' ? 'New Script' : 'Edit Script'}
+        </h3>
+      </Modal.Header>
+      <form onSubmit={onSubmit}>
+        <Modal.Body>
+          <div className="space-y-4">
+            {/* Name & Description row */}
+            <div className="grid grid-cols-2 gap-3">
+              <FormField label="Name *" hint="Script name (used as identifier)">
+                <Input
+                  type="text"
+                  required
+                  value={form.name}
+                  onChange={e => setForm(prev => ({ ...prev, name: e.target.value }))}
+                  className="focus:border-green-500"
+                  placeholder="e.g. deploy"
+                />
+              </FormField>
+              <FormField label="Description">
+                <Input
+                  type="text"
+                  value={form.description}
+                  onChange={e => setForm(prev => ({ ...prev, description: e.target.value }))}
+                  className="focus:border-green-500"
+                  placeholder="What this script does"
+                />
+              </FormField>
+            </div>
+
+            {/* Filename */}
+            <FormField label="Filename" hint="Defaults to name.sh if empty">
+              <Input
+                type="text"
+                value={form.filename}
+                onChange={e => setForm(prev => ({ ...prev, filename: e.target.value }))}
+                className="focus:border-green-500"
+                placeholder={form.name ? `${form.name}.sh` : 'e.g. deploy.sh'}
+              />
+            </FormField>
+
+            {/* Content */}
+            <FormField label="Script Content *" hint="Shell script to execute on the agent-manager machine.">
+              <Textarea
+                required
+                value={form.content}
+                onChange={e => setForm(prev => ({ ...prev, content: e.target.value }))}
+                mono
+                className="focus:border-green-500 min-h-[200px]"
+                placeholder={'#!/bin/bash\necho "Hello from script"'}
+              />
+            </FormField>
+          </div>
+
+          <MutationError error={error} />
+        </Modal.Body>
+        <Modal.Footer>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={onClose}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="primary"
+            size="sm"
+            disabled={isPending || !form.name || !form.content}
+            icon={<Save className="w-3.5 h-3.5" />}
+            className="bg-green-600 hover:bg-green-500"
+          >
+            {isPending ? 'Saving...' : formMode === 'create' ? 'Create' : 'Save'}
+          </Button>
+        </Modal.Footer>
+      </form>
+    </Modal>
+  )
+}

--- a/frontend/src/components/organisms/ScriptList.tsx
+++ b/frontend/src/components/organisms/ScriptList.tsx
@@ -17,13 +17,14 @@ import type { ScriptDiff } from '@taskguild/proto/taskguild/v1/agent_manager_pb.
 import { ScriptDiffType, ScriptResolutionChoice } from '@taskguild/proto/taskguild/v1/agent_manager_pb.ts'
 import type { Template } from '@taskguild/proto/taskguild/v1/template_pb.ts'
 import { EventType } from '@taskguild/proto/taskguild/v1/event_pb.ts'
-import { Terminal, Plus, Trash2, Edit2, X, Save, Cloud, Play, Square, CheckCircle, XCircle, StopCircle, Loader2, Layers, Copy, AlertTriangle, Server, Monitor } from 'lucide-react'
+import { Terminal, Plus, Trash2, Edit2, X, Cloud, Play, Square, CheckCircle, XCircle, StopCircle, Loader2, Layers, Copy, AlertTriangle, Server, Monitor } from 'lucide-react'
 import { useEventSubscription } from '@/hooks/useEventSubscription'
 import { useTemplateIntegration } from '@/hooks/useTemplateIntegration.ts'
-import { Button, Input, Textarea, Badge, MutationError } from '../atoms/index.ts'
-import { Card, FormField, Modal, PageHeading, EmptyState, SyncButton } from '../molecules/index.ts'
+import { Button, Badge, MutationError } from '../atoms/index.ts'
+import { Card, Modal, PageHeading, EmptyState, SyncButton } from '../molecules/index.ts'
 import { emptyForm, scriptToForm, diffTypeLabel } from './ScriptListUtils'
 import type { ScriptFormData } from './ScriptListUtils'
+import { ScriptFormModal } from './ScriptFormModal.tsx'
 import { LogOutput } from './LogOutput'
 import { useScriptExecution } from './useScriptExecution'
 import { SaveAsTemplateDialog } from './SaveAsTemplateDialog.tsx'
@@ -238,89 +239,17 @@ export function ScriptList({ projectId }: { projectId: string }) {
         </div>
       )}
 
-      {/* Script Form */}
+      {/* Script Form Modal */}
       {formMode && (
-        <form onSubmit={handleSubmit}>
-          <Card className="p-5 mb-6">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-white">
-                {formMode === 'create' ? 'New Script' : 'Edit Script'}
-              </h3>
-              <Button variant="ghost" size="sm" iconOnly onClick={closeForm} type="button" icon={<X className="w-5 h-5" />} />
-            </div>
-
-            <div className="space-y-4">
-              {/* Name & Description row */}
-              <div className="grid grid-cols-2 gap-3">
-                <FormField label="Name *" hint="Script name (used as identifier)">
-                  <Input
-                    type="text"
-                    required
-                    value={form.name}
-                    onChange={e => setForm(prev => ({ ...prev, name: e.target.value }))}
-                    className="focus:border-green-500"
-                    placeholder="e.g. deploy"
-                  />
-                </FormField>
-                <FormField label="Description">
-                  <Input
-                    type="text"
-                    value={form.description}
-                    onChange={e => setForm(prev => ({ ...prev, description: e.target.value }))}
-                    className="focus:border-green-500"
-                    placeholder="What this script does"
-                  />
-                </FormField>
-              </div>
-
-              {/* Filename */}
-              <FormField label="Filename" hint="Defaults to name.sh if empty">
-                <Input
-                  type="text"
-                  value={form.filename}
-                  onChange={e => setForm(prev => ({ ...prev, filename: e.target.value }))}
-                  className="focus:border-green-500"
-                  placeholder={form.name ? `${form.name}.sh` : 'e.g. deploy.sh'}
-                />
-              </FormField>
-
-              {/* Content */}
-              <FormField label="Script Content *" hint="Shell script to execute on the agent-manager machine.">
-                <Textarea
-                  required
-                  value={form.content}
-                  onChange={e => setForm(prev => ({ ...prev, content: e.target.value }))}
-                  mono
-                  className="focus:border-green-500 min-h-[200px]"
-                  placeholder={'#!/bin/bash\necho "Hello from script"'}
-                />
-              </FormField>
-            </div>
-
-            <MutationError error={mutation.error} />
-
-            <div className="flex justify-end gap-2 mt-4">
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={closeForm}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="submit"
-                variant="primary"
-                size="sm"
-                disabled={mutation.isPending || !form.name || !form.content}
-                icon={<Save className="w-3.5 h-3.5" />}
-                className="bg-green-600 hover:bg-green-500"
-              >
-                {mutation.isPending ? 'Saving...' : formMode === 'create' ? 'Create' : 'Save'}
-              </Button>
-            </div>
-          </Card>
-        </form>
+        <ScriptFormModal
+          formMode={formMode}
+          form={form}
+          setForm={setForm}
+          onSubmit={handleSubmit}
+          onClose={closeForm}
+          isPending={mutation.isPending}
+          error={mutation.error}
+        />
       )}
 
       {/* Script Cards */}

--- a/frontend/src/components/organisms/SkillFormModal.tsx
+++ b/frontend/src/components/organisms/SkillFormModal.tsx
@@ -1,0 +1,188 @@
+import { Save } from 'lucide-react'
+import { Button, Input, Textarea, Select, Checkbox, MutationError } from '../atoms/index.ts'
+import { Modal, FormField } from '../molecules/index.ts'
+import { AVAILABLE_TOOLS, MODEL_OPTIONS, CONTEXT_OPTIONS, AGENT_OPTIONS } from '@/lib/constants.ts'
+import { toggleArrayItem } from '@/lib/arrays.ts'
+import type { SkillFormData } from './SkillListUtils.ts'
+
+export function SkillFormModal({ formMode, form, setForm, onSubmit, onClose, isPending, error }: {
+  formMode: 'create' | 'edit'
+  form: SkillFormData
+  setForm: React.Dispatch<React.SetStateAction<SkillFormData>>
+  onSubmit: (e: React.FormEvent) => void
+  onClose: () => void
+  isPending: boolean
+  error?: Error | null
+}) {
+  const toggleAllowedTool = (tool: string) => {
+    setForm(prev => ({ ...prev, allowedTools: toggleArrayItem(prev.allowedTools, tool) }))
+  }
+
+  return (
+    <Modal open={true} onClose={onClose} size="lg">
+      <Modal.Header onClose={onClose}>
+        <h3 className="text-lg font-semibold text-white">
+          {formMode === 'create' ? 'New Skill' : 'Edit Skill'}
+        </h3>
+      </Modal.Header>
+      <form onSubmit={onSubmit}>
+        <Modal.Body>
+          <div className="space-y-4">
+            {/* Name & Description row */}
+            <div className="grid grid-cols-2 gap-3">
+              <FormField label="Name *" hint="Lowercase with hyphens. Used as directory name in .claude/skills/">
+                <Input
+                  type="text"
+                  required
+                  value={form.name}
+                  onChange={e => setForm(prev => ({ ...prev, name: e.target.value }))}
+                  className="focus:border-purple-500"
+                  placeholder="e.g. explain-code"
+                />
+              </FormField>
+              <FormField label="Description" hint="Claude uses this to decide when to load this skill">
+                <Input
+                  type="text"
+                  value={form.description}
+                  onChange={e => setForm(prev => ({ ...prev, description: e.target.value }))}
+                  className="focus:border-purple-500"
+                  placeholder="When to use this skill"
+                />
+              </FormField>
+            </div>
+
+            {/* Argument Hint */}
+            <FormField label="Argument Hint" hint="Hint shown in autocomplete for expected arguments">
+              <Input
+                type="text"
+                value={form.argumentHint}
+                onChange={e => setForm(prev => ({ ...prev, argumentHint: e.target.value }))}
+                className="focus:border-purple-500"
+                placeholder="e.g. [issue-number] or [filename] [format]"
+              />
+            </FormField>
+
+            {/* Content */}
+            <FormField label="Content *" hint="Body of the SKILL.md file. Instructions Claude follows when this skill is invoked.">
+              <Textarea
+                required
+                value={form.content}
+                onChange={e => setForm(prev => ({ ...prev, content: e.target.value }))}
+                mono
+                className="focus:border-purple-500 min-h-[150px]"
+                placeholder={"When explaining code, always include:\n1. Start with an analogy\n2. Draw a diagram using ASCII art\n3. Walk through the code step-by-step"}
+              />
+            </FormField>
+
+            {/* Invocation Control */}
+            <div>
+              <label className="block text-xs text-gray-400 mb-2">Invocation Control</label>
+              <div className="flex gap-6">
+                <Checkbox
+                  label="Disable model invocation"
+                  color="purple"
+                  checked={form.disableModelInvocation}
+                  onChange={e => setForm(prev => ({ ...prev, disableModelInvocation: e.target.checked }))}
+                />
+                <Checkbox
+                  label="User invocable"
+                  color="purple"
+                  checked={form.userInvocable}
+                  onChange={e => setForm(prev => ({ ...prev, userInvocable: e.target.checked }))}
+                />
+              </div>
+              <p className="text-[10px] text-gray-600 mt-1">
+                "Disable model invocation" prevents Claude from auto-loading. "User invocable" controls /slash-command visibility.
+              </p>
+            </div>
+
+            {/* Allowed Tools */}
+            <div>
+              <label className="block text-xs text-gray-400 mb-1">Allowed Tools</label>
+              <div className="flex flex-wrap gap-1.5">
+                {AVAILABLE_TOOLS.map(tool => (
+                  <button
+                    key={tool}
+                    type="button"
+                    onClick={() => toggleAllowedTool(tool)}
+                    className={`px-2.5 py-1 text-xs rounded-lg transition-colors ${
+                      form.allowedTools.includes(tool)
+                        ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
+                        : 'bg-slate-800 text-gray-500 border border-slate-700 hover:text-gray-300'
+                    }`}
+                  >
+                    {tool}
+                  </button>
+                ))}
+              </div>
+              <p className="text-[10px] text-gray-600 mt-1">Tools Claude can use without asking when this skill is active. Leave empty for default.</p>
+            </div>
+
+            {/* Model, Context & Agent row */}
+            <div className="grid grid-cols-3 gap-3">
+              <FormField label="Model">
+                <Select
+                  value={form.model}
+                  onChange={e => setForm(prev => ({ ...prev, model: e.target.value }))}
+                  selectSize="xs"
+                  className="rounded focus:border-purple-500"
+                >
+                  {MODEL_OPTIONS.map(opt => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </Select>
+              </FormField>
+              <FormField label="Context">
+                <Select
+                  value={form.context}
+                  onChange={e => setForm(prev => ({ ...prev, context: e.target.value }))}
+                  selectSize="xs"
+                  className="rounded focus:border-purple-500"
+                >
+                  {CONTEXT_OPTIONS.map(opt => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </Select>
+              </FormField>
+              <FormField label="Agent" hint='Only used when context is "fork"'>
+                <Select
+                  value={form.agent}
+                  onChange={e => setForm(prev => ({ ...prev, agent: e.target.value }))}
+                  disabled={form.context !== 'fork'}
+                  selectSize="xs"
+                  className="rounded focus:border-purple-500 disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  {AGENT_OPTIONS.map(opt => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </Select>
+              </FormField>
+            </div>
+          </div>
+
+          <MutationError error={error} />
+        </Modal.Body>
+        <Modal.Footer>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={onClose}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="primary"
+            size="sm"
+            disabled={isPending || !form.name || !form.content}
+            icon={<Save className="w-3.5 h-3.5" />}
+            className="bg-purple-600 hover:bg-purple-500"
+          >
+            {isPending ? 'Saving...' : formMode === 'create' ? 'Create' : 'Save'}
+          </Button>
+        </Modal.Footer>
+      </form>
+    </Modal>
+  )
+}

--- a/frontend/src/components/organisms/SkillList.tsx
+++ b/frontend/src/components/organisms/SkillList.tsx
@@ -3,56 +3,15 @@ import { useQuery, useMutation } from '@connectrpc/connect-query'
 import { listSkills, createSkill, updateSkill, deleteSkill, syncSkillsFromDir } from '@taskguild/proto/taskguild/v1/skill-SkillService_connectquery.ts'
 import type { SkillDefinition } from '@taskguild/proto/taskguild/v1/skill_pb.ts'
 import type { Template } from '@taskguild/proto/taskguild/v1/template_pb.ts'
-import { Sparkles, Plus, Trash2, Edit2, X, Save, Cloud, Layers, Copy } from 'lucide-react'
-import { Button } from '../atoms/index.ts'
-import { Input, Textarea, Select, Checkbox, Badge, MutationError } from '../atoms/index.ts'
-import { Card, FormField, PageHeading, EmptyState, SyncButton } from '../molecules/index.ts'
-import { AVAILABLE_TOOLS, MODEL_OPTIONS, CONTEXT_OPTIONS, AGENT_OPTIONS } from '@/lib/constants.ts'
-import { toggleArrayItem } from '@/lib/arrays.ts'
+import { Sparkles, Plus, Trash2, Edit2, Cloud, Layers, Copy } from 'lucide-react'
+import { Button, Badge } from '../atoms/index.ts'
+import { Card, PageHeading, EmptyState, SyncButton } from '../molecules/index.ts'
 import { useTemplateIntegration } from '@/hooks/useTemplateIntegration.ts'
 import { SaveAsTemplateDialog } from './SaveAsTemplateDialog.tsx'
 import { TemplatePickerDialog } from './TemplatePickerDialog.tsx'
-
-interface SkillFormData {
-  name: string
-  description: string
-  content: string
-  disableModelInvocation: boolean
-  userInvocable: boolean
-  allowedTools: string[]
-  model: string
-  context: string
-  agent: string
-  argumentHint: string
-}
-
-const emptyForm: SkillFormData = {
-  name: '',
-  description: '',
-  content: '',
-  disableModelInvocation: false,
-  userInvocable: true,
-  allowedTools: [],
-  model: '',
-  context: '',
-  agent: '',
-  argumentHint: '',
-}
-
-function skillToForm(s: SkillDefinition): SkillFormData {
-  return {
-    name: s.name,
-    description: s.description,
-    content: s.content,
-    disableModelInvocation: s.disableModelInvocation,
-    userInvocable: s.userInvocable,
-    allowedTools: [...(s.allowedTools ?? [])],
-    model: s.model,
-    context: s.context,
-    agent: s.agent,
-    argumentHint: s.argumentHint,
-  }
-}
+import { SkillFormModal } from './SkillFormModal.tsx'
+import { emptyForm, skillToForm } from './SkillListUtils.ts'
+import type { SkillFormData } from './SkillListUtils.ts'
 
 export function SkillList({ projectId }: { projectId: string }) {
   const { data, refetch, isLoading } = useQuery(listSkills, { projectId })
@@ -133,10 +92,6 @@ export function SkillList({ projectId }: { projectId: string }) {
     )
   }
 
-  const toggleAllowedTool = (tool: string) => {
-    setForm(prev => ({ ...prev, allowedTools: toggleArrayItem(prev.allowedTools, tool) }))
-  }
-
   const mutation = formMode === 'create' ? createMut : updateMut
 
   return (
@@ -181,174 +136,17 @@ export function SkillList({ projectId }: { projectId: string }) {
         </div>
       )}
 
-      {/* Skill Form */}
+      {/* Skill Form Modal */}
       {formMode && (
-        <form onSubmit={handleSubmit}>
-          <Card className="p-5 mb-6">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-white">
-                {formMode === 'create' ? 'New Skill' : 'Edit Skill'}
-              </h3>
-              <Button variant="ghost" size="sm" iconOnly onClick={closeForm} type="button" icon={<X className="w-5 h-5" />} />
-            </div>
-
-            <div className="space-y-4">
-              {/* Name & Description row */}
-              <div className="grid grid-cols-2 gap-3">
-                <FormField label="Name *" hint="Lowercase with hyphens. Used as directory name in .claude/skills/">
-                  <Input
-                    type="text"
-                    required
-                    value={form.name}
-                    onChange={e => setForm(prev => ({ ...prev, name: e.target.value }))}
-                    className="focus:border-purple-500"
-                    placeholder="e.g. explain-code"
-                  />
-                </FormField>
-                <FormField label="Description" hint="Claude uses this to decide when to load this skill">
-                  <Input
-                    type="text"
-                    value={form.description}
-                    onChange={e => setForm(prev => ({ ...prev, description: e.target.value }))}
-                    className="focus:border-purple-500"
-                    placeholder="When to use this skill"
-                  />
-                </FormField>
-              </div>
-
-              {/* Argument Hint */}
-              <FormField label="Argument Hint" hint="Hint shown in autocomplete for expected arguments">
-                <Input
-                  type="text"
-                  value={form.argumentHint}
-                  onChange={e => setForm(prev => ({ ...prev, argumentHint: e.target.value }))}
-                  className="focus:border-purple-500"
-                  placeholder="e.g. [issue-number] or [filename] [format]"
-                />
-              </FormField>
-
-              {/* Content */}
-              <FormField label="Content *" hint="Body of the SKILL.md file. Instructions Claude follows when this skill is invoked.">
-                <Textarea
-                  required
-                  value={form.content}
-                  onChange={e => setForm(prev => ({ ...prev, content: e.target.value }))}
-                  mono
-                  className="focus:border-purple-500 min-h-[150px]"
-                  placeholder={"When explaining code, always include:\n1. Start with an analogy\n2. Draw a diagram using ASCII art\n3. Walk through the code step-by-step"}
-                />
-              </FormField>
-
-              {/* Invocation Control */}
-              <div>
-                <label className="block text-xs text-gray-400 mb-2">Invocation Control</label>
-                <div className="flex gap-6">
-                  <Checkbox
-                    label="Disable model invocation"
-                    color="purple"
-                    checked={form.disableModelInvocation}
-                    onChange={e => setForm(prev => ({ ...prev, disableModelInvocation: e.target.checked }))}
-                  />
-                  <Checkbox
-                    label="User invocable"
-                    color="purple"
-                    checked={form.userInvocable}
-                    onChange={e => setForm(prev => ({ ...prev, userInvocable: e.target.checked }))}
-                  />
-                </div>
-                <p className="text-[10px] text-gray-600 mt-1">
-                  "Disable model invocation" prevents Claude from auto-loading. "User invocable" controls /slash-command visibility.
-                </p>
-              </div>
-
-              {/* Allowed Tools */}
-              <div>
-                <label className="block text-xs text-gray-400 mb-1">Allowed Tools</label>
-                <div className="flex flex-wrap gap-1.5">
-                  {AVAILABLE_TOOLS.map(tool => (
-                    <button
-                      key={tool}
-                      type="button"
-                      onClick={() => toggleAllowedTool(tool)}
-                      className={`px-2.5 py-1 text-xs rounded-lg transition-colors ${
-                        form.allowedTools.includes(tool)
-                          ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
-                          : 'bg-slate-800 text-gray-500 border border-slate-700 hover:text-gray-300'
-                      }`}
-                    >
-                      {tool}
-                    </button>
-                  ))}
-                </div>
-                <p className="text-[10px] text-gray-600 mt-1">Tools Claude can use without asking when this skill is active. Leave empty for default.</p>
-              </div>
-
-              {/* Model, Context & Agent row */}
-              <div className="grid grid-cols-3 gap-3">
-                <FormField label="Model">
-                  <Select
-                    value={form.model}
-                    onChange={e => setForm(prev => ({ ...prev, model: e.target.value }))}
-                    selectSize="xs"
-                    className="rounded focus:border-purple-500"
-                  >
-                    {MODEL_OPTIONS.map(opt => (
-                      <option key={opt.value} value={opt.value}>{opt.label}</option>
-                    ))}
-                  </Select>
-                </FormField>
-                <FormField label="Context">
-                  <Select
-                    value={form.context}
-                    onChange={e => setForm(prev => ({ ...prev, context: e.target.value }))}
-                    selectSize="xs"
-                    className="rounded focus:border-purple-500"
-                  >
-                    {CONTEXT_OPTIONS.map(opt => (
-                      <option key={opt.value} value={opt.value}>{opt.label}</option>
-                    ))}
-                  </Select>
-                </FormField>
-                <FormField label="Agent" hint='Only used when context is "fork"'>
-                  <Select
-                    value={form.agent}
-                    onChange={e => setForm(prev => ({ ...prev, agent: e.target.value }))}
-                    disabled={form.context !== 'fork'}
-                    selectSize="xs"
-                    className="rounded focus:border-purple-500 disabled:opacity-40 disabled:cursor-not-allowed"
-                  >
-                    {AGENT_OPTIONS.map(opt => (
-                      <option key={opt.value} value={opt.value}>{opt.label}</option>
-                    ))}
-                  </Select>
-                </FormField>
-              </div>
-            </div>
-
-            <MutationError error={mutation.error} />
-
-            <div className="flex justify-end gap-2 mt-4">
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={closeForm}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="submit"
-                variant="primary"
-                size="sm"
-                disabled={mutation.isPending || !form.name || !form.content}
-                icon={<Save className="w-3.5 h-3.5" />}
-                className="bg-purple-600 hover:bg-purple-500"
-              >
-                {mutation.isPending ? 'Saving...' : formMode === 'create' ? 'Create' : 'Save'}
-              </Button>
-            </div>
-          </Card>
-        </form>
+        <SkillFormModal
+          formMode={formMode}
+          form={form}
+          setForm={setForm}
+          onSubmit={handleSubmit}
+          onClose={closeForm}
+          isPending={mutation.isPending}
+          error={mutation.error}
+        />
       )}
 
       {/* Skill Cards */}

--- a/frontend/src/components/organisms/SkillListUtils.ts
+++ b/frontend/src/components/organisms/SkillListUtils.ts
@@ -1,0 +1,42 @@
+import type { SkillDefinition } from '@taskguild/proto/taskguild/v1/skill_pb.ts'
+
+export interface SkillFormData {
+  name: string
+  description: string
+  content: string
+  disableModelInvocation: boolean
+  userInvocable: boolean
+  allowedTools: string[]
+  model: string
+  context: string
+  agent: string
+  argumentHint: string
+}
+
+export const emptyForm: SkillFormData = {
+  name: '',
+  description: '',
+  content: '',
+  disableModelInvocation: false,
+  userInvocable: true,
+  allowedTools: [],
+  model: '',
+  context: '',
+  agent: '',
+  argumentHint: '',
+}
+
+export function skillToForm(s: SkillDefinition): SkillFormData {
+  return {
+    name: s.name,
+    description: s.description,
+    content: s.content,
+    disableModelInvocation: s.disableModelInvocation,
+    userInvocable: s.userInvocable,
+    allowedTools: [...(s.allowedTools ?? [])],
+    model: s.model,
+    context: s.context,
+    agent: s.agent,
+    argumentHint: s.argumentHint,
+  }
+}


### PR DESCRIPTION
## Summary
- Replace inline Card-based create/edit forms with proper Modal dialogs for Agents, Skills, and Scripts
- Matches the existing Task creation modal pattern (`Modal` + `Modal.Header` / `Modal.Body` / `Modal.Footer`) for consistent UX
- Extract `SkillFormModal` and `ScriptFormModal` as new components; convert existing `AgentFormModal` from Card to Modal
- Extract `SkillListUtils.ts` with `SkillFormData` type and helpers (`emptyForm`, `skillToForm`)
- Clean up unused imports in `SkillList.tsx` and `ScriptList.tsx`

## Test plan
- [ ] Agents page: New / Edit opens modal; Cancel / Escape / backdrop click closes it; Save persists
- [ ] Skills page: New / Edit opens modal; Cancel / Escape / backdrop click closes it; Save persists
- [ ] Scripts page: New / Edit opens modal; Cancel / Escape / backdrop click closes it; Save persists
- [ ] Template-based creation opens modal with pre-filled data
- [ ] Agent page: browser back closes modal (URL param state preserved)
- [ ] `cd frontend && npm run build` succeeds without new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)