### PR TITLE
fix: sync agent/skill/script changes and deletions to taskguild-agent

### DIFF
--- a/cmd/taskguild-agent/sync.go
+++ b/cmd/taskguild-agent/sync.go
@@ -78,7 +78,7 @@ func syncAgents(ctx context.Context, client taskguildv1connect.AgentManagerServi
 		slog.Debug("synced agent", "filename", filename)
 	}
 
-	cleanupStaleAgentFiles(agentsDir, serverFiles, forceAll)
+	cleanupStaleAgentFiles(agentsDir, serverFiles)
 }
 
 // buildAgentMDContent generates markdown content with YAML frontmatter
@@ -146,8 +146,7 @@ func writeYAMLStringField(sb *strings.Builder, key, value string) {
 
 // cleanupStaleAgentFiles removes .md files from the agents directory
 // that were not found on the server during the current sync.
-// When forceAll is false, local-only files are preserved.
-func cleanupStaleAgentFiles(agentsDir string, serverFiles map[string]bool, forceAll bool) {
+func cleanupStaleAgentFiles(agentsDir string, serverFiles map[string]bool) {
 	entries, err := os.ReadDir(agentsDir)
 	if err != nil {
 		return
@@ -159,14 +158,10 @@ func cleanupStaleAgentFiles(agentsDir string, serverFiles map[string]bool, force
 		}
 		if !serverFiles[entry.Name()] {
 			filePath := filepath.Join(agentsDir, entry.Name())
-			if !forceAll {
-				slog.Debug("preserving locally-modified agent file not found on server", "filename", entry.Name())
-				continue
-			}
 			if err := os.Remove(filePath); err != nil {
 				slog.Error("failed to remove stale agent file", "path", filePath, "error", err)
 			} else {
-				slog.Debug("removed stale agent", "filename", entry.Name())
+				slog.Info("removed stale agent file", "filename", entry.Name())
 			}
 		}
 	}

--- a/cmd/taskguild-agent/sync_scripts.go
+++ b/cmd/taskguild-agent/sync_scripts.go
@@ -40,6 +40,8 @@ func syncScripts(ctx context.Context, client taskguildv1connect.AgentManagerServ
 		return
 	}
 
+	// serverFiles tracks filenames known to the server.
+	serverFiles := make(map[string]bool)
 	var written, skipped int
 	for _, sc := range scripts {
 		filename := sc.GetFilename()
@@ -53,6 +55,7 @@ func syncScripts(ctx context.Context, client taskguildv1connect.AgentManagerServ
 			continue
 		}
 
+		serverFiles[filename] = true
 		filePath := filepath.Join(scriptsDir, filename)
 
 		// Check if the file already exists.
@@ -75,5 +78,29 @@ func syncScripts(ctx context.Context, client taskguildv1connect.AgentManagerServ
 		written++
 	}
 
+	cleanupStaleScriptFiles(scriptsDir, serverFiles)
 	slog.Info("script sync complete", "written", written, "skipped_existing", skipped)
+}
+
+// cleanupStaleScriptFiles removes script files from the scripts directory
+// that were not found on the server during the current sync.
+func cleanupStaleScriptFiles(scriptsDir string, serverFiles map[string]bool) {
+	entries, err := os.ReadDir(scriptsDir)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if !serverFiles[entry.Name()] {
+			filePath := filepath.Join(scriptsDir, entry.Name())
+			if err := os.Remove(filePath); err != nil {
+				slog.Error("failed to remove stale script file", "path", filePath, "error", err)
+			} else {
+				slog.Info("removed stale script file", "filename", entry.Name())
+			}
+		}
+	}
 }

--- a/cmd/taskguild-agent/sync_skills.go
+++ b/cmd/taskguild-agent/sync_skills.go
@@ -41,6 +41,8 @@ func syncSkills(ctx context.Context, client taskguildv1connect.AgentManagerServi
 		return
 	}
 
+	// serverSkillNames tracks skill directory names known to the server.
+	serverSkillNames := make(map[string]bool)
 	var written, skipped int
 	for _, sk := range skills {
 		name := sk.GetName()
@@ -55,6 +57,7 @@ func syncSkills(ctx context.Context, client taskguildv1connect.AgentManagerServi
 			continue
 		}
 
+		serverSkillNames[name] = true
 		skillDir := filepath.Join(skillsDir, name)
 		filePath := filepath.Join(skillDir, "SKILL.md")
 
@@ -85,6 +88,7 @@ func syncSkills(ctx context.Context, client taskguildv1connect.AgentManagerServi
 		written++
 	}
 
+	cleanupStaleSkillDirs(skillsDir, serverSkillNames)
 	slog.Info("skill sync complete", "written", written, "skipped_existing", skipped)
 }
 
@@ -135,4 +139,27 @@ func buildSkillMDContent(sk *v1.SkillDefinition) string {
 	}
 
 	return sb.String()
+}
+
+// cleanupStaleSkillDirs removes skill subdirectories from the skills directory
+// that were not found on the server during the current sync.
+func cleanupStaleSkillDirs(skillsDir string, serverSkillNames map[string]bool) {
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if !serverSkillNames[entry.Name()] {
+			dirPath := filepath.Join(skillsDir, entry.Name())
+			if err := os.RemoveAll(dirPath); err != nil {
+				slog.Error("failed to remove stale skill directory", "path", dirPath, "error", err)
+			} else {
+				slog.Info("removed stale skill directory", "name", entry.Name())
+			}
+		}
+	}
 }

--- a/cmd/taskguild-server/run.go
+++ b/cmd/taskguild-server/run.go
@@ -61,7 +61,7 @@ type agentChangeNotifier struct {
 	projectRepo project.Repository
 }
 
-func (n *agentChangeNotifier) NotifyAgentChange(projectID string) {
+func (n *agentChangeNotifier) NotifyAgentChange(projectID string, changedAgentNames []string) {
 	p, err := n.projectRepo.Get(context.Background(), projectID)
 	if err != nil {
 		slog.Error("failed to look up project for agent change notification", "project_id", projectID, "error", err)
@@ -69,7 +69,9 @@ func (n *agentChangeNotifier) NotifyAgentChange(projectID string) {
 	}
 	n.registry.BroadcastCommandToProject(p.Name, &taskguildv1.AgentCommand{
 		Command: &taskguildv1.AgentCommand_SyncAgents{
-			SyncAgents: &taskguildv1.SyncAgentsCommand{},
+			SyncAgents: &taskguildv1.SyncAgentsCommand{
+				ForceOverwriteAgentNames: changedAgentNames,
+			},
 		},
 	})
 }
@@ -122,6 +124,28 @@ type skillChangeNotifier struct {
 	projectRepo project.Repository
 }
 
+// scriptChangeNotifier implements script.ChangeNotifier by broadcasting
+// a SyncScriptsCommand to connected agents in the same project.
+type scriptChangeNotifier struct {
+	registry    *agentmanager.Registry
+	projectRepo project.Repository
+}
+
+func (n *scriptChangeNotifier) NotifyScriptChange(projectID string, changedScriptIDs []string) {
+	p, err := n.projectRepo.Get(context.Background(), projectID)
+	if err != nil {
+		slog.Error("failed to look up project for script change notification", "project_id", projectID, "error", err)
+		return
+	}
+	n.registry.BroadcastCommandToProject(p.Name, &taskguildv1.AgentCommand{
+		Command: &taskguildv1.AgentCommand_SyncScripts{
+			SyncScripts: &taskguildv1.SyncScriptsCommand{
+				ForceOverwriteScriptIds: changedScriptIDs,
+			},
+		},
+	})
+}
+
 // claudeSettingsChangeNotifier implements claudesettings.ChangeNotifier by broadcasting
 // a SyncClaudeSettingsCommand to connected agents in the same project.
 type claudeSettingsChangeNotifier struct {
@@ -142,7 +166,7 @@ func (n *claudeSettingsChangeNotifier) NotifyClaudeSettingsChange(projectID stri
 	})
 }
 
-func (n *skillChangeNotifier) NotifySkillChange(projectID string) {
+func (n *skillChangeNotifier) NotifySkillChange(projectID string, changedSkillIDs []string) {
 	p, err := n.projectRepo.Get(context.Background(), projectID)
 	if err != nil {
 		slog.Error("failed to look up project for skill change notification", "project_id", projectID, "error", err)
@@ -150,7 +174,9 @@ func (n *skillChangeNotifier) NotifySkillChange(projectID string) {
 	}
 	n.registry.BroadcastCommandToProject(p.Name, &taskguildv1.AgentCommand{
 		Command: &taskguildv1.AgentCommand_SyncSkills{
-			SyncSkills: &taskguildv1.SyncSkillsCommand{},
+			SyncSkills: &taskguildv1.SyncSkillsCommand{
+				ForceOverwriteSkillIds: changedSkillIDs,
+			},
 		},
 	})
 }
@@ -259,7 +285,11 @@ func runServer() {
 		projectRepo: projectRepo,
 	}
 	skillServer := skill.NewServer(skillRepo, skillChangeNotifier, wdResolver)
-	scriptServer := script.NewServer(scriptRepo, agentManagerServer, scriptBroker, wdResolver)
+	scriptChangeNotifier := &scriptChangeNotifier{
+		registry:    agentManagerRegistry,
+		projectRepo: projectRepo,
+	}
+	scriptServer := script.NewServer(scriptRepo, agentManagerServer, scriptBroker, wdResolver, scriptChangeNotifier)
 	taskLogServer := tasklog.NewServer(taskLogRepo, taskRepo)
 	eventServer := event.NewServer(bus)
 	permissionChangeNotifier := &permissionChangeNotifier{

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -21,8 +21,10 @@ var _ taskguildv1connect.AgentServiceHandler = (*Server)(nil)
 
 // ChangeNotifier is called after agent CRUD operations to notify connected
 // agents that they should re-sync their local agent definitions.
+// changedAgentNames lists agents that were created or updated and should be
+// force-overwritten on the agent side even if a local file already exists.
 type ChangeNotifier interface {
-	NotifyAgentChange(projectID string)
+	NotifyAgentChange(projectID string, changedAgentNames []string)
 }
 
 // WorkDirResolver resolves the absolute working directory for a project
@@ -41,9 +43,9 @@ func NewServer(repo Repository, notifier ChangeNotifier, resolver WorkDirResolve
 	return &Server{repo: repo, notifier: notifier, resolver: resolver}
 }
 
-func (s *Server) notifyChange(projectID string) {
+func (s *Server) notifyChange(projectID string, changedAgentNames []string) {
 	if s.notifier != nil {
-		s.notifier.NotifyAgentChange(projectID)
+		s.notifier.NotifyAgentChange(projectID, changedAgentNames)
 	}
 }
 
@@ -68,7 +70,7 @@ func (s *Server) CreateAgent(ctx context.Context, req *connect.Request[taskguild
 	if err := s.repo.Create(ctx, a); err != nil {
 		return nil, err
 	}
-	s.notifyChange(a.ProjectID)
+	s.notifyChange(a.ProjectID, []string{a.Name})
 	return connect.NewResponse(&taskguildv1.CreateAgentResponse{
 		Agent: toProto(a),
 	}), nil
@@ -146,7 +148,7 @@ func (s *Server) UpdateAgent(ctx context.Context, req *connect.Request[taskguild
 	if err := s.repo.Update(ctx, a); err != nil {
 		return nil, err
 	}
-	s.notifyChange(a.ProjectID)
+	s.notifyChange(a.ProjectID, []string{a.Name})
 	return connect.NewResponse(&taskguildv1.UpdateAgentResponse{
 		Agent: toProto(a),
 	}), nil
@@ -161,7 +163,7 @@ func (s *Server) DeleteAgent(ctx context.Context, req *connect.Request[taskguild
 	if err := s.repo.Delete(ctx, req.Msg.Id); err != nil {
 		return nil, err
 	}
-	s.notifyChange(a.ProjectID)
+	s.notifyChange(a.ProjectID, nil)
 	return connect.NewResponse(&taskguildv1.DeleteAgentResponse{}), nil
 }
 
@@ -252,7 +254,7 @@ func (s *Server) SyncAgentsFromDir(ctx context.Context, req *connect.Request[tas
 	}
 
 	if created > 0 || updated > 0 {
-		s.notifyChange(req.Msg.ProjectId)
+		s.notifyChange(req.Msg.ProjectId, nil)
 	}
 
 	return connect.NewResponse(&taskguildv1.SyncAgentsFromDirResponse{

--- a/internal/script/server.go
+++ b/internal/script/server.go
@@ -29,6 +29,14 @@ type ExecutionRequester interface {
 	RequestScriptStop(projectID string, requestID string) error
 }
 
+// ChangeNotifier is called after script CRUD operations to notify connected
+// agents that they should re-sync their local script files.
+// changedScriptIDs lists scripts that were created or updated and should be
+// force-overwritten on the agent side even if a local file already exists.
+type ChangeNotifier interface {
+	NotifyScriptChange(projectID string, changedScriptIDs []string)
+}
+
 // WorkDirResolver resolves the absolute working directory for a project
 // by looking up the connected agent's work_dir.
 type WorkDirResolver interface {
@@ -40,10 +48,17 @@ type Server struct {
 	execReq  ExecutionRequester
 	broker   *ScriptExecutionBroker
 	resolver WorkDirResolver
+	notifier ChangeNotifier
 }
 
-func NewServer(repo Repository, execReq ExecutionRequester, broker *ScriptExecutionBroker, resolver WorkDirResolver) *Server {
-	return &Server{repo: repo, execReq: execReq, broker: broker, resolver: resolver}
+func NewServer(repo Repository, execReq ExecutionRequester, broker *ScriptExecutionBroker, resolver WorkDirResolver, notifier ChangeNotifier) *Server {
+	return &Server{repo: repo, execReq: execReq, broker: broker, resolver: resolver, notifier: notifier}
+}
+
+func (s *Server) notifyChange(projectID string, changedScriptIDs []string) {
+	if s.notifier != nil {
+		s.notifier.NotifyScriptChange(projectID, changedScriptIDs)
+	}
 }
 
 func (s *Server) CreateScript(ctx context.Context, req *connect.Request[taskguildv1.CreateScriptRequest]) (*connect.Response[taskguildv1.CreateScriptResponse], error) {
@@ -66,6 +81,7 @@ func (s *Server) CreateScript(ctx context.Context, req *connect.Request[taskguil
 	if err := s.repo.Create(ctx, sc); err != nil {
 		return nil, err
 	}
+	s.notifyChange(sc.ProjectID, []string{sc.ID})
 	return connect.NewResponse(&taskguildv1.CreateScriptResponse{
 		Script: toProto(sc),
 	}), nil
@@ -128,18 +144,21 @@ func (s *Server) UpdateScript(ctx context.Context, req *connect.Request[taskguil
 	if err := s.repo.Update(ctx, sc); err != nil {
 		return nil, err
 	}
+	s.notifyChange(sc.ProjectID, []string{sc.ID})
 	return connect.NewResponse(&taskguildv1.UpdateScriptResponse{
 		Script: toProto(sc),
 	}), nil
 }
 
 func (s *Server) DeleteScript(ctx context.Context, req *connect.Request[taskguildv1.DeleteScriptRequest]) (*connect.Response[taskguildv1.DeleteScriptResponse], error) {
-	if _, err := s.repo.Get(ctx, req.Msg.Id); err != nil {
+	sc, err := s.repo.Get(ctx, req.Msg.Id)
+	if err != nil {
 		return nil, err
 	}
 	if err := s.repo.Delete(ctx, req.Msg.Id); err != nil {
 		return nil, err
 	}
+	s.notifyChange(sc.ProjectID, nil)
 	return connect.NewResponse(&taskguildv1.DeleteScriptResponse{}), nil
 }
 

--- a/internal/script/server_test.go
+++ b/internal/script/server_test.go
@@ -136,7 +136,7 @@ func newTestServer() (*Server, *fakeRepository, *fakeExecutionRequester, *Script
 	repo := newFakeRepository()
 	execReq := &fakeExecutionRequester{}
 	broker := NewScriptExecutionBroker()
-	srv := NewServer(repo, execReq, broker, nil)
+	srv := NewServer(repo, execReq, broker, nil, nil)
 	return srv, repo, execReq, broker
 }
 

--- a/internal/skill/server.go
+++ b/internal/skill/server.go
@@ -21,8 +21,10 @@ var _ taskguildv1connect.SkillServiceHandler = (*Server)(nil)
 
 // ChangeNotifier is called after skill CRUD operations to notify connected
 // agents that they should re-sync their local skill definitions.
+// changedSkillIDs lists skills that were created or updated and should be
+// force-overwritten on the agent side even if a local file already exists.
 type ChangeNotifier interface {
-	NotifySkillChange(projectID string)
+	NotifySkillChange(projectID string, changedSkillIDs []string)
 }
 
 // WorkDirResolver resolves the absolute working directory for a project
@@ -41,9 +43,9 @@ func NewServer(repo Repository, notifier ChangeNotifier, resolver WorkDirResolve
 	return &Server{repo: repo, notifier: notifier, resolver: resolver}
 }
 
-func (s *Server) notifyChange(projectID string) {
+func (s *Server) notifyChange(projectID string, changedSkillIDs []string) {
 	if s.notifier != nil {
-		s.notifier.NotifySkillChange(projectID)
+		s.notifier.NotifySkillChange(projectID, changedSkillIDs)
 	}
 }
 
@@ -69,7 +71,7 @@ func (s *Server) CreateSkill(ctx context.Context, req *connect.Request[taskguild
 	if err := s.repo.Create(ctx, sk); err != nil {
 		return nil, err
 	}
-	s.notifyChange(sk.ProjectID)
+	s.notifyChange(sk.ProjectID, []string{sk.ID})
 	return connect.NewResponse(&taskguildv1.CreateSkillResponse{
 		Skill: toProto(sk),
 	}), nil
@@ -147,7 +149,7 @@ func (s *Server) UpdateSkill(ctx context.Context, req *connect.Request[taskguild
 	if err := s.repo.Update(ctx, sk); err != nil {
 		return nil, err
 	}
-	s.notifyChange(sk.ProjectID)
+	s.notifyChange(sk.ProjectID, []string{sk.ID})
 	return connect.NewResponse(&taskguildv1.UpdateSkillResponse{
 		Skill: toProto(sk),
 	}), nil
@@ -161,7 +163,7 @@ func (s *Server) DeleteSkill(ctx context.Context, req *connect.Request[taskguild
 	if err := s.repo.Delete(ctx, req.Msg.Id); err != nil {
 		return nil, err
 	}
-	s.notifyChange(sk.ProjectID)
+	s.notifyChange(sk.ProjectID, nil)
 	return connect.NewResponse(&taskguildv1.DeleteSkillResponse{}), nil
 }
 


### PR DESCRIPTION
## Summary
- **Agent/Skill/Script updates not reflected on agent side**: Extended `ChangeNotifier` interfaces to pass changed resource identifiers, populating `force_overwrite_*` fields in `SyncAgentsCommand`, `SyncSkillsCommand`, and `SyncScriptsCommand`
- **Deleted resources not cleaned up on agent side**: Removed `forceAll` guard from `cleanupStaleAgentFiles` so deleted agents are always removed; added new `cleanupStaleSkillDirs` and `cleanupStaleScriptFiles` functions for skills and scripts
- **Script server had no change notification**: Added `ChangeNotifier` interface to script server with notifications on Create, Update, and Delete operations

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all existing tests pass, including updated script server tests)
- [ ] Manual: Create agent via UI → verify `.claude/agents/{name}.md` is generated on agent
- [ ] Manual: Edit agent via UI → verify `.claude/agents/{name}.md` is updated on agent
- [ ] Manual: Delete agent via UI → verify `.claude/agents/{name}.md` is removed from agent
- [ ] Manual: Same create/edit/delete verification for Skills and Scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)