### PR TITLE
feat: display skill name in task log tool use summary

### DIFF
--- a/cmd/taskguild-agent/toolhooks.go
+++ b/cmd/taskguild-agent/toolhooks.go
@@ -226,6 +226,10 @@ func formatToolSummary(toolName string, toolInput map[string]any) string {
 		if nbPath, ok := toolInput["notebook_path"].(string); ok {
 			return fmt.Sprintf("NotebookEdit: %s", nbPath)
 		}
+	case "Skill":
+		if skill, ok := toolInput["skill"].(string); ok {
+			return fmt.Sprintf("Skill /%s", skill)
+		}
 	case "AskUserQuestion":
 		return "AskUserQuestion"
 	}


### PR DESCRIPTION
## Summary
- Add `case "Skill":` to `formatToolSummary()` in `cmd/taskguild-agent/toolhooks.go`
- Extract skill name from `toolInput["skill"]` and format as `Skill /skill_name` (e.g., `Skill /commit`, `Skill /architect`)
- Falls back to generic `"Skill"` when skill name is unavailable

## Test plan
- [ ] `go build ./cmd/taskguild-agent/` passes
- [ ] `go vet ./cmd/taskguild-agent/` passes
- [ ] Run a task that invokes a Skill (e.g., `/architect`) and verify the task log shows `Skill /architect` instead of just `Skill`