### PR TITLE
fix(edit-diff): unescape Edit tool output and render as diff

### DIFF
--- a/cmd/taskguild-agent/toolhooks.go
+++ b/cmd/taskguild-agent/toolhooks.go
@@ -146,12 +146,22 @@ func logToolUse(tl *taskLogger, taskID string, input claudeagent.HookInput, isFa
 	}
 
 	// Serialize tool output/response.
+	// Note: input.ToolResponse is often already a JSON string (from Claude's raw
+	// tool result). Re-marshalling such a string would double-encode it —
+	// wrapping the content in quotes and escaping inner characters (e.g. `<`
+	// becomes `\u003c`, newlines become literal `\n`). Detect that case and
+	// store the string as-is; only marshal non-string payloads.
 	if input.ToolResponse != nil {
-		if outputJSON, err := json.Marshal(input.ToolResponse); err == nil {
-			metadata["tool_output"] = truncateText(string(outputJSON), maxToolOutputSize)
-		} else {
-			// Fallback: convert to string.
-			metadata["tool_output"] = truncateText(fmt.Sprintf("%v", input.ToolResponse), maxToolOutputSize)
+		switch v := input.ToolResponse.(type) {
+		case string:
+			metadata["tool_output"] = truncateText(v, maxToolOutputSize)
+		default:
+			if outputJSON, err := json.Marshal(v); err == nil {
+				metadata["tool_output"] = truncateText(string(outputJSON), maxToolOutputSize)
+			} else {
+				// Fallback: convert to string.
+				metadata["tool_output"] = truncateText(fmt.Sprintf("%v", v), maxToolOutputSize)
+			}
 		}
 	}
 

--- a/cmd/taskguild-agent/toolhooks_test.go
+++ b/cmd/taskguild-agent/toolhooks_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	claudeagent "github.com/kazz187/claude-agent-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLogToolUse_StringToolResponseNotDoubleEncoded verifies that when
+// ToolResponse is already a JSON string, logToolUse stores it verbatim
+// (no second json.Marshal pass). Regression for the bug where `<` became
+// `\u003c` and newlines became literal `\n` in the persisted metadata.
+func TestLogToolUse_StringToolResponseNotDoubleEncoded(t *testing.T) {
+	tc := newTestClients()
+	defer tc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tl := newTaskLogger(ctx, tc.agentClient, "task-1")
+	defer tl.Close()
+
+	raw := `{"filePath":"/a.ts","newString":"<div>\n</div>"}`
+	input := claudeagent.HookInput{
+		ToolName:     "Edit",
+		ToolInput:    map[string]any{"file_path": "/a.ts"},
+		ToolResponse: raw,
+	}
+
+	logToolUse(tl, "task-1", input, false)
+
+	// Wait for the async ReportTaskLog RPC to land.
+	require.Eventually(t, func() bool {
+		tc.agentHandler.mu.Lock()
+		defer tc.agentHandler.mu.Unlock()
+		return len(tc.agentHandler.reportTaskLogReqs) >= 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	tc.agentHandler.mu.Lock()
+	defer tc.agentHandler.mu.Unlock()
+	req := tc.agentHandler.reportTaskLogReqs[0]
+	out, ok := req.Metadata["tool_output"]
+	require.True(t, ok, "tool_output should be present")
+
+	assert.Equal(t, raw, out, "tool_output must be stored verbatim (no double encoding)")
+	assert.False(t, strings.Contains(out, `\u003c`), "tool_output must not unicode-escape `<`")
+	// It must also not be wrapped in an extra pair of JSON quotes.
+	assert.False(t, strings.HasPrefix(out, `"`) && strings.HasSuffix(out, `"`),
+		"tool_output must not be wrapped in extra JSON quotes")
+}
+
+// TestLogToolUse_NonStringToolResponseMarshaled verifies that non-string
+// ToolResponse values are still json.Marshaled (the existing behaviour).
+func TestLogToolUse_NonStringToolResponseMarshaled(t *testing.T) {
+	tc := newTestClients()
+	defer tc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tl := newTaskLogger(ctx, tc.agentClient, "task-2")
+	defer tl.Close()
+
+	input := claudeagent.HookInput{
+		ToolName:  "Edit",
+		ToolInput: map[string]any{"file_path": "/a.ts"},
+		ToolResponse: map[string]any{
+			"filePath": "/a.ts",
+			"count":    7,
+		},
+	}
+
+	logToolUse(tl, "task-2", input, false)
+
+	require.Eventually(t, func() bool {
+		tc.agentHandler.mu.Lock()
+		defer tc.agentHandler.mu.Unlock()
+		return len(tc.agentHandler.reportTaskLogReqs) >= 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	tc.agentHandler.mu.Lock()
+	defer tc.agentHandler.mu.Unlock()
+	req := tc.agentHandler.reportTaskLogReqs[0]
+	out, ok := req.Metadata["tool_output"]
+	require.True(t, ok, "tool_output should be present")
+
+	// Should be valid JSON containing the map fields.
+	assert.Contains(t, out, `"filePath":"/a.ts"`)
+	assert.Contains(t, out, `"count":7`)
+}

--- a/frontend/src/components/molecules/EditToolDiffView.tsx
+++ b/frontend/src/components/molecules/EditToolDiffView.tsx
@@ -8,13 +8,43 @@ export interface EditToolDiffViewProps {
   oldString: string
   newString: string
   replaceAll?: boolean
+  /**
+   * Original (pre-edit) full file content. When provided, the user can
+   * toggle "Full File" mode to see the diff applied to the entire file for
+   * extra context. Typically supplied by the Edit tool's output payload.
+   */
+  originalFile?: string
+  /**
+   * Header label / semantic origin of this diff view.
+   * - 'input'  (default): rendering the Edit tool's input payload.
+   * - 'output': rendering the Edit tool's output payload (post-apply).
+   *   When combined with `originalFile`, defaults to Full File mode.
+   */
+  variant?: 'input' | 'output'
 }
 
-export function EditToolDiffView({ filePath, oldString, newString, replaceAll }: EditToolDiffViewProps) {
+export function EditToolDiffView({
+  filePath,
+  oldString,
+  newString,
+  replaceAll,
+  originalFile,
+  variant = 'input',
+}: EditToolDiffViewProps) {
   const [ignoreWhitespace, setIgnoreWhitespace] = useState(false)
+  // Full File mode is only meaningful when we have the original file. Default
+  // to ON for the 'output' variant so that the output section gives extra
+  // surrounding context rather than duplicating the input snippet diff.
+  const [fullFile, setFullFile] = useState<boolean>(variant === 'output' && !!originalFile)
+
+  const headerLabel = variant === 'output' ? 'Output' : 'Input'
 
   const computedLines = useMemo(() => {
-    const changes = diffLines(oldString, newString, { ignoreWhitespace })
+    const useFull = fullFile && originalFile !== undefined
+    const { left, right } = useFull
+      ? applyEditToFile(originalFile as string, oldString, newString, replaceAll)
+      : { left: oldString, right: newString }
+    const changes = diffLines(left, right, { ignoreWhitespace })
     // Split each Change into individual lines for rendering
     const result: DiffLine[] = []
     for (const change of changes) {
@@ -32,15 +62,15 @@ export function EditToolDiffView({ filePath, oldString, newString, replaceAll }:
       }
     }
     return result
-  }, [oldString, newString, ignoreWhitespace])
+  }, [oldString, newString, ignoreWhitespace, fullFile, originalFile, replaceAll])
 
-  const isEmpty = oldString === '' && newString === ''
+  const isEmpty = !fullFile && oldString === '' && newString === ''
 
   return (
     <div className="space-y-1.5">
       {/* Metadata: file_path and replace_all */}
       <div>
-        <div className="text-[9px] text-gray-600 font-medium mb-0.5 uppercase tracking-wider">Input</div>
+        <div className="text-[9px] text-gray-600 font-medium mb-0.5 uppercase tracking-wider">{headerLabel}</div>
         <div className="bg-slate-900/50 rounded px-2 py-1 space-y-1">
           <div>
             <div className="text-[10px] text-gray-500 font-medium">file_path</div>
@@ -61,13 +91,24 @@ export function EditToolDiffView({ filePath, oldString, newString, replaceAll }:
       <div>
         <div className="flex items-center justify-between mb-0.5">
           <div className="text-[9px] text-gray-600 font-medium uppercase tracking-wider">Diff</div>
-          <Checkbox
-            color="purple"
-            label="-w"
-            checked={ignoreWhitespace}
-            onChange={(e) => setIgnoreWhitespace(e.target.checked)}
-            className="!text-[10px] !text-gray-500 !gap-1"
-          />
+          <div className="flex items-center gap-2">
+            {originalFile !== undefined && (
+              <Checkbox
+                color="purple"
+                label="Full File"
+                checked={fullFile}
+                onChange={(e) => setFullFile(e.target.checked)}
+                className="!text-[10px] !text-gray-500 !gap-1"
+              />
+            )}
+            <Checkbox
+              color="purple"
+              label="-w"
+              checked={ignoreWhitespace}
+              onChange={(e) => setIgnoreWhitespace(e.target.checked)}
+              className="!text-[10px] !text-gray-500 !gap-1"
+            />
+          </div>
         </div>
         <div className="bg-slate-900/50 rounded max-h-64 overflow-y-auto">
           {isEmpty ? (
@@ -113,4 +154,34 @@ function lineClassName(type: DiffLine['type']): string {
     case 'context':
       return 'text-gray-500 px-2'
   }
+}
+
+/**
+ * Apply an Edit-tool style replacement to the full file content.
+ * Returns the original and patched content to feed into diffLines.
+ *
+ * Matches the Edit tool semantics: when replaceAll is true, replace every
+ * occurrence of oldString; otherwise replace only the first occurrence. If
+ * oldString is empty, the file is treated as unchanged (we cannot infer an
+ * insertion point).
+ */
+function applyEditToFile(
+  original: string,
+  oldString: string,
+  newString: string,
+  replaceAll: boolean | undefined,
+): { left: string; right: string } {
+  if (oldString === '') {
+    return { left: original, right: original }
+  }
+  if (replaceAll) {
+    // Split/join avoids RegExp escaping issues.
+    return { left: original, right: original.split(oldString).join(newString) }
+  }
+  const idx = original.indexOf(oldString)
+  if (idx === -1) {
+    return { left: original, right: original }
+  }
+  const right = original.slice(0, idx) + newString + original.slice(idx + oldString.length)
+  return { left: original, right }
 }

--- a/frontend/src/components/organisms/TimelineEntry.tsx
+++ b/frontend/src/components/organisms/TimelineEntry.tsx
@@ -14,6 +14,7 @@ import { isAsciiArt } from '../../lib/asciiArt.ts'
 import { WorktreePath } from '../atoms/WorktreePath.tsx'
 import { MarkdownDescription } from './MarkdownDescription.tsx'
 import { EditToolDiffView } from '../molecules/EditToolDiffView.tsx'
+import { safeParseToolJSON, PARSE_FAILED } from '../../lib/tool-output.ts'
 
 export type TimelineItem =
   | { kind: 'interaction'; interaction: Interaction }
@@ -302,31 +303,50 @@ function ToolUseDetail({ metadata }: { metadata: Record<string, string> }) {
   // Detect Edit tool and extract its fields for diff rendering
   const editInput = useMemo(() => {
     if (toolName !== 'Edit' || !toolInput) return null
-    try {
-      const parsed = JSON.parse(toolInput)
-      if (
-        typeof parsed === 'object' &&
-        parsed !== null &&
-        'file_path' in parsed &&
-        ('old_string' in parsed || 'new_string' in parsed)
-      ) {
-        return parsed as {
-          file_path: string
-          old_string?: string
-          new_string?: string
-          replace_all?: boolean
-        }
+    const parsed = safeParseToolJSON(toolInput)
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      'file_path' in parsed &&
+      ('old_string' in parsed || 'new_string' in parsed)
+    ) {
+      return parsed as {
+        file_path: string
+        old_string?: string
+        new_string?: string
+        replace_all?: boolean
       }
-    } catch {
-      /* ignore parse errors */
     }
     return null
   }, [toolName, toolInput])
+
+  // Detect Edit tool output and extract its fields (including the full original
+  // file content) for richer diff rendering with surrounding context.
+  const editOutput = useMemo(() => {
+    if (toolName !== 'Edit' || !toolOutput) return null
+    const parsed = safeParseToolJSON(toolOutput)
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      'filePath' in parsed &&
+      ('oldString' in parsed || 'newString' in parsed)
+    ) {
+      return parsed as {
+        filePath: string
+        oldString?: string
+        newString?: string
+        originalFile?: string
+        replaceAll?: boolean
+      }
+    }
+    return null
+  }, [toolName, toolOutput])
 
   return (
     <div className="space-y-1.5">
       {editInput ? (
         <EditToolDiffView
+          variant="input"
           filePath={editInput.file_path}
           oldString={editInput.old_string ?? ''}
           newString={editInput.new_string ?? ''}
@@ -338,12 +358,21 @@ function ToolUseDetail({ metadata }: { metadata: Record<string, string> }) {
           <JsonKeyValueDisplay raw={toolInput} />
         </div>
       ) : null}
-      {toolOutput && (
+      {editOutput ? (
+        <EditToolDiffView
+          variant="output"
+          filePath={editOutput.filePath}
+          oldString={editOutput.oldString ?? ''}
+          newString={editOutput.newString ?? ''}
+          replaceAll={editOutput.replaceAll ?? editInput?.replace_all}
+          originalFile={editOutput.originalFile}
+        />
+      ) : toolOutput ? (
         <div>
           <div className="text-[9px] text-gray-600 font-medium mb-0.5 uppercase tracking-wider">Output</div>
           <JsonKeyValueDisplay raw={toolOutput} />
         </div>
-      )}
+      ) : null}
       {error && (
         <div>
           <div className="text-[9px] text-red-400 font-medium mb-0.5 uppercase tracking-wider">Error</div>
@@ -435,10 +464,10 @@ function formatValue(value: unknown): string {
 
 /** Render JSON as flat key-value pairs. Falls back to raw string for non-object JSON. */
 function JsonKeyValueDisplay({ raw }: { raw: string }) {
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(raw)
-  } catch {
+  // safeParseToolJSON transparently handles legacy double-encoded payloads
+  // (where JSON.parse yields a string that itself contains JSON).
+  const parsed = safeParseToolJSON(raw)
+  if (parsed === PARSE_FAILED) {
     return (
       <pre className="text-[11px] text-gray-400 font-mono whitespace-pre-wrap break-all bg-slate-900/50 rounded px-2 py-1 max-h-48 overflow-y-auto">
         {raw}

--- a/frontend/src/lib/tool-output.test.ts
+++ b/frontend/src/lib/tool-output.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { safeParseToolJSON, PARSE_FAILED } from './tool-output'
+
+describe('safeParseToolJSON', () => {
+  it('parses a plain JSON object', () => {
+    const raw = '{"file_path":"/a/b.ts","old_string":"x"}'
+    expect(safeParseToolJSON(raw)).toEqual({
+      file_path: '/a/b.ts',
+      old_string: 'x',
+    })
+  })
+
+  it('unwraps a legacy double-encoded JSON object', () => {
+    // Outer JSON string whose content is itself JSON (the shape that
+    // the old backend produced before the double-encode fix).
+    const inner = '{"filePath":"/a.ts","newString":"<div>\\n</div>"}'
+    const raw = JSON.stringify(inner) // => "\"{\\\"filePath\\\":...}\""
+    expect(safeParseToolJSON(raw)).toEqual({
+      filePath: '/a.ts',
+      newString: '<div>\n</div>',
+    })
+  })
+
+  it('returns PARSE_FAILED for non-JSON input', () => {
+    expect(safeParseToolJSON('not json at all')).toBe(PARSE_FAILED)
+  })
+
+  it('returns the first string when it is not itself JSON', () => {
+    // JSON.parse('"hello"') => 'hello' (a plain string, not nested JSON).
+    expect(safeParseToolJSON('"hello"')).toBe('hello')
+  })
+
+  it('preserves a legitimate null result', () => {
+    // null parses successfully and must be distinguishable from PARSE_FAILED.
+    expect(safeParseToolJSON('null')).toBeNull()
+  })
+
+  it('preserves arrays', () => {
+    expect(safeParseToolJSON('[1,2,3]')).toEqual([1, 2, 3])
+  })
+
+  it('does not unescape characters in already-single-encoded JSON', () => {
+    // New (fixed) backend path: tool_output stored as a valid JSON object
+    // whose string fields retain raw `<` / newlines unchanged.
+    const raw = '{"newString":"<div>\\n</div>"}'
+    const parsed = safeParseToolJSON(raw) as { newString: string }
+    expect(parsed.newString).toBe('<div>\n</div>')
+    expect(parsed.newString).not.toContain('\\u003c')
+  })
+})

--- a/frontend/src/lib/tool-output.ts
+++ b/frontend/src/lib/tool-output.ts
@@ -1,0 +1,42 @@
+// Utilities for parsing tool_input / tool_output JSON stored in TaskLog metadata.
+//
+// Historically the backend sometimes double-encoded string payloads (calling
+// `json.Marshal` on a value that was already a JSON string). As a result some
+// stored `tool_output` values parse to a *string* on the first JSON.parse; the
+// actual object only emerges after a second parse. This helper handles both
+// the new (single-encoded) and legacy (double-encoded) shapes transparently.
+
+/** Sentinel indicating the input was not valid JSON at all. */
+export const PARSE_FAILED: unique symbol = Symbol('PARSE_FAILED')
+
+/**
+ * Parse a JSON-encoded tool payload, transparently handling the legacy
+ * double-encoded form.
+ *
+ * Behaviour:
+ * - Tries JSON.parse(raw). If it fails, returns `PARSE_FAILED`.
+ * - If the first parse yields a string, tries JSON.parse(first). If that
+ *   succeeds, returns the inner value; otherwise returns the first string.
+ * - Otherwise returns the first parse result.
+ *
+ * Note: a successful parse may legitimately yield `null`; callers must
+ * distinguish that from parse failure via `PARSE_FAILED`.
+ */
+export function safeParseToolJSON(raw: string): unknown | typeof PARSE_FAILED {
+  let first: unknown
+  try {
+    first = JSON.parse(raw)
+  } catch {
+    return PARSE_FAILED
+  }
+
+  if (typeof first === 'string') {
+    try {
+      return JSON.parse(first)
+    } catch {
+      return first
+    }
+  }
+
+  return first
+}


### PR DESCRIPTION
## Summary
- Backend: `cmd/taskguild-agent/toolhooks.go` の `logToolUse` で `ToolResponse` が `string` の場合は再 `json.Marshal` せずそのまま `tool_output` に格納する。これにより `<` → `\u003c`、改行 → 文字列 `\n` といった二重エンコードが解消される。
- Frontend: 共通ヘルパ `frontend/src/lib/tool-output.ts` (`safeParseToolJSON`) を新設し、過去の二重エンコード済みログにもフォールバックでパースが効くようにした (`PARSE_FAILED` で真の解析失敗と区別)。
- Frontend: `EditToolDiffView` に `variant: 'input' | 'output'` と `originalFile` props を追加。`originalFile` がある場合は「Full File」トグルで原本に対する適用後差分を表示できる（`output` バリアントではデフォルト ON）。
- Frontend: `TimelineEntry` の `ToolUseDetail` で `editOutput` を判定し、`EditToolDiffView (variant="output")` にルーティング。`JsonKeyValueDisplay` も `safeParseToolJSON` ベースに置き換え。

親タスク: kazz187/taskguild#64T3ZW5M「Edit の Tool のログや Interaction の差分表示の改善」

## Test plan
- [x] `pnpm typecheck` (frontend)
- [x] `pnpm test` (frontend, vitest run)
- [x] `go build ./cmd/taskguild-agent/`
- [x] `go test ./cmd/taskguild-agent/...`
- [x] `go vet ./cmd/taskguild-agent/...`
- [ ] `taskguild-agent` を起動し、Edit ツールを含むタスクを 1 件実行 → 新規 TaskLog の `tool_output` が `<` のまま保存され `\u003c` にならないこと
- [ ] Timeline で当該 TOOL_USE ログを展開し、Input/Output ともに差分ビュー描画、`\u003c` / 生 `\n` が出ないこと
- [ ] 既存 (二重エンコード済) のログでも `safeParseToolJSON` で正しく差分が表示されること
- [ ] Read / Write / Bash / Glob など他ツールの表示が回帰していないこと