### PR TITLE
feat: add auto permission mode to UI and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ memory: project
 | `tools` | string / list | 使用可能なツール（カンマ区切り or YAML リスト） |
 | `disallowedTools` | string / list | 使用禁止のツール |
 | `model` | string | 使用モデル: `sonnet` / `opus` / `haiku` / `inherit` |
-| `permissionMode` | string | 権限モード: `default` / `acceptEdits` / `dontAsk` / `bypassPermissions` / `plan` |
+| `permissionMode` | string | 権限モード: `default` / `acceptEdits` / `dontAsk` / `bypassPermissions` / `plan` / `auto` |
 | `skills` | list | プリロードするスキル |
 | `memory` | string | メモリスコープ: `user` / `project` / `local` |
 

--- a/frontend/src/components/organisms/StatusCard.tsx
+++ b/frontend/src/components/organisms/StatusCard.tsx
@@ -192,6 +192,7 @@ export function StatusCard({ status: s, index, statuses, skills, scripts, onMove
               <option value="acceptEdits">Accept Edits (auto-approve file changes)</option>
               <option value="plan">Plan (no tool execution, plan only)</option>
               <option value="bypassPermissions">Bypass Permissions (auto-approve all)</option>
+              <option value="auto">Auto (model-classified)</option>
             </Select>
           </FormField>
         </div>

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -37,6 +37,7 @@ export const PERMISSION_MODE_OPTIONS = [
   { value: 'dontAsk', label: "Don't Ask (auto-deny unpermitted)" },
   { value: 'bypassPermissions', label: 'Bypass Permissions' },
   { value: 'plan', label: 'Plan (read-only exploration)' },
+  { value: 'auto', label: 'Auto (model-classified)' },
 ]
 
 export const MEMORY_OPTIONS = [

--- a/proto/gen/go/taskguild/v1/agent.pb.go
+++ b/proto/gen/go/taskguild/v1/agent.pb.go
@@ -38,7 +38,7 @@ type AgentDefinition struct {
 	DisallowedTools []string `protobuf:"bytes,7,rep,name=disallowed_tools,json=disallowedTools,proto3" json:"disallowed_tools,omitempty"` // tools to deny from inherited list
 	// model & permissions
 	Model          string `protobuf:"bytes,8,opt,name=model,proto3" json:"model,omitempty"`                                         // sonnet, opus, haiku, inherit
-	PermissionMode string `protobuf:"bytes,9,opt,name=permission_mode,json=permissionMode,proto3" json:"permission_mode,omitempty"` // default, acceptEdits, dontAsk, bypassPermissions, plan
+	PermissionMode string `protobuf:"bytes,9,opt,name=permission_mode,json=permissionMode,proto3" json:"permission_mode,omitempty"` // default, acceptEdits, dontAsk, bypassPermissions, plan, auto
 	// extensions
 	Skills []string `protobuf:"bytes,10,rep,name=skills,proto3" json:"skills,omitempty"` // skills to preload into agent context
 	Memory string   `protobuf:"bytes,11,opt,name=memory,proto3" json:"memory,omitempty"` // persistent memory scope: user, project, local

--- a/proto/gen/go/taskguild/v1/workflow.pb.go
+++ b/proto/gen/go/taskguild/v1/workflow.pb.go
@@ -365,7 +365,7 @@ type WorkflowStatus struct {
 	// hooks
 	Hooks []*StatusHook `protobuf:"bytes,8,rep,name=hooks,proto3" json:"hooks,omitempty"`
 	// permission mode for agents executing tasks in this status
-	// (default, acceptEdits, dontAsk, bypassPermissions, plan)
+	// (default, acceptEdits, dontAsk, bypassPermissions, plan, auto)
 	PermissionMode string `protobuf:"bytes,11,opt,name=permission_mode,json=permissionMode,proto3" json:"permission_mode,omitempty"`
 	// Name of the status whose session to inherit (fork) when entering this status.
 	// Empty means start a fresh session.

--- a/proto/gen/ts/taskguild/v1/agent_pb.ts
+++ b/proto/gen/ts/taskguild/v1/agent_pb.ts
@@ -82,7 +82,7 @@ export type AgentDefinition = Message<"taskguild.v1.AgentDefinition"> & {
   model: string;
 
   /**
-   * default, acceptEdits, dontAsk, bypassPermissions, plan
+   * default, acceptEdits, dontAsk, bypassPermissions, plan, auto
    *
    * @generated from field: string permission_mode = 9;
    */

--- a/proto/gen/ts/taskguild/v1/workflow_pb.ts
+++ b/proto/gen/ts/taskguild/v1/workflow_pb.ts
@@ -215,7 +215,7 @@ export type WorkflowStatus = Message<"taskguild.v1.WorkflowStatus"> & {
 
   /**
    * permission mode for agents executing tasks in this status
-   * (default, acceptEdits, dontAsk, bypassPermissions, plan)
+   * (default, acceptEdits, dontAsk, bypassPermissions, plan, auto)
    *
    * @generated from field: string permission_mode = 11;
    */

--- a/proto/taskguild/v1/agent.proto
+++ b/proto/taskguild/v1/agent.proto
@@ -34,7 +34,7 @@ message AgentDefinition {
 
   // model & permissions
   string model = 8;                      // sonnet, opus, haiku, inherit
-  string permission_mode = 9;            // default, acceptEdits, dontAsk, bypassPermissions, plan
+  string permission_mode = 9;            // default, acceptEdits, dontAsk, bypassPermissions, plan, auto
 
   // extensions
   repeated string skills = 10;           // skills to preload into agent context

--- a/proto/taskguild/v1/workflow.proto
+++ b/proto/taskguild/v1/workflow.proto
@@ -84,7 +84,7 @@ message WorkflowStatus {
   reserved "enable_agent_md_harness", "agent_md_harness_explicitly_disabled";
 
   // permission mode for agents executing tasks in this status
-  // (default, acceptEdits, dontAsk, bypassPermissions, plan)
+  // (default, acceptEdits, dontAsk, bypassPermissions, plan, auto)
   string permission_mode = 11;
 
   // Name of the status whose session to inherit (fork) when entering this status.


### PR DESCRIPTION
## Summary
- claude-agent-sdk-python v0.1.57 で追加された `auto` permission mode (model classifier がツール呼び出しを自動承認/拒否) を taskguild から選択可能にする
- SDK 側 (`claude-agent-sdk-go` v0.1.0, commit `680351d`) は既に `PermissionModeAuto` を公開し、`cmd/taskguild-agent/interaction.go` も対応済みだったため、本 PR は **UI 導線とドキュメンテーションのみ** を追加する
- frontend (`PERMISSION_MODE_OPTIONS` と `StatusCard` の `<option>` リスト)、proto コメント、README の値リストに `auto` を追加し、proto コード生成物 (`*.pb.go` / `*_pb.ts`) も再生成

## Changes
- `frontend/src/lib/constants.ts`: `PERMISSION_MODE_OPTIONS` に `{ value: 'auto', label: 'Auto (model-classified)' }` を追加
- `frontend/src/components/organisms/StatusCard.tsx`: ハードコードされた `<option>` リストに `auto` を追加
- `proto/taskguild/v1/agent.proto`, `proto/taskguild/v1/workflow.proto`: `permission_mode` のコメント値リストに `auto` を追加
- `proto/gen/**`: `make -C proto generate` で再生成
- `README.md`: 権限モード値リストに `auto` を追加

## Out of scope (intentionally untouched)
- `claude-agent-sdk-go` (既に対応済み)
- `cmd/taskguild-agent/interaction.go` の auto 取扱い (現状 bypassPermissions / dontAsk と同等の「全許可」扱い。Python SDK semantic との厳密な整合は別タスク)

## Test plan
- [x] `cd frontend && pnpm typecheck` — pass
- [x] `go build ./...` — pass
- [x] `go test ./cmd/taskguild-agent/... ./internal/agent/... ./internal/workflow/...` — pass
- [x] `make -C proto generate` で生成差分が `auto` コメント追加のみであることを確認 (validate 系の upstream churn は revert)
- [ ] (manual) UI で Agent 編集モーダル / StatusCard の "Permission Mode" に `Auto (model-classified)` が表示される
- [ ] (manual) Status の `permission_mode` を `auto` に設定 → タスク起動 → taskguild-agent ログで `--permission-mode auto` が CLI に渡る