### PR TITLE
feat(scripts): render ANSI color codes in script log output

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "@tanstack/react-router-devtools": "^1.132.0",
     "@tanstack/router-plugin": "^1.132.0",
     "@taskguild/proto": "file:../proto/gen/ts",
+    "anser": "^2.3.5",
     "diff": "^8.0.3",
     "lucide-react": "^0.545.0",
     "react": "^19.2.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@taskguild/proto':
         specifier: file:../proto/gen/ts
         version: file:../proto/gen/ts
+      anser:
+        specifier: ^2.3.5
+        version: 2.3.5
       diff:
         specifier: ^8.0.3
         version: 8.0.3
@@ -1228,6 +1231,9 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  anser@2.3.5:
+    resolution: {integrity: sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -3034,6 +3040,8 @@ snapshots:
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
+
+  anser@2.3.5: {}
 
   ansi-regex@5.0.1: {}
 

--- a/frontend/src/components/organisms/LogOutput.tsx
+++ b/frontend/src/components/organisms/LogOutput.tsx
@@ -1,9 +1,32 @@
-import { useMemo } from 'react'
+import { useMemo, type CSSProperties } from 'react'
 import { AutoScrollPre } from './AutoScrollPre'
 import { groupLogEntries } from './ScriptListUtils'
 import type { LogEntry } from './ScriptListUtils'
+import type { AnsiSegment } from '@/lib/ansi'
 
-/** Renders interleaved log entries with stderr in red, grouped for performance */
+/**
+ * Builds an inline style object for an ANSI segment. Returns `undefined`
+ * when no styling overrides are needed so the parent's text color (set via
+ * the stream-based class) is inherited as before.
+ */
+function ansiSegmentStyle(seg: AnsiSegment): CSSProperties | undefined {
+  if (!seg.fg && !seg.bg && !seg.bold && !seg.italic && !seg.underline) {
+    return undefined
+  }
+  const style: CSSProperties = {}
+  if (seg.fg) style.color = seg.fg
+  if (seg.bg) style.backgroundColor = seg.bg
+  if (seg.bold) style.fontWeight = 600
+  if (seg.italic) style.fontStyle = 'italic'
+  if (seg.underline) style.textDecoration = 'underline'
+  return style
+}
+
+/**
+ * Renders interleaved log entries with stderr in red, grouped for performance.
+ * ANSI escape sequences inside the entries are parsed and rendered as
+ * colored spans (overriding the stream-based default color when present).
+ */
 export function LogOutput({ entries, className }: { entries: LogEntry[]; className: string }) {
   const groups = useMemo(() => groupLogEntries(entries), [entries])
   return (
@@ -16,7 +39,16 @@ export function LogOutput({ entries, className }: { entries: LogEntry[]; classNa
           key={i}
           className={group.stream === 'stderr' ? 'text-red-400' : 'text-gray-300'}
         >
-          {group.text}
+          {group.segments.map((seg, j) => {
+            const style = ansiSegmentStyle(seg)
+            return style ? (
+              <span key={j} style={style}>
+                {seg.content}
+              </span>
+            ) : (
+              <span key={j}>{seg.content}</span>
+            )
+          })}
         </span>
       ))}
     </AutoScrollPre>

--- a/frontend/src/components/organisms/ScriptListUtils.ts
+++ b/frontend/src/components/organisms/ScriptListUtils.ts
@@ -1,6 +1,7 @@
 import type { ScriptDefinition, ScriptLogEntry } from '@taskguild/proto/taskguild/v1/script_pb.ts'
 import { ScriptLogStream } from '@taskguild/proto/taskguild/v1/script_pb.ts'
 import { ScriptDiffType } from '@taskguild/proto/taskguild/v1/agent_manager_pb.ts'
+import { parseAnsi, type AnsiSegment } from '@/lib/ansi'
 
 export interface ScriptFormData {
   name: string
@@ -57,22 +58,29 @@ export function diffTypeLabel(dt: ScriptDiffType): string {
   }
 }
 
+export interface LogGroup {
+  stream: 'stdout' | 'stderr'
+  segments: AnsiSegment[]
+}
+
 /**
- * Groups consecutive log entries with the same stream type into single spans.
- * This dramatically reduces DOM element count (e.g. 30,000 entries → ~100 spans).
+ * Groups consecutive log entries with the same stream type and parses ANSI
+ * escape sequences within each group. This both:
+ *   - reduces DOM element count (e.g. 30,000 entries → ~100 groups), and
+ *   - enables colored rendering of ANSI sequences emitted by user scripts.
  */
-export function groupLogEntries(entries: LogEntry[]): { stream: 'stdout' | 'stderr'; text: string }[] {
+export function groupLogEntries(entries: LogEntry[]): LogGroup[] {
   if (entries.length === 0) return []
-  const groups: { stream: 'stdout' | 'stderr'; text: string }[] = []
+  const merged: { stream: 'stdout' | 'stderr'; text: string }[] = []
   let current = { stream: entries[0].stream, text: entries[0].text }
   for (let i = 1; i < entries.length; i++) {
     if (entries[i].stream === current.stream) {
       current.text += entries[i].text
     } else {
-      groups.push(current)
+      merged.push(current)
       current = { stream: entries[i].stream, text: entries[i].text }
     }
   }
-  groups.push(current)
-  return groups
+  merged.push(current)
+  return merged.map(g => ({ stream: g.stream, segments: parseAnsi(g.text) }))
 }

--- a/frontend/src/lib/ansi.test.ts
+++ b/frontend/src/lib/ansi.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { parseAnsi } from './ansi'
+
+describe('parseAnsi', () => {
+  it('returns an empty list for an empty string', () => {
+    expect(parseAnsi('')).toEqual([])
+  })
+
+  it('returns a single un-styled segment for plain text', () => {
+    const segs = parseAnsi('hello world')
+    expect(segs).toHaveLength(1)
+    expect(segs[0].content).toBe('hello world')
+    expect(segs[0].fg).toBeUndefined()
+    expect(segs[0].bg).toBeUndefined()
+    expect(segs[0].bold).toBeUndefined()
+  })
+
+  it('parses a simple cyan SGR sequence', () => {
+    // \x1b[0;36m === reset + cyan foreground
+    const segs = parseAnsi('\x1b[0;36m===> hello\x1b[0m')
+    // anser may emit a leading empty segment for the reset; we filter empties
+    // so we expect only the colored segment to remain.
+    expect(segs).toHaveLength(1)
+    expect(segs[0].content).toBe('===> hello')
+    expect(segs[0].fg).toBe('rgb(0, 187, 187)')
+  })
+
+  it('separates colored and plain runs', () => {
+    const segs = parseAnsi('plain \x1b[0;31mred\x1b[0m tail')
+    expect(segs.map(s => s.content)).toEqual(['plain ', 'red', ' tail'])
+    expect(segs[0].fg).toBeUndefined()
+    expect(segs[1].fg).toBe('rgb(187, 0, 0)')
+    expect(segs[2].fg).toBeUndefined()
+  })
+
+  it('detects bold decoration', () => {
+    const segs = parseAnsi('\x1b[1mbold\x1b[0m')
+    expect(segs).toHaveLength(1)
+    expect(segs[0].bold).toBe(true)
+  })
+
+  it('preserves newlines inside the content', () => {
+    const segs = parseAnsi('\x1b[0;32mfirst\nsecond\x1b[0m')
+    expect(segs).toHaveLength(1)
+    expect(segs[0].content).toBe('first\nsecond')
+    expect(segs[0].fg).toBe('rgb(0, 187, 0)')
+  })
+
+  it('keeps text on incomplete sequences without crashing', () => {
+    // Trailing escape with no closing 'm'. Should not throw and should
+    // surface the readable portion in some form.
+    const segs = parseAnsi('hello \x1b[31')
+    const joined = segs.map(s => s.content).join('')
+    expect(joined).toContain('hello')
+  })
+})

--- a/frontend/src/lib/ansi.ts
+++ b/frontend/src/lib/ansi.ts
@@ -1,0 +1,42 @@
+import Anser from 'anser'
+
+/**
+ * A normalized segment of text after ANSI parsing.
+ * Color fields are pre-formatted CSS color strings (e.g. "rgb(0, 187, 187)")
+ * so that callers can drop them directly into `style.color` / `style.backgroundColor`.
+ */
+export interface AnsiSegment {
+  content: string
+  fg?: string
+  bg?: string
+  bold?: boolean
+  italic?: boolean
+  underline?: boolean
+}
+
+/**
+ * Parses ANSI SGR escape sequences in `text` and returns a list of styled
+ * segments. Plain text (no ANSI) is returned as a single segment with no
+ * styling fields set.
+ *
+ * Uses the `anser` library under the hood. We extract only the fields we
+ * actually render and convert color triples ("R, G, B") into full CSS
+ * `rgb(...)` strings.
+ */
+export function parseAnsi(text: string): AnsiSegment[] {
+  if (text.length === 0) return []
+  const entries = Anser.ansiToJson(text, { json: true, remove_empty: false, use_classes: false })
+  const segments: AnsiSegment[] = []
+  for (const e of entries) {
+    if (e.content.length === 0) continue
+    const seg: AnsiSegment = { content: e.content }
+    if (e.fg) seg.fg = `rgb(${e.fg})`
+    if (e.bg) seg.bg = `rgb(${e.bg})`
+    const decorations = e.decorations ?? (e.decoration ? [e.decoration] : [])
+    if (decorations.includes('bold')) seg.bold = true
+    if (decorations.includes('italic')) seg.italic = true
+    if (decorations.includes('underline')) seg.underline = true
+    segments.push(seg)
+  }
+  return segments
+}


### PR DESCRIPTION
## Summary
- Script log output rendered ANSI escape sequences (e.g. `\x1b[0;36m===> ...\x1b[0m`) as literal text because `LogOutput.tsx` dumped raw text into a `<pre>` with no ANSI parser, so the ESC byte was eaten by the browser and only `[0;36m` remained visible.
- Add an `anser`-backed `parseAnsi(text)` helper (`frontend/src/lib/ansi.ts`) that returns `{ content, fg, bg, bold, italic, underline }[]` segments with pre-formatted CSS color strings.
- Plumb segments through `groupLogEntries` so the existing DOM-reduction grouping (30k entries → ~100 groups) is preserved, then run ANSI parsing once per merged chunk.
- `LogOutput.tsx` now renders each segment in an inner `<span>`, applying inline `color` / `backgroundColor` / `fontWeight` / `fontStyle` / `textDecoration` only where ANSI specified them; uncolored segments inherit the existing `text-red-400` / `text-gray-300` stream defaults unchanged.
- Server-side env injection (`FORCE_COLOR=1` / `TERM=...`) and PTY allocation are intentionally out of scope per the approved plan.

## Test plan
- [x] `pnpm vitest run src/lib/ansi.test.ts` — 7 new unit tests cover plain text, simple SGR, mixed runs, bold, multiline, and incomplete sequences.
- [x] `pnpm test` — full suite (42 tests) green.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm build` — vite bundles `anser` without warnings/errors.
- [ ] Manual e2e: run a script that emits `echo -e "\033[0;36m===> hello\033[0m"` via the Scripts UI and confirm the line renders cyan; run on stderr with `\033[0;31mERROR\033[0m` to confirm red is preserved.