### PR TITLE
feat(taskguild-agent): add per-task Skill loop guard

### DIFF
--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -199,8 +199,15 @@ func runTask(
 	userResponseRetries := 0
 	statusTransitionRetries := 0
 
+	// Per-task Skill loop guard: blocks recursive same-skill invocations and
+	// caps repeated identical Skill calls across all turns of this task. The
+	// guard MUST live outside the turn loop so the per-task cap is not reset
+	// each turn; per-turn scope would silently defeat the cap because every
+	// new turn would create a fresh guard.
+	loopGuard := newSkillLoopGuard()
+
 	for turn := 0; ; turn++ {
-		opts := buildClaudeOptions(instructions, workDir, metadata, sessionID, worktreeName, client, taskClient, interClient, ctx, taskID, agentManagerID, waiter, permCache, scpCache, tl, func(newMode string) {
+		opts := buildClaudeOptions(instructions, workDir, metadata, sessionID, worktreeName, client, taskClient, interClient, ctx, taskID, agentManagerID, waiter, permCache, scpCache, tl, loopGuard, func(newMode string) {
 			modeMu.Lock()
 			old := currentMode
 			currentMode = newMode
@@ -785,6 +792,7 @@ func buildClaudeOptions(
 	permCache *permissionCache,
 	scpCache *singleCommandPermissionCache,
 	tl *taskLogger,
+	loopGuard *skillLoopGuard,
 	onModeChange func(newMode string),
 ) *claudeagent.ClaudeAgentOptions {
 	logger := clog.LoggerFromContext(ctx)
@@ -793,6 +801,10 @@ func buildClaudeOptions(
 	permMode := claudeagent.PermissionModeDefault
 	if pm := metadata["_permission_mode"]; pm != "" {
 		permMode = claudeagent.PermissionMode(pm)
+	}
+
+	if loopGuard == nil {
+		loopGuard = newSkillLoopGuard()
 	}
 
 	cwd := workDir
@@ -821,12 +833,6 @@ func buildClaudeOptions(
 	// skills registered as hooks for the status. Both are pre-approved by
 	// the TaskGuild workflow definition.
 	statusSkills := collectStatusSkills(metadata)
-
-	// Per-task Skill loop guard: blocks recursive same-skill invocations and
-	// caps repeated identical Skill calls in this task. Discarded when the
-	// task completes; lifetime is intentionally task-scoped so unrelated
-	// tasks are not affected.
-	loopGuard := newSkillLoopGuard()
 
 	opts := &claudeagent.ClaudeAgentOptions{
 		Cwd:            cwd,

--- a/cmd/taskguild-agent/runner.go
+++ b/cmd/taskguild-agent/runner.go
@@ -822,6 +822,12 @@ func buildClaudeOptions(
 	// the TaskGuild workflow definition.
 	statusSkills := collectStatusSkills(metadata)
 
+	// Per-task Skill loop guard: blocks recursive same-skill invocations and
+	// caps repeated identical Skill calls in this task. Discarded when the
+	// task completes; lifetime is intentionally task-scoped so unrelated
+	// tasks are not affected.
+	loopGuard := newSkillLoopGuard()
+
 	opts := &claudeagent.ClaudeAgentOptions{
 		Cwd:            cwd,
 		PermissionMode: permMode,
@@ -831,7 +837,7 @@ func buildClaudeOptions(
 		StderrCallback: func(line string) {
 			logger.Debug("claude-stderr", "line", line)
 		},
-		Hooks: buildToolUseHooks(tl, taskID, onModeChange, client, interClient, agentManagerID, waiter),
+		Hooks: buildToolUseHooks(tl, taskID, onModeChange, client, interClient, agentManagerID, waiter, loopGuard),
 	}
 
 	// Skill-based mode: set model/tools/disallowedTools from status metadata.

--- a/cmd/taskguild-agent/skill_loop_guard.go
+++ b/cmd/taskguild-agent/skill_loop_guard.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sync"
+)
+
+// skillInvocationCap is the per-task limit for identical (skill, args) Skill
+// invocations. Once a Skill has been invoked this many times in the same task
+// with the same arguments, subsequent invocations are auto-denied to prevent
+// runaway token consumption from buggy AI-side recursion loops.
+const skillInvocationCap = 2
+
+// skillLoopGuard tracks active Skill invocations per task to detect recursive
+// calls (the same skill name running twice concurrently) and to cap repeated
+// identical calls (same skill + same arguments invoked too many times).
+//
+// Lifetime: per task. The guard is created in runTask and discarded when the
+// task completes; nothing in it persists across tasks. This keeps false
+// positives scoped to a single task even if the legitimate use of a skill
+// repeats heavily across tasks.
+//
+// All methods are safe for concurrent use.
+type skillLoopGuard struct {
+	mu              sync.Mutex
+	activeSkills    map[string]string // tool_use_id → skill name (currently executing)
+	invocationCount map[string]int    // skill_name + ":" + args_hash → cumulative count
+}
+
+// newSkillLoopGuard creates an empty guard for a single task's lifetime.
+func newSkillLoopGuard() *skillLoopGuard {
+	return &skillLoopGuard{
+		activeSkills:    make(map[string]string),
+		invocationCount: make(map[string]int),
+	}
+}
+
+// CheckAndRegister inspects an incoming Skill invocation. Returns (block,
+// reason). If block is true, the caller MUST NOT proceed to execute the tool
+// — the reason string explains why and is intended to be surfaced to the
+// model so it stops retrying. On non-block, the call is registered as active
+// and counted; the caller must subsequently invoke Release(toolUseID) once
+// the tool finishes (success or failure).
+func (g *skillLoopGuard) CheckAndRegister(toolUseID, skillName string, input map[string]any) (block bool, reason string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	// A. Recursion: any OTHER tool_use_id already executing the same skill?
+	for activeID, activeName := range g.activeSkills {
+		if activeID != toolUseID && activeName == skillName {
+			return true, fmt.Sprintf(
+				"Skill loop guard: %q is already running (active tool_use_id=%s). Recursive same-skill invocation blocked. Do not retry this skill in this task — pursue an alternative approach.",
+				skillName, activeID,
+			)
+		}
+	}
+
+	// B. Cap: same (skill, args) invoked >= cap times in this task?
+	argsHash := hashArgs(input)
+	key := skillName + ":" + argsHash
+
+	if g.invocationCount[key] >= skillInvocationCap {
+		return true, fmt.Sprintf(
+			"Skill loop guard: %q has been invoked %d times with identical arguments in this task (cap=%d). Auto-denied to prevent runaway token consumption. Do not retry this skill in this task — pursue an alternative approach.",
+			skillName, g.invocationCount[key], skillInvocationCap,
+		)
+	}
+
+	// Register.
+	g.activeSkills[toolUseID] = skillName
+	g.invocationCount[key]++
+
+	return false, ""
+}
+
+// Release marks a Skill invocation as finished (called on PostToolUse and
+// PostToolUseFail). The cumulative invocation count is intentionally NOT
+// decremented — the cap covers the entire task lifetime.
+func (g *skillLoopGuard) Release(toolUseID string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	delete(g.activeSkills, toolUseID)
+}
+
+// hashArgs returns a stable SHA256 hex of the input map. encoding/json sorts
+// map keys, so the digest is deterministic regardless of the original key
+// insertion order.
+func hashArgs(input map[string]any) string {
+	data, err := json.Marshal(input)
+	if err != nil {
+		return ""
+	}
+
+	sum := sha256.Sum256(data)
+
+	return hex.EncodeToString(sum[:])
+}

--- a/cmd/taskguild-agent/skill_loop_guard_test.go
+++ b/cmd/taskguild-agent/skill_loop_guard_test.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestRecursionDetected: registering the same skill name with a second
+// tool_use_id while the first is still active must be blocked.
+func TestRecursionDetected(t *testing.T) {
+	g := newSkillLoopGuard()
+
+	block, _ := g.CheckAndRegister("tu-1", "codex:rescue", map[string]any{"skill": "codex:rescue", "args": "first"})
+	if block {
+		t.Fatalf("first registration should not block")
+	}
+
+	block, reason := g.CheckAndRegister("tu-2", "codex:rescue", map[string]any{"skill": "codex:rescue", "args": "second"})
+	if !block {
+		t.Fatalf("recursive registration should block")
+	}
+
+	if !strings.Contains(reason, "Recursive") {
+		t.Fatalf("recursion reason should mention 'Recursive', got: %s", reason)
+	}
+}
+
+// TestCapEnforced: same (skill, args) past skillInvocationCap must be
+// blocked. With cap=2, the third invocation is the first one denied.
+func TestCapEnforced(t *testing.T) {
+	g := newSkillLoopGuard()
+
+	args := map[string]any{"skill": "codex:rescue", "task": "review"}
+
+	// 1st: allow.
+	if block, _ := g.CheckAndRegister("tu-1", "codex:rescue", args); block {
+		t.Fatalf("1st invocation should not block")
+	}
+
+	g.Release("tu-1")
+
+	// 2nd: allow (still within cap).
+	if block, _ := g.CheckAndRegister("tu-2", "codex:rescue", args); block {
+		t.Fatalf("2nd invocation should not block (cap=%d)", skillInvocationCap)
+	}
+
+	g.Release("tu-2")
+
+	// 3rd: block (cap exceeded).
+	block, reason := g.CheckAndRegister("tu-3", "codex:rescue", args)
+	if !block {
+		t.Fatalf("3rd invocation should block")
+	}
+
+	if !strings.Contains(reason, "cap=") {
+		t.Fatalf("cap reason should mention 'cap=', got: %s", reason)
+	}
+}
+
+// TestArgsDistinguished: same skill name with different args is counted
+// separately and not subject to the cap of the other args.
+func TestArgsDistinguished(t *testing.T) {
+	g := newSkillLoopGuard()
+
+	argsA := map[string]any{"skill": "codex:rescue", "task": "alpha"}
+	argsB := map[string]any{"skill": "codex:rescue", "task": "beta"}
+
+	// Two invocations of argsA — exhaust cap.
+	g.CheckAndRegister("tu-1", "codex:rescue", argsA)
+	g.Release("tu-1")
+	g.CheckAndRegister("tu-2", "codex:rescue", argsA)
+	g.Release("tu-2")
+
+	// argsB should still be allowed twice.
+	if block, _ := g.CheckAndRegister("tu-3", "codex:rescue", argsB); block {
+		t.Fatalf("argsB 1st invocation should not block (separate args)")
+	}
+
+	g.Release("tu-3")
+
+	if block, _ := g.CheckAndRegister("tu-4", "codex:rescue", argsB); block {
+		t.Fatalf("argsB 2nd invocation should not block (separate args)")
+	}
+}
+
+// TestReleaseAllowsReuse: after Release, the same skill name can be
+// re-registered (provided the cap is not yet exceeded).
+func TestReleaseAllowsReuse(t *testing.T) {
+	g := newSkillLoopGuard()
+
+	args := map[string]any{"skill": "dig:dig"}
+
+	if block, _ := g.CheckAndRegister("tu-1", "dig:dig", args); block {
+		t.Fatalf("1st invocation should not block")
+	}
+
+	g.Release("tu-1")
+
+	// Re-registering with a different tool_use_id should be allowed (no
+	// concurrent activity, cap not yet exceeded).
+	if block, _ := g.CheckAndRegister("tu-2", "dig:dig", args); block {
+		t.Fatalf("post-Release 2nd invocation should not block (sequential, within cap)")
+	}
+}
+
+// TestRecursionPriorityOverCap: when both recursion and cap conditions could
+// apply, the recursion message wins (it is checked first).
+func TestRecursionPriorityOverCap(t *testing.T) {
+	g := newSkillLoopGuard()
+
+	args := map[string]any{"skill": "codex:rescue"}
+
+	// Two prior allowed invocations (now released) bring count to cap.
+	g.CheckAndRegister("tu-1", "codex:rescue", args)
+	g.Release("tu-1")
+	g.CheckAndRegister("tu-2", "codex:rescue", args)
+	// Don't release tu-2 — keep it active so the next invocation triggers
+	// recursion AND cap simultaneously.
+
+	block, reason := g.CheckAndRegister("tu-3", "codex:rescue", args)
+	if !block {
+		t.Fatalf("3rd concurrent invocation should block")
+	}
+
+	// Recursion wins.
+	if !strings.Contains(reason, "Recursive") {
+		t.Fatalf("recursion should be reported first; got: %s", reason)
+	}
+
+	if strings.Contains(reason, "cap=") {
+		t.Fatalf("cap message should NOT appear when recursion already detected; got: %s", reason)
+	}
+}
+
+// TestConcurrent: parallel CheckAndRegister/Release calls must not race.
+// Run with `go test -race` to validate.
+func TestConcurrent(t *testing.T) {
+	g := newSkillLoopGuard()
+
+	const goroutines = 32
+
+	const iterations = 50
+
+	var wg sync.WaitGroup
+
+	wg.Add(goroutines)
+
+	for i := range goroutines {
+		go func(workerID int) {
+			defer wg.Done()
+
+			for j := range iterations {
+				toolUseID := makeID(workerID, j)
+				skill := "skill-x"
+				args := map[string]any{"i": j}
+
+				_, _ = g.CheckAndRegister(toolUseID, skill, args)
+				g.Release(toolUseID)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// TestArgsHashStable: hashArgs must return the same hash for input maps that
+// differ only in original key insertion order (encoding/json sorts keys).
+func TestArgsHashStable(t *testing.T) {
+	a := map[string]any{
+		"skill": "codex:rescue",
+		"args":  "review the diff",
+		"flag":  true,
+	}
+
+	b := map[string]any{
+		"flag":  true,
+		"args":  "review the diff",
+		"skill": "codex:rescue",
+	}
+
+	ha := hashArgs(a)
+	hb := hashArgs(b)
+
+	if ha == "" {
+		t.Fatalf("hashArgs returned empty string")
+	}
+
+	if ha != hb {
+		t.Fatalf("hashArgs should be stable across map key order; ha=%s hb=%s", ha, hb)
+	}
+
+	// Different content must produce a different hash.
+	c := map[string]any{
+		"skill": "codex:rescue",
+		"args":  "review a different diff",
+	}
+
+	if hashArgs(c) == ha {
+		t.Fatalf("hashArgs collision for different content")
+	}
+}
+
+func makeID(worker, iter int) string {
+	const digits = "0123456789"
+
+	buf := make([]byte, 0, 16)
+	buf = append(buf, 'w')
+	buf = appendInt(buf, worker, digits)
+	buf = append(buf, '-', 'i')
+	buf = appendInt(buf, iter, digits)
+
+	return string(buf)
+}
+
+func appendInt(buf []byte, n int, digits string) []byte {
+	if n == 0 {
+		return append(buf, '0')
+	}
+
+	var tmp [20]byte
+
+	i := len(tmp)
+
+	for n > 0 {
+		i--
+		tmp[i] = digits[n%10]
+		n /= 10
+	}
+
+	return append(buf, tmp[i:]...)
+}

--- a/cmd/taskguild-agent/toolhooks.go
+++ b/cmd/taskguild-agent/toolhooks.go
@@ -20,7 +20,9 @@ import (
 // It also tracks plan file writes and saves the plan content as a RESULT log
 // when ExitPlanMode is called.
 // The PreToolUse hook intercepts ExitPlanMode to require user approval before
-// the plan is accepted and the agent exits plan mode.
+// the plan is accepted and the agent exits plan mode. It also runs the
+// per-task skill loop guard to block recursive / runaway Skill invocations
+// before they consume forked-session tokens.
 func buildToolUseHooks(
 	tl *taskLogger,
 	taskID string,
@@ -29,6 +31,7 @@ func buildToolUseHooks(
 	interClient taskguildv1connect.InteractionServiceClient,
 	agentManagerID string,
 	waiter *interactionWaiter,
+	loopGuard *skillLoopGuard,
 ) map[claudeagent.HookEvent][]*claudeagent.HookMatcher {
 	// Track the most recently written plan file path across hook invocations.
 	var planFilePath string
@@ -39,6 +42,30 @@ func buildToolUseHooks(
 				Matcher: "",
 				Hooks: []claudeagent.HookCallback{
 					func(input claudeagent.HookInput, toolUseID string, hookCtx claudeagent.HookContext) (claudeagent.HookOutput, error) {
+						// Skill loop guard: block recursive / over-capped Skill
+						// invocations before they reach the permission UI or
+						// fork a new Claude session. This catches AI-side
+						// loops (e.g. codex:rescue calling itself
+						// recursively) and avoids runaway token consumption.
+						if input.ToolName == "Skill" && loopGuard != nil {
+							skillName, _ := input.ToolInput["skill"].(string)
+							if skillName != "" {
+								block, reason := loopGuard.CheckAndRegister(input.ToolUseID, skillName, input.ToolInput)
+								if block {
+									slog.Warn("skill loop guard blocked invocation",
+										"task_id", taskID,
+										"skill", skillName,
+										"tool_use_id", input.ToolUseID,
+										"reason", reason)
+
+									return claudeagent.HookOutput{
+										Decision: "block",
+										Reason:   reason,
+									}, nil
+								}
+							}
+						}
+
 						if input.ToolName != "ExitPlanMode" {
 							return claudeagent.HookOutput{}, nil
 						}
@@ -53,6 +80,12 @@ func buildToolUseHooks(
 				Matcher: "",
 				Hooks: []claudeagent.HookCallback{
 					func(input claudeagent.HookInput, toolUseID string, ctx claudeagent.HookContext) (claudeagent.HookOutput, error) {
+						// Release the skill loop guard slot for this Skill
+						// invocation now that it has finished.
+						if input.ToolName == "Skill" && loopGuard != nil {
+							loopGuard.Release(input.ToolUseID)
+						}
+
 						// Track permission mode changes from CLI.
 						if input.PermissionMode != "" && onModeChange != nil {
 							onModeChange(input.PermissionMode)
@@ -115,6 +148,14 @@ func buildToolUseHooks(
 				Matcher: "",
 				Hooks: []claudeagent.HookCallback{
 					func(input claudeagent.HookInput, toolUseID string, ctx claudeagent.HookContext) (claudeagent.HookOutput, error) {
+						// Release the skill loop guard slot for this Skill
+						// invocation. Note: when the guard itself blocked the
+						// invocation in PreToolUse, the slot was never
+						// registered, so this Release is a no-op — safe.
+						if input.ToolName == "Skill" && loopGuard != nil {
+							loopGuard.Release(input.ToolUseID)
+						}
+
 						// Track permission mode changes from CLI.
 						if input.PermissionMode != "" && onModeChange != nil {
 							onModeChange(input.PermissionMode)


### PR DESCRIPTION
## Summary

- AI 側 (claude-agent-sdk-go の forked Claude session) で `Skill(codex:rescue)` などが再帰的に呼ばれ続けるループを TaskGuild Agent 層で水際遮断する
- ハイブリッド 2 段ガードを PreToolUse hook に追加:
  - **再帰検知**: 同タスク内で同名 Skill が他の `tool_use_id` で active 中なら強制 deny
  - **同一呼び出しキャップ**: 同一 `(skill 名, 引数 SHA256)` がタスク内で 2 回を超えたら強制 deny
- ループ検知時はモデルへ「Do not retry this skill in this task — pursue an alternative approach.」を返却し、AI の retry 動機を断つ
- 元症状: 同一引数で 10 回 (9 allow / 1 deny) の Permission Request が生成され、1 セッション $2.33 / 764k cache_read tokens を消費したケース (タスク `01KQYHP4XYMNCCKRMHN6E7QAJG`、現 archived)

## Implementation

- `cmd/taskguild-agent/skill_loop_guard.go` (新規): `skillLoopGuard` 構造体 (mutex + activeSkills map + invocationCount map) と `CheckAndRegister` / `Release` / `hashArgs` メソッド。タスクスコープで生成・破棄
- `cmd/taskguild-agent/toolhooks.go`: `buildToolUseHooks` に `loopGuard *skillLoopGuard` 引数を追加。PreToolUse で Skill 分岐 → block 時 `HookOutput{Decision: "block", Reason: ...}`。PostToolUse / PostToolUseFail 冒頭で `Release`
- `cmd/taskguild-agent/runner.go`: `runTask` 内で `loopGuard := newSkillLoopGuard()` を per-task で生成し `buildToolUseHooks` に渡す

## Test plan

- [x] `go build ./cmd/... ./internal/... ./pkg/...` クリーン
- [x] `go test ./cmd/taskguild-agent/...` 全グリーン
- [x] 新規 7 ケース (`TestRecursionDetected` / `TestCapEnforced` / `TestArgsDistinguished` / `TestReleaseAllowsReuse` / `TestRecursionPriorityOverCap` / `TestConcurrent` / `TestArgsHashStable`) を `-race` 付きで実行 → 全パス
- [ ] 任意の Review タスクで `senior-engineer` 経由 `codex:rescue` を単発呼びし、prompt 動作が壊れていないこと (=既存挙動の非退行) を本番反映前に手動確認