### PR TITLE
fix(frontend): order TransitTo buttons by workflow status.order

### DIFF
--- a/frontend/src/components/organisms/TaskBoard.tsx
+++ b/frontend/src/components/organisms/TaskBoard.tsx
@@ -277,10 +277,9 @@ export function TaskBoard({ projectId, workflow, headerActionsRef }: TaskBoardPr
     for (const s of sortedStatuses) {
       const normalIds = new Set(s.transitionsTo ?? [])
       const targets: { id: string; name: string; isForce: boolean }[] = []
-      // Normal transitions first
-      for (const toId of normalIds) {
-        const toStatus = statusById.get(toId)
-        if (toStatus) {
+      // Normal transitions first (status.order ascending)
+      for (const toStatus of sortedStatuses) {
+        if (toStatus.id !== s.id && normalIds.has(toStatus.id)) {
           targets.push({ id: toStatus.id, name: toStatus.name, isForce: false })
         }
       }
@@ -293,7 +292,7 @@ export function TaskBoard({ projectId, workflow, headerActionsRef }: TaskBoardPr
       map.set(s.id, targets)
     }
     return map
-  }, [sortedStatuses, statusById])
+  }, [sortedStatuses])
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
     lastDropWasSuccessful.current = false

--- a/frontend/src/components/organisms/TaskDetailModal.tsx
+++ b/frontend/src/components/organisms/TaskDetailModal.tsx
@@ -119,7 +119,12 @@ export function TaskDetailModal({
   }, [worktreeDraft, projectId, isTaskLocked])
 
   const currentStatus = statuses.find((s) => s.id === (task?.statusId ?? currentStatusId))
-  const allowedTransitions = currentStatus?.transitionsTo ?? []
+  // Sort allowed transitions by workflow status.order (statuses prop is already sorted by callers).
+  const allowedTransitions = useMemo(() => {
+    if (!currentStatus) return []
+    const allowed = new Set(currentStatus.transitionsTo ?? [])
+    return statuses.filter((s) => allowed.has(s.id)).map((s) => s.id)
+  }, [currentStatus, statuses])
 
   // Force transition targets: all statuses except current and normal transitions
   const forceTransitions = useMemo(() => {

--- a/frontend/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/frontend/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -88,7 +88,12 @@ function TaskDetailPage() {
   const workflow = workflows.find((w) => w.id === task?.workflowId)
   const sortedStatuses = workflow ? [...workflow.statuses].sort((a, b) => a.order - b.order) : []
   const currentStatus = sortedStatuses.find((s) => s.id === task?.statusId)
-  const allowedTransitions = currentStatus?.transitionsTo ?? []
+  // Sort allowed transitions by workflow status.order so buttons follow workflow progression.
+  const allowedTransitions = useMemo(() => {
+    if (!currentStatus) return []
+    const allowed = new Set(currentStatus.transitionsTo ?? [])
+    return sortedStatuses.filter((s) => allowed.has(s.id)).map((s) => s.id)
+  }, [currentStatus, sortedStatuses])
 
   // Fetch sibling tasks for parent-child relationship display
   const { data: allTasksData, refetch: refetchAllTasks } = useQuery(


### PR DESCRIPTION
## Summary
- TransitTo ボタン (タスク詳細ページ上部 / TaskDetailModal / TaskBoard モバイル遷移リスト) を `WorkflowStatus.transitionsTo` の YAML 定義順 / Set 反復順ではなく、workflow の `status.order` 昇順 (Draft → Plan → Develop → Review → Closed) で並べるよう修正
- 3 ファイル共通で、既に各画面が保持している `sortedStatuses` を基準に `transitionsTo` を絞り込むことでソート。Force transition の挙動は変更なし
- バックエンドの proto / Go ロジックは無変更。`allowedTransitions` の集合は同一で順序のみ変わる

## Test plan
- [x] `pnpm typecheck` 成功
- [x] `pnpm build` 成功
- [x] `pnpm test` 全テスト pass (42/42)
- [ ] 手動: 戻り遷移が定義されたステータス (例 Develop → [Review, Draft]) のタスクを開き、タスク詳細ページ上部のボタンが Draft → Review の workflow 順に並ぶことを確認
- [ ] 手動: 同タスクを TaskDetailModal でも開いて同じ並びを確認
- [ ] 手動: TaskBoard のモバイル遷移ボタンでも順序確認 + ステータス遷移が動作すること