### PR TITLE
chore(deps): migrate fsnotify to gofsnotify fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.9
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/fatih/color v1.19.0
-	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-chi/chi/v5 v5.2.2
+	github.com/gofsnotify/fsnotify v0.0.3
 	github.com/kazz187/claude-agent-sdk-go v0.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/oklog/ulid/v2 v2.1.1
@@ -101,6 +101,7 @@ require (
 	github.com/ettle/strcase v0.2.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/firefart/nonamedreturns v1.0.6 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/ghostiam/protogetter v0.3.20 // indirect
 	github.com/go-critic/go-critic v0.14.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -281,6 +281,8 @@ github.com/godoc-lint/godoc-lint v0.11.2 h1:Bp0FkJWoSdNsBikdNgIcgtaoo+xz6I/Y9s5W
 github.com/godoc-lint/godoc-lint v0.11.2/go.mod h1:iVpGdL1JCikNH2gGeAn3Hh+AgN5Gx/I/cxV+91L41jo=
 github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
 github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
+github.com/gofsnotify/fsnotify v0.0.3 h1:svt0uJunliagm31MQbIdhKOBdUVgTs6JG8P7vxpnuok=
+github.com/gofsnotify/fsnotify v0.0.3/go.mod h1:CIQsu068LxiEIHQK1EUuCic0r7vqxRxzxBqUqkOyVQg=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
 github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=

--- a/pkg/sentinel/sentinel.go
+++ b/pkg/sentinel/sentinel.go
@@ -15,7 +15,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/fsnotify/fsnotify"
+	"github.com/gofsnotify/fsnotify"
 	"github.com/sourcegraph/conc"
 )
 
@@ -346,7 +346,7 @@ func (s *Sentinel) watchBinary(updateCh chan<- struct{}) {
 	watchDir := filepath.Dir(s.binaryPath)
 	binaryName := filepath.Base(s.binaryPath)
 
-	if err := watcher.Add(watchDir); err != nil {
+	if err := watcher.Add(watchDir, fsnotify.Create|fsnotify.Write|fsnotify.Rename); err != nil {
 		slog.Error("failed to watch directory", "dir", watchDir, "error", err)
 		return
 	}


### PR DESCRIPTION
## Summary
- upstream `github.com/fsnotify/fsnotify` のメンテナーがセキュリティ上危険視されたため、fork の `github.com/gofsnotify/fsnotify` v0.0.3 に直接 import を載せ替え。
- 唯一の direct user である `pkg/sentinel/sentinel.go` の import を書換。
- fork は `Watcher.Add` のシグネチャが `(path string, op Op)` に変わっているため、watch 対象 op を `Create|Write|Rename` で明示（既存の `event.Op` フィルタと一致させる）。
- `go get github.com/gofsnotify/fsnotify@latest` + `go mod tidy` で go.mod / go.sum を更新。

## Notes
- upstream `github.com/fsnotify/fsnotify v1.9.0` は **golangci-lint v2 (tool dep) → spf13/viper** の indirect 経由で `// indirect` として go.mod に残ります。自分のバイナリにはリンクされず、lint ツール起動時のみ参照されるため、セキュリティ影響は限定的と判断しそのまま残置しています。tool 依存も完全排除する場合は `replace` ディレクティブの追加を別 PR で検討してください。
- fork のリポジトリ最新タグは `v0.0.3` を採用 (`go get @latest` で解決)。

## Test plan
- [x] `go build ./...` — 成功
- [x] `go vet ./...` — 警告なし
- [x] `go test ./pkg/sentinel/...` — `ok` (0.204s)
- [x] `grep -rn "fsnotify/fsnotify" --include=*.go` で旧 import の残存なしを確認
- [ ] CI のフルテストパス